### PR TITLE
Restrict LANGUAGES to those we have.

### DIFF
--- a/candidates/models/popit.py
+++ b/candidates/models/popit.py
@@ -117,7 +117,7 @@ form_complex_fields_locations = {
         'sub_array': 'links',
         'info_type_key': 'note',
         'info_value_key': 'url',
-        'info_type': 'party PPC page',
+        'info_type': 'party candidate page',
     }
 }
 

--- a/candidates/tests/test_create_person.py
+++ b/candidates/tests/test_create_person.py
@@ -39,7 +39,7 @@ EXPECTED_ARGS = {
             'url': 'http://notreallyfacebook/tessajowellcampaign',
         },
         {
-            'note': 'party PPC page',
+            'note': 'party candidate page',
             'url': 'http://labour.example.org/tessajowell',
         },
         {

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -9,8 +9,8 @@ https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS
-from django.utils.translation import ugettext_lazy as _
+from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS, LANGUAGES
+from django.utils.translation import to_locale, ugettext_lazy as _
 import importlib
 import os
 import re
@@ -208,15 +208,16 @@ else:
 # Internationalization
 # https://docs.djangoproject.com/en/1.6/topics/i18n/
 
+LOCALE_PATHS = [
+    os.path.join(BASE_DIR, 'locale')
+]
+
+LANGUAGES = [l for l in LANGUAGES if os.path.exists(os.path.join(LOCALE_PATHS[0], to_locale(l[0])))]
 LANGUAGE_CODE = conf.get('LANGUAGE_CODE', 'en-gb')
 
 TIME_ZONE = conf.get('TIME_ZONE', 'Europe/London')
 
 USE_I18N = True
-
-LOCALE_PATHS = [
-    os.path.join(BASE_DIR, 'locale')
-]
 
 USE_L10N = True
 


### PR DESCRIPTION
Without this, as our two current languages are en and es-ar, if someone
presents an Accept-Language: es header they get en (because es is a
supported Django language).

Plus one PPC rename.