### PR TITLE
Fix photo upload header hover styles

### DIFF
--- a/moderation_queue/static/moderation_queue/css/crop.scss
+++ b/moderation_queue/static/moderation_queue/css/crop.scss
@@ -1,6 +1,3 @@
-@import "../../../../candidates/static/foundation/scss/normalize";
-@import "../../../../candidates/static/foundation/scss/foundation";
-
 /* This removes all size-related styles from the image for review; if
    we don't do this then Jcrop gets confused about the true size of
    the image and returns the wrong coordinates. */

--- a/moderation_queue/static/moderation_queue/css/crop.scss
+++ b/moderation_queue/static/moderation_queue/css/crop.scss
@@ -1,3 +1,6 @@
+@import "../../../../candidates/static/foundation/scss/normalize";
+@import "../../../../candidates/static/foundation/scss/foundation";
+
 /* This removes all size-related styles from the image for review; if
    we don't do this then Jcrop gets confused about the true size of
    the image and returns the wrong coordinates. */

--- a/moderation_queue/templates/moderation_queue/photo-upload-new.html
+++ b/moderation_queue/templates/moderation_queue/photo-upload-new.html
@@ -6,10 +6,6 @@
 
 {% load compressed %}
 
-{% block extra_css %}
-{% compressed_css 'image-review' %}
-{% endblock %}
-
 {% block hero %}
   <h1>Upload a photo of {{ person.name }}</h1>
 {% endblock %}

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -210,7 +210,6 @@ PIPELINE_CSS = {
         'source_filenames': (
             'moderation_queue/css/jquery.Jcrop.css',
             'moderation_queue/css/crop.scss',
-            'moderation_queue/css/photo-upload.scss',
         ),
         'output_filename': 'css/image-review.css',
     },
@@ -228,6 +227,7 @@ PIPELINE_CSS = {
             'jquery/jquery-ui.css',
             'jquery/jquery-ui.structure.css',
             'jquery/jquery-ui.theme.css',
+            'moderation_queue/css/photo-upload.scss',
         ),
         'output_filename': 'css/all.css',
     }


### PR DESCRIPTION
The specific issue addressed here is the hover colour of the header text on the photo upload page:
![screen shot 2015-04-21 at 17 22 26](https://cloud.githubusercontent.com/assets/464193/7257096/15dbc494-e84b-11e4-8112-3c267f66a125.png)

Foundation has already been imported at this point (as part of all.css). Re-importing just causes it to clobber YNMP styles.