### PR TITLE
Support either a hidden or usable post field on the person form

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -4,7 +4,7 @@ import re
 
 from .cache import get_post_cached, get_all_posts_cached, UnknownPostException
 from .popit import create_popit_api_object, PopItApiMixin
-from .election_specific import MAPIT_DATA, PARTY_DATA, AREA_POST_DATA
+from .election_specific import PARTY_DATA, AREA_POST_DATA
 from .models.address import check_address
 
 from django import forms

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -3,7 +3,7 @@
 import re
 
 from .cache import get_post_cached, get_all_posts_cached, UnknownPostException
-from .popit import create_popit_api_object
+from .popit import create_popit_api_object, PopItApiMixin
 from .election_specific import MAPIT_DATA, PARTY_DATA, AREA_POST_DATA
 from .models.address import check_address
 
@@ -56,7 +56,7 @@ class CandidacyDeleteForm(BaseCandidacyForm):
         max_length=512,
     )
 
-class BasePersonForm(forms.Form):
+class BasePersonForm(PopItApiMixin, forms.Form):
     honorific_prefix = forms.CharField(
         label=_("Title / pre-nominal honorific (e.g. Dr, Sir, etc.)"),
         max_length=256,

--- a/candidates/popit.py
+++ b/candidates/popit.py
@@ -127,5 +127,5 @@ class PopItApiMixin(object):
     """This provides helper methods for manipulating data in a PopIt instance"""
 
     def __init__(self, *args, **kwargs):
-        super(PopItApiMixin, self).__init__(*args, **kwargs)
         self.api = create_popit_api_object()
+        super(PopItApiMixin, self).__init__(*args, **kwargs)

--- a/candidates/tests/test_validators.py
+++ b/candidates/tests/test_validators.py
@@ -59,7 +59,7 @@ class TestValidators(TestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors, {
             '__all__':
-            [u'If you mark the candidate as standing in the 2015 General Election, you must select a constituency']
+            [u'If you mark the candidate as standing in the 2015 General Election, you must select a post']
         })
 
     def test_update_person_form_standing_no_party_but_gb_constituency(self):

--- a/candidates/views/areas.py
+++ b/candidates/views/areas.py
@@ -64,7 +64,8 @@ class AreasView(PopItApiMixin, TemplateView):
                         'candidates': current_candidates,
                         'add_candidate_form': NewPersonForm(
                             election=election,
-                            initial={'constituency': post_id}
+                            initial={'constituency': post_id},
+                            hidden_post_widget=True,
                         ),
                     })
         context['all_area_names'] = u' — '.join(all_area_names)

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -120,7 +120,8 @@ class ConstituencyDetailView(ElectionMixin, PopItApiMixin, TemplateView):
 
         context['add_candidate_form'] = NewPersonForm(
             election=self.election,
-            initial={'constituency': post_id}
+            initial={'constituency': post_id},
+            hidden_post_widget=True,
         )
 
         return context

--- a/elections/uk_general_election_2015/lib.py
+++ b/elections/uk_general_election_2015/lib.py
@@ -45,7 +45,7 @@ class AreaPostData(BaseAreaPostData):
     def post_id_to_party_set(self, post_id):
         area = self.areas_by_post_id.get(post_id, None)
         if area is None:
-            return area
+            return None
         if area['country_name'] == 'Northern Ireland':
             return 'ni'
         elif area['country_name'] in ('England', 'Scotland', 'Wales'):


### PR DESCRIPTION
Previously, the post field (previously "constituency field") was only
ever a hidden field, since its value was always known - the add person
field was embedded in the area or post page, or it was brought up when
complaining about validation errors, in which case the field's value
was carried over.  Now we want to be able to link to the 'person-create'
page to allow people to add a new candidate to any post in an election
so we add a 'hidden_post_widget' keyword argument to indicate that the
form is being embedded with a supplied post_id.
    
Fixes #419
