### PR TITLE
Update the posts to be invalidated any time standing_in is changed

### DIFF
--- a/candidates/models/popit.py
+++ b/candidates/models/popit.py
@@ -666,6 +666,7 @@ class PopItPerson(object):
 
         self.popit_data['memberships'] = memberships
         self.popit_data['standing_in'] = v
+        self.store_posts_for_invalidation()
 
     @property
     def party_memberships(self):


### PR DESCRIPTION
The cache of post (with embedded memberships, people and organizations)
wasn't being invalidated properly on creating new people, in particular
when a new person was created or had their membership of posts changed.