### PR TITLE
Issues/395 argentina style fixes

### DIFF
--- a/candidates/static/candidates/_content.scss
+++ b/candidates/static/candidates/_content.scss
@@ -5,6 +5,7 @@
 }
 
 .container {
+  max-width: 960px; // for browsers that don't understand rems
   @include grid-row();
   padding-left: $column-gutter / 2;
   padding-right: $column-gutter / 2;

--- a/elections/ar_elections_2015/static/candidates/style.scss
+++ b/elections/ar_elections_2015/static/candidates/style.scss
@@ -133,11 +133,16 @@ a {
         height: 53px * 0.75;
         background-size: 230px * 0.75;
         margin-left: 0;
+        margin-top: 0.5em;
     }
 
     @media ($high_dpi_screen) {
         background-image: url(img/logo-yqs-investigacion@2.png);
         background-size: 230px;
+
+        @media (max-width: 30em) {
+            background-size: 230px * 0.75;
+        }
     }
 }
 
@@ -301,6 +306,10 @@ body.finder .content {
     background-color: darken($color-offwhite, 5%);
 }
 
+.finder__getting-started__demo {
+    margin-bottom: 2em;
+}
+
 .finder__intro {
     p {
         font-size: 1.2em;
@@ -336,6 +345,7 @@ body.finder .content {
         left: 0;
         width: 100%;
         height: 100%;
+        border: none;
     }
 }
 


### PR DESCRIPTION
Connected to #395 – some small CSS fixes for the Yo Quiero Saber header and homepage.

Also, adds a minor fix to the core YNR styles, to cap the width of the site at something sensible in IE7–8 (where the current `max-width`, set in `rem`s, doesn't work).