### PR TITLE
Add JavaScript translation capability.

### DIFF
--- a/bin/pre-deploy
+++ b/bin/pre-deploy
@@ -65,3 +65,4 @@ fi
 
 # Compile all translations from .po files into .mo files
 ./manage.py compilemessages
+./manage.py compilejsi18n

--- a/candidates/static/js/constituency.js
+++ b/candidates/static/js/constituency.js
@@ -50,8 +50,8 @@ $(function() {
       constituencyName=$('#constituency-name').text(),
       partyName=enclosingDiv.find('.party').text(),
       message;
-    message = "Are you sure that " + candidateName + " (" + partyName + ") " +
-      "was the winner in " + constituencyName + "?";
+    message = interpolate(gettext("Are you sure that %s (%s) was the winner in %s?"),
+        [candidateName, partyName, constituencyName]);
     return confirm(message);
   });
 

--- a/candidates/static/js/versions.js
+++ b/candidates/static/js/versions.js
@@ -1,9 +1,9 @@
 $(function() {
   var toggleFullVersion = function toggleFullVersion($fullVersion){
     if($fullVersion.is(':visible')){
-      $fullVersion.hide().siblings('.js-toggle-full-version-json').text('Show full version');
+      $fullVersion.hide().siblings('.js-toggle-full-version-json').text(gettext('Show full version'));
     } else {
-      $fullVersion.show().siblings('.js-toggle-full-version-json').text('Hide full version');
+      $fullVersion.show().siblings('.js-toggle-full-version-json').text(gettext('Hide full version'));
     }
   }
 

--- a/elections/ar_elections_2015/templates/base.html
+++ b/elections/ar_elections_2015/templates/base.html
@@ -25,6 +25,9 @@
       <script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.1.0/respond.min.js"></script>
     <![endif]-->
 
+    {% load statici18n %}
+    <script src="{% statici18n LANGUAGE_CODE %}"></script>
+
     {% javascript 'all' %}
     {% block extra_js %}
     {% endblock %}

--- a/locale/en/LC_MESSAGES/djangojs.po
+++ b/locale/en/LC_MESSAGES/djangojs.po
@@ -1,0 +1,31 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-30 14:53+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: candidates/static/js/constituency.js:53
+#, javascript-format
+msgid "Are you sure that %s (%s) was the winner in %s?"
+msgstr ""
+
+#: candidates/static/js/versions.js:4
+msgid "Show full version"
+msgstr ""
+
+#: candidates/static/js/versions.js:6
+msgid "Hide full version"
+msgstr ""

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -357,7 +357,7 @@ msgstr "El usuario de twitter sólo debe contener caracteres alfanuméricos o gu
 msgid ""
 "If you mark the candidate as standing in the {election}, you must select a "
 "post"
-msgstr "Si indicás que el candidato se presenta a {elecion}, debes seleccionar un cargo"
+msgstr "Si indicás que el candidato se presenta a {election}, debes seleccionar un cargo"
 
 #: candidates/forms.py:171
 #, python-brace-format

--- a/locale/es_AR/LC_MESSAGES/djangojs.po
+++ b/locale/es_AR/LC_MESSAGES/djangojs.po
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-07-30 14:53+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: candidates/static/js/constituency.js:53
+#, javascript-format
+msgid "Are you sure that %s (%s) was the winner in %s?"
+msgstr ""
+
+#: candidates/static/js/versions.js:4
+msgid "Show full version"
+msgstr ""
+
+#: candidates/static/js/versions.js:6
+msgid "Hide full version"
+msgstr ""

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -106,6 +106,7 @@ INSTALLED_APPS = (
     'django.contrib.sites',
     'django_nose',
     'pipeline',
+    'statici18n',
     ELECTION_APP_FULLY_QUALIFIED,
     'candidates',
     'tasks',

--- a/mysite/templates/generic_base.html
+++ b/mysite/templates/generic_base.html
@@ -25,6 +25,9 @@
       <script src="//cdnjs.cloudflare.com/ajax/libs/respond.js/1.1.0/respond.min.js"></script>
     <![endif]-->
 
+    {% load statici18n %}
+    <script src="{% statici18n LANGUAGE_CODE %}"></script>
+
     {% javascript 'all' %}
     {% block extra_js %}
     {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,14 @@ coverage==3.7.1
 cryptography==0.8
 Django==1.8.3
 django-allauth==0.21.0
+django-appconf==1.0.1
 django-braces==1.4.0
 django-date-extensions==0.1.dev0
 django-debug-toolbar==1.3.2
 django-debug-toolbar-template-timings==0.6.4
 django-nose==1.4.1
 django-pipeline==1.5.1
+django-statici18n==1.1.3
 django-webtest==1.7.7
 docutils==0.10
 -e git+https://github.com/django-extensions/django-extensions.git@44a39ccd882b31381c3da63861d70f0b3b5690f8#egg=django-extensions


### PR DESCRIPTION
This allows translation of the three strings present in JavaScript,
using Django's built in functionality and a third party module to
create static versions of the output on deploy.

Fixes #463 (the remaining string).