### PR TITLE
Remove 'PPC' from the link key for a party candidate page

### DIFF
--- a/candidates/tests/test_create_person.py
+++ b/candidates/tests/test_create_person.py
@@ -40,7 +40,7 @@ EXPECTED_ARGS = {
             'url': 'http://notreallyfacebook/tessajowellcampaign',
         },
         {
-            'note': 'party PPC page',
+            'note': 'party candidate page',
             'url': 'http://labour.example.org/tessajowell',
         },
         {


### PR DESCRIPTION
Thanks to Matthew Somerville for spotting this still used UK-specific
terminology.