### PR TITLE
WiP: Canonicalize BASE_DIR, which should fix some caching issues

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -13,11 +13,11 @@ from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS, LANGUAGES
 from django.utils.translation import to_locale, ugettext_lazy as _
 from collections import defaultdict
 import importlib
-import os
+from os.path import dirname, exists, join
 import re
 import sys
 import yaml
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = dirname(dirname(__file__))
 
 from .helpers import mkdir_p
 
@@ -27,7 +27,7 @@ configuration_file_basename = 'general.yml'
 if 'test' in sys.argv:
     configuration_file_basename = 'general.yml-example'
 
-configuration_file = os.path.join(
+configuration_file = join(
     BASE_DIR, 'conf', configuration_file_basename
 )
 
@@ -73,7 +73,7 @@ DEBUG = bool(int(conf.get('STAGING')))
 TEMPLATE_DEBUG = True
 
 TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'mysite', 'templates'),
+    join(BASE_DIR, 'mysite', 'templates'),
 )
 
 TEMPLATE_CONTEXT_PROCESSORS += (
@@ -204,7 +204,7 @@ else:
     DATABASES = {
         'default': {
             'ENGINE': 'django.db.backends.sqlite3',
-            'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+            'NAME': join(BASE_DIR, 'db.sqlite3'),
         }
     }
 
@@ -212,7 +212,7 @@ else:
 # https://docs.djangoproject.com/en/1.6/topics/i18n/
 
 LOCALE_PATHS = [
-    os.path.join(BASE_DIR, 'locale')
+    join(BASE_DIR, 'locale')
 ]
 
 # The code below sets LANGUAGES to only those we have translations
@@ -228,7 +228,7 @@ LOCALE_PATHS = [
 # Accept-Language is 'es' then it will use the 'es-ar' translation.  We think
 # this is generally desirable (e.g. so someone can see YourNextMP in Spanish
 # if their browser asks for Spanish).
-LANGUAGES = [l for l in LANGUAGES if os.path.exists(os.path.join(LOCALE_PATHS[0], to_locale(l[0])))]
+LANGUAGES = [l for l in LANGUAGES if exists(join(LOCALE_PATHS[0], to_locale(l[0])))]
 
 LANGUAGE_CODE = conf.get('LANGUAGE_CODE', 'en-gb')
 
@@ -242,10 +242,10 @@ USE_TZ = True
 
 MEDIA_ROOT = conf.get('MEDIA_ROOT')
 if not MEDIA_ROOT:
-    MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+    MEDIA_ROOT = join(BASE_DIR, 'media')
 # Make sure that the MEDIA_ROOT and subdirectory for archived CSV
 # files exist:
-mkdir_p(os.path.join(MEDIA_ROOT, 'csv-archives'))
+mkdir_p(join(MEDIA_ROOT, 'csv-archives'))
 
 MEDIA_URL = '/media/'
 
@@ -254,13 +254,13 @@ MEDIA_URL = '/media/'
 
 STATIC_URL = '/static/'
 
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = join(BASE_DIR, 'static')
 
 if 'test' not in sys.argv:
     STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 
 STATICFILES_DIRS = (
-    os.path.join(BASE_DIR, 'mysite/static'),
+    join(BASE_DIR, 'mysite/static'),
 )
 
 STATICFILES_FINDERS = (
@@ -437,7 +437,7 @@ for election_tuple in ELECTIONS_CURRENT:
 # both Python 2 and Python 3; this uses exec rather than import so
 # that the local settings can modify existing values rather than just
 # overwriting them.
-LOCAL_SETTINGS_FILE = os.path.join(BASE_DIR, 'mysite', 'local_settings.py')
+LOCAL_SETTINGS_FILE = join(BASE_DIR, 'mysite', 'local_settings.py')
 try:
     with open(LOCAL_SETTINGS_FILE) as f:
         exec(compile(f.read(), 'local_settings.py', 'exec'))

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -13,11 +13,11 @@ from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS, LANGUAGES
 from django.utils.translation import to_locale, ugettext_lazy as _
 from collections import defaultdict
 import importlib
-from os.path import dirname, exists, join
+from os.path import dirname, exists, join, realpath
 import re
 import sys
 import yaml
-BASE_DIR = dirname(dirname(__file__))
+BASE_DIR = realpath(dirname(dirname(__file__)))
 
 from .helpers import mkdir_p
 


### PR DESCRIPTION
The keys used in the memcached backend are based on the database name
(so that multiple instances of the application on the same host can
use the same memcached); however, in the case where you're using
sqlite as a database, the name of the database will be the path to
the sqlite database file.  This was based on BASE_DIR in
mysite.settings, which didn't canonicalize the path, so sometimes
the path to the database would be relative and sometimes absolute.
This meant that values stored in memcached couldn't be reliably
retrieved.
    
We think this is probably the reason that collecstatic would sometimes
appear not to update the cache of fingerprinted filenames, and may
also explain why cache invalidation for posts seems to be failing on
the instance for Argentina.
    
This commit introduces a change so that BASE_DIR is set to a value
that has has os.path.realpath run on it, so that you always get the
canonical absolute path, which the sqlite database path is then based
on.