### PR TITLE
Make the tests network-independent again

### DIFF
--- a/cached_counts/tests.py
+++ b/cached_counts/tests.py
@@ -7,7 +7,9 @@ from django.core.management import call_command
 from django_webtest import WebTest
 
 from candidates.tests.test_create_person import mock_create_person
-from candidates.tests.fake_popit import fake_mp_post_search_results
+from candidates.tests.fake_popit import (
+    fake_mp_post_search_results, FakePostCollection
+)
 
 from .models import CachedCount
 
@@ -98,8 +100,10 @@ class CachedCountTestCase(WebTest):
 
 class TestCachedCountsCreateCommand(WebTest):
 
+    @patch('candidates.popit.PopIt')
     @patch('candidates.popit.requests')
-    def test_cached_counts_create_command(self, mock_requests):
+    def test_cached_counts_create_command(self, mock_requests, mock_popit):
+        mock_popit.return_value.posts = FakePostCollection
         mock_requests.get.side_effect = fake_mp_post_search_results
         call_command('cached_counts_create')
         non_zero_counts = CachedCount.objects.exclude(count=0). \

--- a/candidates/example-popit-data/search_mp_posts_page=1.json
+++ b/candidates/example-popit-data/search_mp_posts_page=1.json
@@ -3959,7 +3959,5696 @@
       "role": "Member of Parliament",
       "start_date": "2005-05-06",
       "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/posts/65808"
+    },
+    {
+      "area": {
+        "identifier": "http://mapit.mysociety.org/area/65913",
+        "name": "Camberwell and Peckham",
+        "id": "mapit:65913"
+      },
+      "html_url": "http://candidates.127.0.0.1.xip.io:3000/posts/65913",
+      "id": "65913",
+      "label": "Member of Parliament for Camberwell and Peckham",
+      "organization_id": "commons",
+      "role": "Member of Parliament",
+      "start_date": "2005-05-06",
+      "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/posts/65913",
+      "candidates_locked": true,
+      "images": [],
+      "memberships": [
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/546f808bd484cf5c58509b30",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/1089",
+            "id": "1089",
+            "name": "Steven Robbins",
+            "party_memberships": {
+              "2010": {
+                "id": "ynmp-party:2",
+                "name": "Independent"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/1089",
+            "versions": [
+              {
+                "version_id": "307f39ee9e9b7407",
+                "timestamp": "2014-11-21T18:12:27.736758",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "steven-robbins",
+                  "phone": null,
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Independent",
+                      "id": "ynmp-party:2"
+                    }
+                  },
+                  "name": "Steven Robbins",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "24621"
+                    }
+                  ],
+                  "id": "1089",
+                  "homepage_url": null,
+                  "gender": "male",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": null,
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "24621",
+                "id": "552f7d35ed1c6ee164ee9589"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "546f808bd484cf5c58509b30",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/546f808bd484cf5c58509b30",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/546f808cd484cf5c58509b33",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/1090",
+            "id": "1090",
+            "name": "Yohara Robby Munilla",
+            "party_memberships": {
+              "2010": {
+                "id": "party:17",
+                "name": "English Democrats"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/1090",
+            "versions": [
+              {
+                "version_id": "5e8875a8978f93df",
+                "timestamp": "2014-11-21T18:12:27.982892",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "yohara-robby-munilla",
+                  "phone": null,
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "English Democrats",
+                      "id": "party:17"
+                    }
+                  },
+                  "name": "Yohara Robby Munilla",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "24622"
+                    }
+                  ],
+                  "id": "1090",
+                  "homepage_url": null,
+                  "gender": "male",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": null,
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "24622",
+                "id": "552f7d35ed1c6ee164ee958a"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "546f808cd484cf5c58509b33",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/546f808cd484cf5c58509b33",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/546f808dd484cf5c58509b48",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "gender": "female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/1095",
+            "id": "1095",
+            "name": "Decima Shamona Francis",
+            "party_memberships": {
+              "2010": {
+                "id": "ynmp-party:2",
+                "name": "Independent"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/1095",
+            "versions": [
+              {
+                "version_id": "1ec43509fde0f793",
+                "timestamp": "2014-11-21T18:12:29.594495",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "decima-shamona-francis",
+                  "phone": null,
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Independent",
+                      "id": "ynmp-party:2"
+                    }
+                  },
+                  "name": "Decima Shamona Francis",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "24619"
+                    }
+                  ],
+                  "id": "1095",
+                  "homepage_url": null,
+                  "gender": "female",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": null,
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "24619",
+                "id": "552f7d35ed1c6ee164ee958e"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "546f808dd484cf5c58509b48",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/546f808dd484cf5c58509b48",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/546f813cd484cf5c5850a2d7",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "patknox@gmail.com",
+            "gender": "female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/1714",
+            "id": "1714",
+            "name": "Patricia Knox",
+            "party_memberships": {
+              "2010": {
+                "id": "ynmp-party:2",
+                "name": "Independent"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/1714",
+            "versions": [
+              {
+                "version_id": "0fb574d00c876e05",
+                "timestamp": "2014-11-21T18:15:24.744815",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "patricia-knox",
+                  "phone": "07894-637207",
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Independent",
+                      "id": "ynmp-party:2"
+                    }
+                  },
+                  "name": "Patricia Knox",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "21834"
+                    }
+                  ],
+                  "id": "1714",
+                  "homepage_url": null,
+                  "gender": "female",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": "patknox@gmail.com",
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "21834",
+                "id": "552f7d7ded1c6ee164ee9732"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "546f813cd484cf5c5850a2d7",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/546f813cd484cf5c5850a2d7",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/546f83f8d484cf5c5850bdfa",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "jill@workersliberty.org",
+            "gender": "female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/3884",
+            "id": "3884",
+            "name": "Jill Mountford",
+            "party_memberships": {
+              "2010": {
+                "id": "party:766",
+                "name": "Alliance for Workers' Liberty"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/3884",
+            "versions": [
+              {
+                "version_id": "750a5ae954b1d3bf",
+                "timestamp": "2014-11-21T18:27:04.759111",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "jill-mountford",
+                  "phone": "07796 690 874",
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Alliance for Workers' Liberty",
+                      "id": "party:766"
+                    }
+                  },
+                  "name": "Jill Mountford",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "2721"
+                    }
+                  ],
+                  "id": "3884",
+                  "homepage_url": null,
+                  "gender": "female",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": "jill@workersliberty.org",
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "2721",
+                "id": "552f7f37ed1c6ee164eea69a"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "546f83f8d484cf5c5850bdfa",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/546f83f8d484cf5c5850bdfa",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5480a3446bacc73870cff52a",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "jenny.jones@greenparty.org.uk",
+            "gender": "female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/1355",
+            "id": "1355",
+            "name": "Jenny Jones",
+            "party_memberships": {
+              "2010": {
+                "id": "party:63",
+                "name": "Green Party"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              },
+              "2015": null
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/1355",
+            "versions": [
+              {
+                "version_id": "3c33385523b213c6",
+                "username": "symroe",
+                "timestamp": "2014-12-04T18:09:07.950336",
+                "information_source": "Because Amelia Womack is standing",
+                "data": {
+                  "wikipedia_url": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "party_ppc_page_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Green Party",
+                      "id": "party:63"
+                    }
+                  },
+                  "name": "Jenny Jones",
+                  "id": "1355",
+                  "homepage_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "",
+                  "facebook_page_url": "",
+                  "email": "jenny.jones@greenparty.org.uk",
+                  "birth_date": null
+                }
+              },
+              {
+                "version_id": "4231fb3265ab229b",
+                "timestamp": "2014-11-21T18:13:48.114667",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "jenny-jones",
+                  "phone": "07818 007171",
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Green Party",
+                      "id": "party:63"
+                    }
+                  },
+                  "name": "Jenny Jones",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "16740"
+                    }
+                  ],
+                  "id": "1355",
+                  "homepage_url": null,
+                  "gender": "female",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": "jenny.jones@greenparty.org.uk",
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "16740",
+                "id": "552f8540ed1c6ee164eecafb"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "5480a3446bacc73870cff52a",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5480a3446bacc73870cff52a",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5499a0b4161dbc6b46cb09fd",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "cb5641@aol.com",
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/63",
+            "id": "63",
+            "name": "Columba Blango",
+            "party_memberships": {
+              "2010": {
+                "id": "party:90",
+                "name": "Liberal Democrats"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              },
+              "2015": null
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/63",
+            "versions": [
+              {
+                "version_id": "641b8a20e02587fe",
+                "username": "adambro",
+                "timestamp": "2014-12-23T17:04:52.291851",
+                "information_source": "http://www.markpack.org.uk/107121/yahaya-kiyingi-selected-camberwell-peckham/",
+                "data": {
+                  "wikipedia_url": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "party_ppc_page_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Liberal Democrats",
+                      "id": "party:90"
+                    }
+                  },
+                  "name": "Columba Blango",
+                  "image": null,
+                  "id": "63",
+                  "homepage_url": "",
+                  "gender": "male",
+                  "facebook_personal_url": "",
+                  "facebook_page_url": "",
+                  "email": "cb5641@aol.com",
+                  "birth_date": null
+                }
+              },
+              {
+                "version_id": "24cc926d27af4d4b",
+                "timestamp": "2014-11-21T18:07:37.861951",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "columba-blango",
+                  "phone": "(mob) 07984412812",
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Liberal Democrats",
+                      "id": "party:90"
+                    }
+                  },
+                  "name": "Columba Blango",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "2718"
+                    }
+                  ],
+                  "id": "63",
+                  "homepage_url": null,
+                  "gender": "male",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": "cb5641@aol.com",
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "2718",
+                "id": "552f8035ed1c6ee164eeaa6c"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "5499a0b4161dbc6b46cb09fd",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5499a0b4161dbc6b46cb09fd",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5499a0be161dbc6b46cb09ff",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "andy@stranack.co.uk",
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/4068",
+            "id": "4068",
+            "name": "Andy Stranack",
+            "party_memberships": {
+              "2010": {
+                "id": "party:52",
+                "name": "Conservative Party"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              },
+              "2015": null
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/4068",
+            "versions": [
+              {
+                "version_id": "543a0f1b3cd56e31",
+                "username": "adambro",
+                "timestamp": "2014-12-23T17:05:01.502532",
+                "information_source": "by implication",
+                "data": {
+                  "wikipedia_url": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "party_ppc_page_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "name": "Andy Stranack",
+                  "image": null,
+                  "id": "4068",
+                  "homepage_url": "",
+                  "gender": "male",
+                  "facebook_personal_url": "",
+                  "facebook_page_url": "",
+                  "email": "andy@stranack.co.uk",
+                  "birth_date": null
+                }
+              },
+              {
+                "version_id": "3b35ebe3632cc84d",
+                "timestamp": "2014-11-21T18:28:05.888319",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "andy-stranack",
+                  "phone": "07789 906261",
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "name": "Andy Stranack",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "4456"
+                    }
+                  ],
+                  "id": "4068",
+                  "homepage_url": null,
+                  "gender": "male",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": "andy@stranack.co.uk",
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "4456",
+                "id": "552f85f6ed1c6ee164eed642"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "5499a0be161dbc6b46cb09ff",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5499a0be161dbc6b46cb09ff",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2015",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/54e1265ef8751c7576e5d597",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "prem.goyal@allpeoplesparty.co.uk",
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/5417",
+            "id": "5417",
+            "image": "http://yournextmp.popit.mysociety.org/persons/5417/image/54bb2e4bcb19ebca71e2af86",
+            "name": "Prem Goyal",
+            "party_memberships": {
+              "2015": {
+                "id": "party:2137",
+                "name": "All People's Party"
+              }
+            },
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F5417%2Fimage%2F54bb2e4bcb19ebca71e2af86",
+            "standing_in": {
+              "2015": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/5417",
+            "versions": [
+              {
+                "version_id": "37bc2908af08ce45",
+                "username": "andylolz",
+                "timestamp": "2015-02-15T23:06:05.752410",
+                "information_source": "Add linkedin page",
+                "data": {
+                  "wikipedia_url": "",
+                  "twitter_username": "PremGoyal_",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F5417%2Fimage%2F54bb2e4bcb19ebca71e2af86",
+                  "party_ppc_page_url": "http://allpeoplesparty.co.uk/about-prem/",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "All People's Party",
+                      "id": "party:2137"
+                    }
+                  },
+                  "other_names": [],
+                  "name": "Prem Goyal",
+                  "linkedin_url": "http://uk.linkedin.com/in/premgoyal/en",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/5417/image/54bb2e4bcb19ebca71e2af86",
+                  "identifiers": [],
+                  "id": "5417",
+                  "homepage_url": "http://www.premgoyal.com/",
+                  "gender": "male",
+                  "facebook_personal_url": "https://www.facebook.com/prem.goyal.50",
+                  "facebook_page_url": "",
+                  "email": "prem.goyal@allpeoplesparty.co.uk",
+                  "birth_date": null
+                }
+              },
+              {
+                "version_id": "33b5f54c6ee00edb",
+                "username": "symroe",
+                "timestamp": "2015-01-11T11:09:44.491708",
+                "information_source": "Party web site & candidate knocking on my door",
+                "data": {
+                  "wikipedia_url": "",
+                  "twitter_username": "PremGoyal_",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "party_ppc_page_url": "http://allpeoplesparty.co.uk/about-prem/",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "All People's Party",
+                      "id": "party:2137"
+                    }
+                  },
+                  "name": "Prem Goyal",
+                  "id": "5417",
+                  "homepage_url": "http://www.premgoyal.com/",
+                  "gender": "male",
+                  "facebook_personal_url": "https://www.facebook.com/prem.goyal.50",
+                  "facebook_page_url": "",
+                  "email": "prem.goyal@allpeoplesparty.co.uk",
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [
+              {
+                "birth_date": null,
+                "created": null,
+                "death_date": null,
+                "dissolution_date": null,
+                "end_date": null,
+                "founding_date": null,
+                "id": "54bb2e4bcb19ebca71e2af86",
+                "local_path": "54/bb/54bb2e4bcb19ebca71e2af86",
+                "local_path_base": "54/bb/54bb2e4bcb19ebca71e2af86",
+                "mime_type": "image/png",
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F5417%2Fimage%2F54bb2e4bcb19ebca71e2af86",
+                "start_date": null,
+                "url": "http://yournextmp.popit.mysociety.org/persons/5417/image/54bb2e4bcb19ebca71e2af86",
+                "md5sum": "0a752d639a08fa490fb30186852906c4"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "party PPC page",
+                "url": "http://allpeoplesparty.co.uk/about-prem/",
+                "id": "552f8302ed1c6ee164eebae8"
+              },
+              {
+                "note": "linkedin",
+                "url": "http://uk.linkedin.com/in/premgoyal/en",
+                "id": "552f8302ed1c6ee164eebae7"
+              },
+              {
+                "note": "facebook personal",
+                "url": "https://www.facebook.com/prem.goyal.50",
+                "id": "552f8302ed1c6ee164eebae6"
+              },
+              {
+                "note": "homepage",
+                "url": "http://www.premgoyal.com/",
+                "id": "552f8302ed1c6ee164eebae5"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "PremGoyal_",
+                "id": "552f8302ed1c6ee164eebae4"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          },
+          "id": "54e1265ef8751c7576e5d597",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/54e1265ef8751c7576e5d597",
+          "end_date": "9999-12-31"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2015",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/54e12752f8751c7576e5d5a5",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "nha.cambpeckham@gmail.com",
+            "gender": "female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/5708",
+            "id": "5708",
+            "image": "http://yournextmp.popit.mysociety.org/persons/5708/image/54c1028b5a9c3744778f9ba7",
+            "name": "Rebecca Fox",
+            "party_memberships": {
+              "2015": {
+                "id": "party:1931",
+                "name": "National Health Action Party"
+              }
+            },
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F5708%2Fimage%2F54c1028b5a9c3744778f9ba7",
+            "standing_in": {
+              "2015": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/5708",
+            "versions": [
+              {
+                "version_id": "28ae084d93c1b060",
+                "username": "andylolz",
+                "timestamp": "2015-02-15T23:10:09.991428",
+                "information_source": "Add linkedin page",
+                "data": {
+                  "wikipedia_url": "",
+                  "twitter_username": "nha_cambpeckham",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F5708%2Fimage%2F54c1028b5a9c3744778f9ba7",
+                  "party_ppc_page_url": "http://nhap.org/rebecca-fox/",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "National Health Action Party",
+                      "id": "party:1931"
+                    }
+                  },
+                  "other_names": [],
+                  "name": "Rebecca Fox",
+                  "linkedin_url": "http://uk.linkedin.com/pub/rebecca-fox/0/24b/a16/en",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/5708/image/54c1028b5a9c3744778f9ba7",
+                  "identifiers": [],
+                  "id": "5708",
+                  "homepage_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "",
+                  "facebook_page_url": "https://www.facebook.com/nhacambpeckham",
+                  "email": "nha.cambpeckham@gmail.com",
+                  "birth_date": null
+                }
+              },
+              {
+                "version_id": "4fd1b4c927167cfa",
+                "username": "RichCBury1",
+                "timestamp": "2015-01-22T13:42:51.440865",
+                "information_source": "http://nhap.org/rebecca-fox/",
+                "data": {
+                  "wikipedia_url": "",
+                  "twitter_username": "nha_cambpeckham",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "party_ppc_page_url": "http://nhap.org/rebecca-fox/",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "National Health Action Party",
+                      "id": "party:1931"
+                    }
+                  },
+                  "name": "Rebecca Fox",
+                  "id": "5708",
+                  "homepage_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "",
+                  "facebook_page_url": "https://www.facebook.com/nhacambpeckham",
+                  "email": "nha.cambpeckham@gmail.com",
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [
+              {
+                "birth_date": null,
+                "created": null,
+                "death_date": null,
+                "dissolution_date": null,
+                "end_date": null,
+                "founding_date": null,
+                "id": "54c1028b5a9c3744778f9ba7",
+                "local_path": "54/c1/54c1028b5a9c3744778f9ba7",
+                "local_path_base": "54/c1/54c1028b5a9c3744778f9ba7",
+                "mime_type": "image/png",
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F5708%2Fimage%2F54c1028b5a9c3744778f9ba7",
+                "start_date": null,
+                "url": "http://yournextmp.popit.mysociety.org/persons/5708/image/54c1028b5a9c3744778f9ba7",
+                "md5sum": "da703fd9a6f5513d923c61828849572d"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "facebook page",
+                "url": "https://www.facebook.com/nhacambpeckham",
+                "id": "552f7f1aed1c6ee164eea5df"
+              },
+              {
+                "note": "party PPC page",
+                "url": "http://nhap.org/rebecca-fox/",
+                "id": "552f7f1aed1c6ee164eea5de"
+              },
+              {
+                "note": "linkedin",
+                "url": "http://uk.linkedin.com/pub/rebecca-fox/0/24b/a16/en",
+                "id": "552f7f1aed1c6ee164eea5dd"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "nha_cambpeckham",
+                "id": "552f7f1aed1c6ee164eea5dc"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          },
+          "id": "54e12752f8751c7576e5d5a5",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/54e12752f8751c7576e5d5a5",
+          "end_date": "9999-12-31"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "election": "2010",
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/54e1283df8751c7576e5d5ad",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "margaretmsharkey@hotmail.com",
+            "gender": "female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/1091",
+            "id": "1091",
+            "name": "Margaret Sharkey",
+            "party_memberships": {
+              "2010": {
+                "id": "party:73",
+                "name": "Socialist Labour Party"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "mapit_url": "http://mapit.mysociety.org/area/65913",
+                "name": "Camberwell and Peckham",
+                "post_id": "65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/1091",
+            "versions": [
+              {
+                "version_id": "3f53b88c50d020ec",
+                "username": "andylolz",
+                "timestamp": "2015-02-15T23:14:04.606389",
+                "information_source": "Add linkedin page",
+                "data": {
+                  "wikipedia_url": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "proxy_image": null,
+                  "party_ppc_page_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Socialist Labour Party",
+                      "id": "party:73"
+                    }
+                  },
+                  "other_names": [],
+                  "name": "Margaret Sharkey",
+                  "linkedin_url": "http://uk.linkedin.com/pub/margaret-sharkey/90/365/3a4/en",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "24623",
+                      "id": "546f808cd484cf5c58509b34"
+                    }
+                  ],
+                  "id": "1091",
+                  "homepage_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "",
+                  "facebook_page_url": "",
+                  "email": "margaretmsharkey@hotmail.com",
+                  "birth_date": null
+                }
+              },
+              {
+                "version_id": "7d6f93090242b098",
+                "timestamp": "2014-11-21T18:12:28.234922",
+                "information_source": "Imported from YourNextMP data from 2010",
+                "data": {
+                  "wikipedia_url": null,
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "slug": "margaret-sharkey",
+                  "phone": null,
+                  "party_ppc_page_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Socialist Labour Party",
+                      "id": "party:73"
+                    }
+                  },
+                  "name": "Margaret Sharkey",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "24623"
+                    }
+                  ],
+                  "id": "1091",
+                  "homepage_url": null,
+                  "gender": "female",
+                  "facebook_personal_url": null,
+                  "facebook_page_url": null,
+                  "email": "margaretmsharkey@hotmail.com",
+                  "birth_date": null
+                }
+              }
+            ],
+            "images": [],
+            "memberships": [],
+            "links": [
+              {
+                "note": "linkedin",
+                "url": "http://uk.linkedin.com/pub/margaret-sharkey/90/365/3a4/en",
+                "id": "552f7e5bed1c6ee164eea1bb"
+              }
+            ],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "24623",
+                "id": "552f7e5bed1c6ee164eea1ba"
+              }
+            ],
+            "other_names": []
+          },
+          "id": "54e1283df8751c7576e5d5ad",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/54e1283df8751c7576e5d5ad",
+          "end_date": "2010-05-06"
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5510aa9ea344efdd4783d77f",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5510aa9ea344efdd4783d77f",
+          "election": "2015",
+          "id": "5510aa9ea344efdd4783d77f",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": "1985-01-12",
+            "email": "amelia.womack@greenparty.org.uk",
+            "gender": "female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/4808",
+            "id": "4808",
+            "image": "http://yournextmp.popit.mysociety.org/persons/4808/image/54bb27a2cb19ebca71e2af85",
+            "name": "Amelia Womack",
+            "party_memberships": {
+              "2015": {
+                "name": "Green Party",
+                "id": "party:63"
+              }
+            },
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F4808%2Fimage%2F54bb27a2cb19ebca71e2af85",
+            "standing_in": {
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/4808",
+            "versions": [
+              {
+                "information_source": "I know her date of birth from her profile.",
+                "timestamp": "2015-03-24T00:06:54.399244",
+                "username": "greensocialistalan",
+                "data": {
+                  "facebook_page_url": "",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://greenparty.org.uk/people/deputy-leader-amelia-womack.html",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/4808/image/54bb27a2cb19ebca71e2af85",
+                  "facebook_personal_url": "https://www.facebook.com/GreenAmeliaWomack",
+                  "id": "4808",
+                  "other_names": [],
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F4808%2Fimage%2F54bb27a2cb19ebca71e2af85",
+                  "honorific_prefix": "",
+                  "wikipedia_url": "https://en.wikipedia.org/wiki/Amelia_Womack",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Green Party",
+                      "id": "party:63"
+                    }
+                  },
+                  "email": "amelia.womack@greenparty.org.uk",
+                  "twitter_username": "amelia_womack",
+                  "name": "Amelia Womack",
+                  "gender": "female",
+                  "identifiers": [],
+                  "linkedin_url": "http://uk.linkedin.com/in/helenameliawomack/en",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://ameliawomack.net/",
+                  "birth_date": "1985-01-12"
+                },
+                "version_id": "40f86033988f0bb2"
+              },
+              {
+                "username": "petermarcus",
+                "timestamp": "2015-02-24T14:19:21.214135",
+                "information_source": "http://greenparty.org.uk/people/green-party-spokespeople/",
+                "data": {
+                  "facebook_page_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "https://www.facebook.com/GreenAmeliaWomack",
+                  "name": "Amelia Womack",
+                  "party_ppc_page_url": "http://greenparty.org.uk/people/deputy-leader-amelia-womack.html",
+                  "linkedin_url": "http://uk.linkedin.com/in/helenameliawomack/en",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/4808/image/54bb27a2cb19ebca71e2af85",
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F4808%2Fimage%2F54bb27a2cb19ebca71e2af85",
+                  "email": "amelia.womack@greenparty.org.uk",
+                  "twitter_username": "amelia_womack",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://ameliawomack.net/",
+                  "wikipedia_url": "https://en.wikipedia.org/wiki/Amelia_Womack",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Green Party",
+                      "id": "party:63"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4808"
+                },
+                "version_id": "6f4b87dc4d9e037c"
+              },
+              {
+                "username": "andylolz",
+                "timestamp": "2015-02-15T23:07:15.626004",
+                "information_source": "Add linkedin page",
+                "data": {
+                  "facebook_page_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "https://www.facebook.com/GreenAmeliaWomack",
+                  "name": "Amelia Womack",
+                  "party_ppc_page_url": "http://greenparty.org.uk/people/deputy-leader-amelia-womack.html",
+                  "linkedin_url": "http://uk.linkedin.com/in/helenameliawomack/en",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/4808/image/54bb27a2cb19ebca71e2af85",
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F4808%2Fimage%2F54bb27a2cb19ebca71e2af85",
+                  "email": "",
+                  "twitter_username": "amelia_womack",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://ameliawomack.net/",
+                  "wikipedia_url": "https://en.wikipedia.org/wiki/Amelia_Womack",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Green Party",
+                      "id": "party:63"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4808"
+                },
+                "version_id": "00c9556075d777f8"
+              },
+              {
+                "username": "RichCBury1",
+                "timestamp": "2015-01-09T06:07:58.455646",
+                "information_source": "https://en.wikipedia.org/wiki/Amelia_Womack",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Amelia Womack",
+                  "party_ppc_page_url": "http://greenparty.org.uk/people/deputy-leader-amelia-womack.html",
+                  "gender": "female",
+                  "image": null,
+                  "facebook_personal_url": "https://www.facebook.com/GreenAmeliaWomack",
+                  "email": "",
+                  "twitter_username": "amelia_womack",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://ameliawomack.net/",
+                  "wikipedia_url": "https://en.wikipedia.org/wiki/Amelia_Womack",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Green Party",
+                      "id": "party:63"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4808"
+                },
+                "version_id": "545139fe0a232da7"
+              },
+              {
+                "username": "RichCBury1",
+                "timestamp": "2015-01-09T06:00:40.117358",
+                "information_source": "http://greenparty.org.uk/people/deputy-leader-amelia-womack.html",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Amelia Womack",
+                  "party_ppc_page_url": "http://greenparty.org.uk/people/deputy-leader-amelia-womack.html",
+                  "gender": "female",
+                  "image": null,
+                  "facebook_personal_url": "https://www.facebook.com/GreenAmeliaWomack",
+                  "email": "",
+                  "twitter_username": "amelia_womack",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://ameliawomack.net/",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Green Party",
+                      "id": "party:63"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4808"
+                },
+                "version_id": "0ff2a4e173e92e0a"
+              },
+              {
+                "username": "symroe",
+                "timestamp": "2014-12-04T16:04:18.291159",
+                "information_source": "https://twitter.com/Amelia_Womack/status/540514473162072065",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Amelia Womack",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "https://www.facebook.com/GreenAmeliaWomack",
+                  "email": "",
+                  "twitter_username": "amelia_womack",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://ameliawomack.net/",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Green Party",
+                      "id": "party:63"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4808"
+                },
+                "version_id": "72ca596b9b37ba54"
+              }
+            ],
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "images": [
+              {
+                "birth_date": null,
+                "created": null,
+                "death_date": null,
+                "dissolution_date": null,
+                "end_date": null,
+                "founding_date": null,
+                "id": "54bb27a2cb19ebca71e2af85",
+                "local_path": "54/bb/54bb27a2cb19ebca71e2af85",
+                "local_path_base": "54/bb/54bb27a2cb19ebca71e2af85",
+                "mime_type": "image/png",
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F4808%2Fimage%2F54bb27a2cb19ebca71e2af85",
+                "start_date": null,
+                "url": "http://yournextmp.popit.mysociety.org/persons/4808/image/54bb27a2cb19ebca71e2af85",
+                "md5sum": "0af066d2c0a726bbd45ebb0707ccb97f"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "party PPC page",
+                "url": "http://greenparty.org.uk/people/deputy-leader-amelia-womack.html",
+                "id": "552f839bed1c6ee164eebe33"
+              },
+              {
+                "note": "linkedin",
+                "url": "http://uk.linkedin.com/in/helenameliawomack/en",
+                "id": "552f839bed1c6ee164eebe32"
+              },
+              {
+                "note": "facebook personal",
+                "url": "https://www.facebook.com/GreenAmeliaWomack",
+                "id": "552f839bed1c6ee164eebe31"
+              },
+              {
+                "note": "homepage",
+                "url": "http://ameliawomack.net/",
+                "id": "552f839bed1c6ee164eebe30"
+              },
+              {
+                "note": "wikipedia",
+                "url": "https://en.wikipedia.org/wiki/Amelia_Womack",
+                "id": "552f839bed1c6ee164eebe2f"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "amelia_womack",
+                "id": "552f839bed1c6ee164eebe2e"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/552687f215d96fc063976e4c",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/552687f215d96fc063976e4c",
+          "election": "2015",
+          "id": "552687f215d96fc063976e4c",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "name": "David Kurten",
+            "honorific_suffix": null,
+            "gender": "male",
+            "versions": [
+              {
+                "information_source": "Approved a photo upload from JPCarrington who provided the message: \"As featured on official party PPC pages: http://www.myukip.com/parliamentary-candidates-a-b.html\"",
+                "timestamp": "2015-04-09T14:08:45.889567",
+                "username": "JPCarrington",
+                "data": {
+                  "facebook_page_url": "",
+                  "identifiers": [],
+                  "proxy_image": null,
+                  "name": "David Kurten",
+                  "honorific_suffix": null,
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.davidkurten.net/",
+                  "id": "6829",
+                  "honorific_prefix": null,
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "twitter_username": "davidkurten",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "id": "party:85",
+                      "name": "UK Independence Party (UKIP)"
+                    }
+                  },
+                  "birth_date": null,
+                  "other_names": [],
+                  "email": "david.kurten@ukiplocal.org"
+                },
+                "version_id": "6876bd62edbc800d"
+              },
+              {
+                "information_source": "https://twitter.com/davidkurten/status/578597498262044672",
+                "timestamp": "2015-03-22T22:27:47.771686",
+                "username": "symroe",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "David Kurten",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "id": "6829",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "facebook_personal_url": "",
+                  "twitter_username": "davidkurten",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "UK Independence Party (UKIP)",
+                      "id": "party:85"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "http://www.davidkurten.net/",
+                  "email": "david.kurten@ukiplocal.org"
+                },
+                "version_id": "53c5dcd090825f6f"
+              },
+              {
+                "information_source": "https://www.facebook.com/permalink.php?story_fbid=1580108622206292&id=1509965975887224",
+                "timestamp": "2015-03-18T01:21:43.783429",
+                "username": "h2g2bob",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "David Kurten",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "facebook_personal_url": "",
+                  "email": "",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.davidkurten.net/",
+                  "linkedin_url": "",
+                  "twitter_username": "davidkurten",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "UK Independence Party (UKIP)",
+                      "id": "party:85"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "6829"
+                },
+                "version_id": "592bdd8f3b6ecbc3"
+              }
+            ],
+            "id": "6829",
+            "honorific_prefix": null,
+            "standing_in": {
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "party_memberships": {
+              "2015": {
+                "id": "party:85",
+                "name": "UK Independence Party (UKIP)"
+              }
+            },
+            "birth_date": null,
+            "email": "david.kurten@ukiplocal.org",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/6829",
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/6829",
+            "image": "http://yournextmp.popit.mysociety.org/persons/6829/image/552687ed59bbc5c063445b62",
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6829%2Fimage%2F552687ed59bbc5c063445b62",
+            "images": [
+              {
+                "mime_type": "image/png",
+                "uploaded_by_user": "JPCarrington",
+                "user_justification_for_use": "As featured on official party PPC pages: http://www.myukip.com/parliamentary-candidates-a-b.html",
+                "moderator_why_allowed": "profile-photo",
+                "md5sum": "6142aa1c2b76d435df47bc1b7ac9f663",
+                "notes": "Approved from photo moderation queue",
+                "user_why_allowed": "profile-photo",
+                "index": "first",
+                "created": null,
+                "local_path": "55/26/552687ed59bbc5c063445b62",
+                "local_path_base": "55/26/552687ed59bbc5c063445b62",
+                "start_date": null,
+                "end_date": null,
+                "birth_date": null,
+                "death_date": null,
+                "founding_date": null,
+                "dissolution_date": null,
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6829%2Fimage%2F552687ed59bbc5c063445b62",
+                "url": "http://yournextmp.popit.mysociety.org/persons/6829/image/552687ed59bbc5c063445b62",
+                "id": "552687ed59bbc5c063445b62"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "homepage",
+                "url": "http://www.davidkurten.net/",
+                "id": "552f8568ed1c6ee164eecbde"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "davidkurten",
+                "id": "552f8568ed1c6ee164eecbdd"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/552918c244c0f7ed16e7273c",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/552918c244c0f7ed16e7273c",
+          "election": "2015",
+          "id": "552918c244c0f7ed16e7273c",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "naomi.newstead@londonconservatives.com",
+            "gender": "female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/4170",
+            "id": "4170",
+            "name": "Naomi Newstead",
+            "party_memberships": {
+              "2015": {
+                "id": "party:52",
+                "name": "Conservative Party"
+              }
+            },
+            "standing_in": {
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/4170",
+            "versions": [
+              {
+                "information_source": "Approved a photo upload from TimPatmore who provided the message: \"Facebook profile picture: https://www.facebook.com/photo.php?fbid=10150487735264023&set=a.10150487735254023.376272.598754022&type=1&theater\"",
+                "timestamp": "2015-04-11T12:51:13.175250",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "identifiers": [],
+                  "proxy_image": null,
+                  "name": "Naomi Newstead",
+                  "honorific_suffix": null,
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "gender": "female",
+                  "image": null,
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.naominewstead.org.uk/",
+                  "id": "4170",
+                  "honorific_prefix": null,
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "https://www.facebook.com/naomi.newstead.9?fref=ts",
+                  "twitter_username": "NaomiNewstead",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "id": "party:52",
+                      "name": "Conservative Party"
+                    }
+                  },
+                  "birth_date": null,
+                  "other_names": [],
+                  "email": "naomi.newstead@londonconservatives.com"
+                },
+                "version_id": "4f1382f23bdffa3b"
+              },
+              {
+                "information_source": "Facebook",
+                "timestamp": "2015-04-06T22:56:25.600647",
+                "username": "TimPatmore",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Naomi Newstead",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "id": "4170",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "facebook_personal_url": "https://www.facebook.com/naomi.newstead.9?fref=ts",
+                  "twitter_username": "NaomiNewstead",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "http://www.naominewstead.org.uk/",
+                  "email": "naomi.newstead@londonconservatives.com"
+                },
+                "version_id": "2caffef1a103183b"
+              },
+              {
+                "username": "andylolz",
+                "timestamp": "2015-02-08T16:42:00.252727",
+                "information_source": "Added twitter handle",
+                "data": {
+                  "facebook_page_url": "",
+                  "gender": "female",
+                  "name": "Naomi Newstead",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "linkedin_url": "",
+                  "image": null,
+                  "identifiers": [],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "NaomiNewstead",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.naominewstead.org.uk/",
+                  "email": "naomi.newstead@londonconservatives.com",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4170"
+                },
+                "version_id": "50e9e64c859af17d"
+              },
+              {
+                "information_source": "Updated candidate from official PPC data (conservatives)",
+                "timestamp": "2015-01-31T18:04:55.300020",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Naomi Newstead",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.naominewstead.org.uk/",
+                  "email": "naomi.newstead@londonconservatives.com",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4170"
+                },
+                "version_id": "6a28a18de27bd908"
+              },
+              {
+                "username": "MartinEden",
+                "timestamp": "2015-01-22T11:18:16.760407",
+                "information_source": "From http://www.naominewstead.org.uk/",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Naomi Newstead",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "gender": "female",
+                  "image": null,
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.naominewstead.org.uk/",
+                  "email": "naomi.newstead@londonconservatives.com",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4170"
+                },
+                "version_id": "2ffbf144018f253a"
+              },
+              {
+                "username": "tfgg",
+                "timestamp": "2015-01-18T11:44:49.029557",
+                "information_source": "Gender from name",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Naomi Newstead",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "gender": "female",
+                  "image": null,
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "email": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4170"
+                },
+                "version_id": "41ace8bd37dd901e"
+              },
+              {
+                "information_source": "Updated candidate from official PPC data (conservatives)",
+                "timestamp": "2014-12-11T12:05:36.369418",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Naomi Newstead",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "gender": null,
+                  "image": null,
+                  "facebook_personal_url": "",
+                  "email": null,
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4170"
+                },
+                "version_id": "337dda7096402dfb"
+              },
+              {
+                "information_source": "Updated candidate from official PPC data (conservatives)",
+                "timestamp": "2014-12-05T17:10:38.343344",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Naomi Newstead",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "gender": "",
+                  "image": null,
+                  "facebook_personal_url": "",
+                  "email": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4170"
+                },
+                "version_id": "2e792c3205b6e6d8"
+              },
+              {
+                "information_source": "Updated candidate from official PPC data (conservatives)",
+                "timestamp": "2014-11-23T09:45:49.409774",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Naomi Newstead",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "gender": "",
+                  "facebook_personal_url": "",
+                  "email": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4170"
+                },
+                "version_id": "62e42d304d16287c"
+              },
+              {
+                "information_source": "Created new candidate from official PPC data (conservatives)",
+                "timestamp": "2014-11-22T08:54:22.332394",
+                "data": {
+                  "name": "Naomi Newstead",
+                  "party_ppc_page_url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                  "facebook_personal_url": "",
+                  "email": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Conservative Party",
+                      "id": "party:52"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "4170"
+                },
+                "version_id": "2ed754214cd40f86"
+              }
+            ],
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "image": "http://yournextmp.popit.mysociety.org/persons/4170/image/552918c1b6a860ed1648be40",
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F4170%2Fimage%2F552918c1b6a860ed1648be40",
+            "images": [
+              {
+                "mime_type": "image/png",
+                "uploaded_by_user": "TimPatmore",
+                "user_justification_for_use": "Facebook profile picture: https://www.facebook.com/photo.php?fbid=10150487735264023&set=a.10150487735254023.376272.598754022&type=1&theater",
+                "moderator_why_allowed": "profile-photo",
+                "md5sum": "7f6b9f96940a51a666b00b08037f1307",
+                "notes": "Approved from photo moderation queue",
+                "user_why_allowed": "profile-photo",
+                "index": "first",
+                "created": null,
+                "local_path": "55/29/552918c1b6a860ed1648be40",
+                "local_path_base": "55/29/552918c1b6a860ed1648be40",
+                "start_date": null,
+                "end_date": null,
+                "birth_date": null,
+                "death_date": null,
+                "founding_date": null,
+                "dissolution_date": null,
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F4170%2Fimage%2F552918c1b6a860ed1648be40",
+                "url": "http://yournextmp.popit.mysociety.org/persons/4170/image/552918c1b6a860ed1648be40",
+                "id": "552918c1b6a860ed1648be40"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "party PPC page",
+                "url": "https://www.conservatives.com/OurTeam/Prospective_Parliamentary_Candidates/Newstead_Naomi.aspx",
+                "id": "552f86f9ed1c6ee164eeda58"
+              },
+              {
+                "note": "facebook personal",
+                "url": "https://www.facebook.com/naomi.newstead.9?fref=ts",
+                "id": "552f86f9ed1c6ee164eeda57"
+              },
+              {
+                "note": "homepage",
+                "url": "http://www.naominewstead.org.uk/",
+                "id": "552f86f9ed1c6ee164eeda56"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "NaomiNewstead",
+                "id": "552f86f9ed1c6ee164eeda55"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5531f49884992d847ad2bf51",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5531f49884992d847ad2bf51",
+          "election": "2015",
+          "id": "5531f49884992d847ad2bf51",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "email": "peckhamtusc@gmail.com",
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/6460",
+            "id": "6460",
+            "image": "http://yournextmp.popit.mysociety.org/persons/6460/image/54f3a4614a2e02e0576a6c93",
+            "name": "Nick Wrack",
+            "party_memberships": {
+              "2015": {
+                "name": "Left Unity - Trade Unionists and Socialists",
+                "id": "joint-party:804-2045"
+              }
+            },
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6460%2Fimage%2F54f3a4614a2e02e0576a6c93",
+            "standing_in": {
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/6460",
+            "versions": [
+              {
+                "information_source": "http://www.tusc.org.uk/txt/336.pdf",
+                "timestamp": "2015-04-18T06:07:15.845214",
+                "username": "andylolz",
+                "data": {
+                  "facebook_page_url": "https://www.facebook.com/pages/Nick-Wrack-for-Camberwell-and-Peckham/1549007035359265",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://peckhamtusc.com/nick-wrack/",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/6460/image/54f3a4614a2e02e0576a6c93",
+                  "facebook_personal_url": "",
+                  "id": "6460",
+                  "other_names": [],
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6460%2Fimage%2F54f3a4614a2e02e0576a6c93",
+                  "honorific_prefix": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Left Unity - Trade Unionists and Socialists",
+                      "id": "joint-party:804-2045"
+                    }
+                  },
+                  "email": "peckhamtusc@gmail.com",
+                  "twitter_username": "nickwrack",
+                  "name": "Nick Wrack",
+                  "gender": "male",
+                  "identifiers": [],
+                  "linkedin_url": "https://www.linkedin.com/pub/nick-wrack/4b/337/a59",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "https://peckhamtusc.com/",
+                  "birth_date": null
+                },
+                "version_id": "4d6dd5cbd7eb3405"
+              },
+              {
+                "information_source": "https://peckhamtusc.com",
+                "timestamp": "2015-03-20T19:22:22.184029",
+                "username": "nickwrack",
+                "data": {
+                  "facebook_page_url": "https://www.facebook.com/pages/Nick-Wrack-for-Camberwell-and-Peckham/1549007035359265",
+                  "name": "Nick Wrack",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://peckhamtusc.com/nick-wrack/",
+                  "gender": "male",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/6460/image/54f3a4614a2e02e0576a6c93",
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6460%2Fimage%2F54f3a4614a2e02e0576a6c93",
+                  "id": "6460",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "honorific_prefix": "",
+                  "linkedin_url": "https://www.linkedin.com/pub/nick-wrack/4b/337/a59",
+                  "facebook_personal_url": "",
+                  "twitter_username": "nickwrack",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Trade Unionist and Socialist Coalition",
+                      "id": "party:804"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "https://peckhamtusc.com/",
+                  "email": "peckhamtusc@gmail.com"
+                },
+                "version_id": "55ae4e382485ca44"
+              },
+              {
+                "information_source": "https://peckhamtusc.com",
+                "timestamp": "2015-03-20T19:21:45.577392",
+                "username": "nickwrack",
+                "data": {
+                  "facebook_page_url": "https://www.facebook.com/pages/Nick-Wrack-for-Camberwell-and-Peckham/1549007035359265",
+                  "name": "Nick Wrack",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://peckhamtusc.com/nick-wrack/",
+                  "gender": "male",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/6460/image/54f3a4614a2e02e0576a6c93",
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6460%2Fimage%2F54f3a4614a2e02e0576a6c93",
+                  "email": "peckhamtusc@gmail.com",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "https://www.linkedin.com/pub/nick-wrack/4b/337/a59",
+                  "twitter_username": "nickwrack",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Trade Unionist and Socialist Coalition",
+                      "id": "party:804"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "https://peckhamtusc.com/",
+                  "id": "6460"
+                },
+                "version_id": "0982054b322bfd9b"
+              },
+              {
+                "information_source": "http://leftunity.org/nick-wrack-a-socialist-candidate-in-camberwell-peckham/?utm_source=rss&utm_medium=rss&utm_campaign=nick-wrack-a-socialist-candidate-in-camberwell-peckham",
+                "timestamp": "2015-03-14T16:36:47.578510",
+                "username": "bwdeacon",
+                "data": {
+                  "facebook_page_url": "https://www.facebook.com/pages/Nick-Wrack-for-Camberwell-and-Peckham/1549007035359265",
+                  "name": "Nick Wrack",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://peckhamtusc.com/nick-wrack/",
+                  "gender": "male",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/6460/image/54f3a4614a2e02e0576a6c93",
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6460%2Fimage%2F54f3a4614a2e02e0576a6c93",
+                  "id": "6460",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "https://www.linkedin.com/pub/nick-wrack/4b/337/a59",
+                  "twitter_username": "nickwrack",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Left Unity",
+                      "id": "party:2045"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "email": "peckhamtusc@gmail.com"
+                },
+                "version_id": "1249ecd3b3474a62"
+              },
+              {
+                "username": "symroe",
+                "timestamp": "2015-03-01T08:35:04.259959",
+                "information_source": "Data found by following Facebook and Twitter links",
+                "data": {
+                  "facebook_page_url": "https://www.facebook.com/pages/Nick-Wrack-for-Camberwell-and-Peckham/1549007035359265",
+                  "name": "Nick Wrack",
+                  "party_ppc_page_url": "http://peckhamtusc.com/nick-wrack/",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [],
+                  "linkedin_url": "https://www.linkedin.com/pub/nick-wrack/4b/337/a59",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "nickwrack",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "email": "peckhamtusc@gmail.com",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Trade Unionist and Socialist Coalition",
+                      "id": "party:804"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "id": "6460"
+                },
+                "version_id": "5c0c152b92166665"
+              },
+              {
+                "username": "RichCBury1",
+                "timestamp": "2015-02-25T15:02:32.663773",
+                "information_source": "http://www.tusc.org.uk/txt/322.pdf",
+                "data": {
+                  "facebook_page_url": "",
+                  "gender": "",
+                  "name": "Nick Wrack",
+                  "party_ppc_page_url": "",
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "email": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Trade Unionist and Socialist Coalition",
+                      "id": "party:804"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "6460"
+                },
+                "version_id": "36ff3ec57662bd05"
+              }
+            ],
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "images": [
+              {
+                "birth_date": null,
+                "created": null,
+                "death_date": null,
+                "dissolution_date": null,
+                "end_date": null,
+                "founding_date": null,
+                "id": "54f3a4614a2e02e0576a6c93",
+                "local_path": "54/f3/54f3a4614a2e02e0576a6c93",
+                "local_path_base": "54/f3/54f3a4614a2e02e0576a6c93",
+                "mime_type": "image/jpeg",
+                "notes": "Approved from photo moderation queue",
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6460%2Fimage%2F54f3a4614a2e02e0576a6c93",
+                "public_domain": "False",
+                "start_date": null,
+                "uploaded_by_user": "nickwrack",
+                "url": "http://yournextmp.popit.mysociety.org/persons/6460/image/54f3a4614a2e02e0576a6c93",
+                "use_allowed_by_owner": "True",
+                "md5sum": "9ade831ee903a4ce353c13cefc8ab355"
+              },
+              {
+                "birth_date": null,
+                "created": null,
+                "death_date": null,
+                "dissolution_date": null,
+                "end_date": null,
+                "founding_date": null,
+                "id": "54f3a49a4a2e02e0576a6c94",
+                "local_path": "54/f3/54f3a49a4a2e02e0576a6c94",
+                "local_path_base": "54/f3/54f3a49a4a2e02e0576a6c94",
+                "mime_type": "image/jpeg",
+                "notes": "Approved from photo moderation queue",
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6460%2Fimage%2F54f3a49a4a2e02e0576a6c94",
+                "public_domain": "False",
+                "start_date": null,
+                "uploaded_by_user": "nickwrack",
+                "url": "http://yournextmp.popit.mysociety.org/persons/6460/image/54f3a49a4a2e02e0576a6c94",
+                "use_allowed_by_owner": "True",
+                "md5sum": "cc5bdf3481241b04ec97813bc06ef2b5"
+              },
+              {
+                "birth_date": null,
+                "created": null,
+                "death_date": null,
+                "dissolution_date": null,
+                "end_date": null,
+                "founding_date": null,
+                "id": "54f3a4bb4a2e02e0576a6c95",
+                "local_path": "54/f3/54f3a4bb4a2e02e0576a6c95",
+                "local_path_base": "54/f3/54f3a4bb4a2e02e0576a6c95",
+                "mime_type": "image/jpeg",
+                "notes": "Approved from photo moderation queue",
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6460%2Fimage%2F54f3a4bb4a2e02e0576a6c95",
+                "public_domain": "False",
+                "start_date": null,
+                "uploaded_by_user": "nickwrack",
+                "url": "http://yournextmp.popit.mysociety.org/persons/6460/image/54f3a4bb4a2e02e0576a6c95",
+                "use_allowed_by_owner": "True",
+                "md5sum": "8fa90a43a6cade6e920049496344d675"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "facebook page",
+                "url": "https://www.facebook.com/pages/Nick-Wrack-for-Camberwell-and-Peckham/1549007035359265",
+                "id": "5531f49584992d847ad2bf4e"
+              },
+              {
+                "note": "party PPC page",
+                "url": "http://peckhamtusc.com/nick-wrack/",
+                "id": "5531f49584992d847ad2bf4d"
+              },
+              {
+                "note": "linkedin",
+                "url": "https://www.linkedin.com/pub/nick-wrack/4b/337/a59",
+                "id": "5531f49584992d847ad2bf4c"
+              },
+              {
+                "note": "homepage",
+                "url": "https://peckhamtusc.com/",
+                "id": "5531f49584992d847ad2bf4b"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "nickwrack",
+                "id": "5531f49584992d847ad2bf4f"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5535149116edb65574eb3c25",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5535149116edb65574eb3c25",
+          "election": "2015",
+          "id": "5535149116edb65574eb3c25",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": "1982-04-12",
+            "email": "felicity@whigs.uk",
+            "gender": "Female",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/6211",
+            "id": "6211",
+            "name": "Felicity Anscomb",
+            "party_memberships": {
+              "2015": {
+                "name": "The Whig Party",
+                "id": "party:2380"
+              }
+            },
+            "standing_in": {
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/6211",
+            "versions": [
+              {
+                "information_source": "http://whigs.uk/camberwell-and-peckham/",
+                "timestamp": "2015-04-20T15:00:28.801796",
+                "username": "Whigs",
+                "data": {
+                  "facebook_page_url": "",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://whigs.uk/camberwell-and-peckham/",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/6211/image/5516ca0f929f1bbe286be034",
+                  "facebook_personal_url": "",
+                  "id": "6211",
+                  "other_names": [],
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6211%2Fimage%2F5516ca0f929f1bbe286be034",
+                  "honorific_prefix": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "The Whig Party",
+                      "id": "party:2380"
+                    }
+                  },
+                  "email": "felicity@whigs.uk",
+                  "twitter_username": "fe_diddy",
+                  "name": "Felicity Anscomb",
+                  "gender": "Female",
+                  "identifiers": [],
+                  "linkedin_url": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "birth_date": "1982-04-12"
+                },
+                "version_id": "5556ba59c7f98dd6"
+              },
+              {
+                "information_source": "Approved a photo upload from Whigs who provided the message: \"\"",
+                "timestamp": "2015-03-28T15:34:39.572448",
+                "username": "tfgg",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Felicity Anscomb",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://whigs.uk/",
+                  "gender": "Female",
+                  "image": null,
+                  "identifiers": [],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "id": "6211",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "",
+                  "twitter_username": "fe_diddy",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "id": "party:2380",
+                      "name": "The Whig Party"
+                    }
+                  },
+                  "birth_date": "1982-04-12",
+                  "email": "felicity@whigs.uk"
+                },
+                "version_id": "1f4b432b6a35928f"
+              },
+              {
+                "username": "symroe",
+                "timestamp": "2015-02-28T18:43:19.072908",
+                "information_source": "http://whigs.uk/ isn't her home page.  Party doesn't have a PPC page.  Should we remove completely?",
+                "data": {
+                  "facebook_page_url": "",
+                  "gender": "Female",
+                  "name": "Felicity Anscomb",
+                  "party_ppc_page_url": "http://whigs.uk/",
+                  "linkedin_url": "",
+                  "image": null,
+                  "identifiers": [],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "fe_diddy",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "email": "felicity@whigs.uk",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "The Whig Party",
+                      "id": "party:2380"
+                    }
+                  },
+                  "birth_date": "1982-04-12",
+                  "id": "6211"
+                },
+                "version_id": "21545bead954dfe5"
+              },
+              {
+                "username": "Whigs",
+                "timestamp": "2015-02-09T17:41:49.805155",
+                "information_source": "Twitter",
+                "data": {
+                  "facebook_page_url": "",
+                  "gender": "Female",
+                  "name": "Felicity Anscomb",
+                  "party_ppc_page_url": "",
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "email": "felicity@whigs.uk",
+                  "twitter_username": "fe_diddy",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://whigs.uk/",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "The Whig Party",
+                      "id": "party:2380"
+                    }
+                  },
+                  "birth_date": "1982-04-12",
+                  "id": "6211"
+                },
+                "version_id": "5a940401f711d793"
+              }
+            ],
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "image": "http://yournextmp.popit.mysociety.org/persons/6211/image/5516ca0f929f1bbe286be034",
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6211%2Fimage%2F5516ca0f929f1bbe286be034",
+            "images": [
+              {
+                "dissolution_date": null,
+                "founding_date": null,
+                "death_date": null,
+                "birth_date": null,
+                "end_date": null,
+                "start_date": null,
+                "id": "5516ca0f929f1bbe286be034",
+                "local_path_base": "55/16/5516ca0f929f1bbe286be034",
+                "local_path": "55/16/5516ca0f929f1bbe286be034",
+                "created": null,
+                "user_why_allowed": "profile-photo",
+                "notes": "Approved from photo moderation queue",
+                "md5sum": "336c6929755b49d4c54ee0be14e6ed00",
+                "moderator_why_allowed": "profile-photo",
+                "uploaded_by_user": "Whigs",
+                "mime_type": "image/png",
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F6211%2Fimage%2F5516ca0f929f1bbe286be034",
+                "url": "http://yournextmp.popit.mysociety.org/persons/6211/image/5516ca0f929f1bbe286be034"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "party PPC page",
+                "url": "http://whigs.uk/camberwell-and-peckham/",
+                "id": "5535148e16edb65574eb3c1d"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "fe_diddy",
+                "id": "5535148e16edb65574eb3c1e"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/553ba0e5340ab5e47615e716",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/553ba0e5340ab5e47615e716",
+          "election": "2015",
+          "id": "553ba0e5340ab5e47615e716",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fcandidates.127.0.0.1.xip.io%3A3000%2Fpersons%2F5259%2Fimage%2F553ba0e410284be476aae88d",
+            "image": "http://candidates.127.0.0.1.xip.io:3000/persons/5259/image/553ba0e410284be476aae88d",
+            "birth_date": null,
+            "email": "yahayakiyingi@gmail.com",
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/5259",
+            "id": "5259",
+            "name": "Yahaya Kiyingi",
+            "party_memberships": {
+              "2015": {
+                "id": "party:90",
+                "name": "Liberal Democrats"
+              }
+            },
+            "standing_in": {
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/5259",
+            "versions": [
+              {
+                "information_source": "Approved a photo upload from edent who provided the message: \"This is the candidate’s twitter profile image, from https://twitter.com/yahayakiyingi\"",
+                "timestamp": "2015-04-25T14:12:52.576020",
+                "username": "edent",
+                "data": {
+                  "facebook_page_url": "",
+                  "identifiers": [],
+                  "proxy_image": null,
+                  "name": "Yahaya Kiyingi",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://www.libdems.org.uk/yahaya_kiyingi",
+                  "gender": "male",
+                  "image": null,
+                  "linkedin_url": "",
+                  "homepage_url": "",
+                  "id": "5259",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "twitter_username": "yahayakiyingi",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "id": "party:90",
+                      "name": "Liberal Democrats"
+                    }
+                  },
+                  "birth_date": null,
+                  "other_names": [],
+                  "email": "yahayakiyingi@gmail.com"
+                },
+                "version_id": "022cdc621b277b12"
+              },
+              {
+                "information_source": "Updated candidate from official PPC data (libdem)",
+                "timestamp": "2015-01-31T18:16:48.407386",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Yahaya Kiyingi",
+                  "party_ppc_page_url": "http://www.libdems.org.uk/yahaya_kiyingi",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "yahayakiyingi",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "id": "5259",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Liberal Democrats",
+                      "id": "party:90"
+                    }
+                  },
+                  "birth_date": null,
+                  "email": "yahayakiyingi@gmail.com"
+                },
+                "version_id": "79519df01c7722ce"
+              },
+              {
+                "username": "MartinEden",
+                "timestamp": "2015-01-22T11:13:37.708147",
+                "information_source": "Email from Humaira Khanom (Member and Supporter Services for Liberal Democrats)",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Yahaya Kiyingi",
+                  "party_ppc_page_url": "http://www.libdems.org.uk/yahaya_kiyingi",
+                  "gender": "male",
+                  "image": null,
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "yahayakiyingi",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "id": "5259",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Liberal Democrats",
+                      "id": "party:90"
+                    }
+                  },
+                  "birth_date": null,
+                  "email": "yahayakiyingi@gmail.com"
+                },
+                "version_id": "31ceb2044f2355a5"
+              },
+              {
+                "username": "h2g2bob",
+                "timestamp": "2015-01-20T00:54:34.433069",
+                "information_source": "http://www.libdems.org.uk/yahaya_kiyingi",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Yahaya Kiyingi",
+                  "party_ppc_page_url": "http://www.libdems.org.uk/yahaya_kiyingi",
+                  "gender": "male",
+                  "image": null,
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "yahayakiyingi",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "id": "5259",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Liberal Democrats",
+                      "id": "party:90"
+                    }
+                  },
+                  "birth_date": null,
+                  "email": ""
+                },
+                "version_id": "4ce0bd8306144cc6"
+              },
+              {
+                "username": "will883",
+                "timestamp": "2015-01-07T12:33:10.032533",
+                "information_source": "http://www.markpack.org.uk/107121/yahaya-kiyingi-selected-camberwell-peckham/",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Yahaya Kiyingi",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "facebook_personal_url": "",
+                  "id": "5259",
+                  "twitter_username": "yahayakiyingi",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Liberal Democrats",
+                      "id": "party:90"
+                    }
+                  },
+                  "birth_date": null,
+                  "email": ""
+                },
+                "version_id": "716390a6088bfed7"
+              },
+              {
+                "username": "adambro",
+                "timestamp": "2014-12-23T17:04:33.880442",
+                "information_source": "http://www.markpack.org.uk/107121/yahaya-kiyingi-selected-camberwell-peckham/",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Yahaya Kiyingi",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "facebook_personal_url": "",
+                  "id": "5259",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Liberal Democrats",
+                      "id": "party:90"
+                    }
+                  },
+                  "birth_date": null,
+                  "email": ""
+                },
+                "version_id": "0e1f2133be0bcb18"
+              }
+            ],
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "images": [
+              {
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fcandidates.127.0.0.1.xip.io%3A3000%2Fpersons%2F5259%2Fimage%2F553ba0e410284be476aae88d",
+                "url": "http://candidates.127.0.0.1.xip.io:3000/persons/5259/image/553ba0e410284be476aae88d",
+                "mime_type": "image/png",
+                "notes": "Approved from photo moderation queue",
+                "user_justification_for_use": "This is the candidate’s twitter profile image, from https://twitter.com/yahayakiyingi",
+                "md5sum": "e5047d020c1585da6994efa71b914bdc",
+                "moderator_why_allowed": "profile-photo",
+                "user_why_allowed": "profile-photo",
+                "index": "first",
+                "uploaded_by_user": "edent",
+                "created": "",
+                "local_path": "55/3b/553ba0e410284be476aae88d",
+                "local_path_base": "55/3b/553ba0e410284be476aae88d",
+                "start_date": null,
+                "end_date": null,
+                "birth_date": null,
+                "death_date": null,
+                "founding_date": null,
+                "dissolution_date": null,
+                "id": "553ba0e410284be476aae88d"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "party PPC page",
+                "url": "http://www.libdems.org.uk/yahaya_kiyingi",
+                "id": "553ba0e5340ab5e47615e713"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "yahayakiyingi",
+                "id": "553ba0e5340ab5e47615e714"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5547b35a02920e3221912452",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5547b35a02920e3221912452",
+          "election": "2015",
+          "id": "5547b35a02920e3221912452",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/1088",
+            "id": "1088",
+            "name": "Joshua Ogunleye",
+            "party_memberships": {
+              "2010": {
+                "id": "party:184",
+                "name": "Workers Revolutionary Party"
+              },
+              "2015": {
+                "name": "Workers Revolutionary Party",
+                "id": "party:184"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              },
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/1088",
+            "versions": [
+              {
+                "information_source": "Approved a photo upload from andylolz who provided the message: \"From candidate’s election leaflet: https://electionleaflets.org/leaflets/11520/\"",
+                "timestamp": "2015-05-04T17:58:49.367121",
+                "username": "tfgg",
+                "data": {
+                  "facebook_page_url": "",
+                  "facebook_personal_url": "",
+                  "name": "Joshua Ogunleye",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/1088/image/5547b359c96b7d3221f3519e",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "55433331da460c2e5082876b",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "linkedin_url": "",
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F1088%2Fimage%2F5547b359c96b7d3221f3519e",
+                  "id": "1088",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    },
+                    "2015": {
+                      "name": "Workers Revolutionary Party",
+                      "id": "party:184"
+                    }
+                  },
+                  "birth_date": null,
+                  "email": "votejoshuaogunleye@outlook.com"
+                },
+                "version_id": "36a51aa5026a9afd"
+              },
+              {
+                "information_source": "https://electionleaflets.org/leaflets/full/75923/",
+                "timestamp": "2015-05-01T08:02:57.138416",
+                "username": "Edward",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Joshua Ogunleye",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "552f8547ed1c6ee164eecb16",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "id": "1088",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "facebook_personal_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    },
+                    "2015": {
+                      "name": "Workers Revolutionary Party",
+                      "id": "party:184"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "email": "votejoshuaogunleye@outlook.com"
+                },
+                "version_id": "1dfe46352b9fe79f"
+              },
+              {
+                "information_source": "spelling, see http://www.southwark.gov.uk/info/1000/5_previous_election_results/1617/general_election_2010 and http://www.wrp.org.uk/images/photos/15-04-07-10813.jpg",
+                "timestamp": "2015-04-07T19:17:28.335766",
+                "username": "sjorford",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Joshua Ogunleye",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5523cbab0e8c99ac614664b8",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "id": "1088",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    },
+                    "2015": {
+                      "name": "Workers Revolutionary Party",
+                      "id": "party:184"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "email": ""
+                },
+                "version_id": "45f1bfedb5852959"
+              },
+              {
+                "information_source": "Confirmed as restanding by official WRP website: http://www.wrp.org.uk/images/photos/15-04-07-10813.jpg",
+                "timestamp": "2015-04-07T11:54:46.559308",
+                "username": "greensocialistalan",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Joshuwa Ogunleye",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5523b8060e8c99ac6145fc60",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "",
+                  "email": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    },
+                    "2015": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "1088"
+                },
+                "version_id": "76fe4be91d9a0a2f"
+              },
+              {
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:12:27.396738",
+                "data": {
+                  "facebook_page_url": null,
+                  "slug": "joshuwa-ogunleye",
+                  "name": "Joshuwa Ogunleye",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "party_ppc_page_url": null,
+                  "gender": "male",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "facebook_personal_url": null,
+                  "email": null,
+                  "twitter_username": null,
+                  "phone": null,
+                  "homepage_url": null,
+                  "wikipedia_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Workers Revolutionary Party",
+                      "id": "party:184"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "1088"
+                },
+                "version_id": "1b57aed84f9dfb4d"
+              }
+            ],
+            "email": "votejoshuaogunleye@outlook.com",
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "image": "http://yournextmp.popit.mysociety.org/persons/1088/image/5547b359c96b7d3221f3519e",
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F1088%2Fimage%2F5547b359c96b7d3221f3519e",
+            "images": [
+              {
+                "mime_type": "image/png",
+                "notes": "Approved from photo moderation queue",
+                "user_justification_for_use": "From candidate’s election leaflet: https://electionleaflets.org/leaflets/11520/",
+                "md5sum": "7c4f553ff7f931eba763f5a85c9ab2e5",
+                "moderator_why_allowed": "other",
+                "user_why_allowed": "other",
+                "index": "first",
+                "uploaded_by_user": "andylolz",
+                "created": null,
+                "local_path": "55/47/5547b359c96b7d3221f3519e",
+                "local_path_base": "55/47/5547b359c96b7d3221f3519e",
+                "start_date": null,
+                "end_date": null,
+                "birth_date": null,
+                "death_date": null,
+                "founding_date": null,
+                "dissolution_date": null,
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F1088%2Fimage%2F5547b359c96b7d3221f3519e",
+                "url": "http://yournextmp.popit.mysociety.org/persons/1088/image/5547b359c96b7d3221f3519e",
+                "id": "5547b359c96b7d3221f3519e"
+              }
+            ],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "24620",
+                "id": "5547b35a02920e322191244f"
+              }
+            ],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/55488bbcc922fa4814d261d3",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/55488bbcc922fa4814d261d3",
+          "election": "2015",
+          "id": "55488bbcc922fa4814d261d3",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "name": "Alex Robertson",
+            "honorific_suffix": "",
+            "gender": "male",
+            "versions": [
+              {
+                "information_source": "Add twitter handle",
+                "timestamp": "2015-05-05T09:22:03.704838",
+                "username": "andylolz",
+                "data": {
+                  "facebook_page_url": "",
+                  "facebook_personal_url": "",
+                  "name": "Alex Robertson",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://cista.org/candidates/25",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [],
+                  "linkedin_url": "",
+                  "proxy_image": null,
+                  "id": "7206",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "twitter_username": "CistaAlex",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Cannabis is Safer than Alcohol",
+                      "id": "party:2552"
+                    }
+                  },
+                  "birth_date": null,
+                  "email": "info@cista.org"
+                },
+                "version_id": "7ed827a894699166"
+              },
+              {
+                "information_source": "http://cista.org/candidates/25",
+                "timestamp": "2015-04-21T10:29:29.971079",
+                "username": "tfgg",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Alex Robertson",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://cista.org/candidates/25",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "email": "info@cista.org",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Cannabis is Safer than Alcohol",
+                      "id": "party:2552"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "id": "7206"
+                },
+                "version_id": "06c4e9bcb495b6e8"
+              },
+              {
+                "information_source": "Not specific to the candidate.",
+                "timestamp": "2015-04-09T10:16:33.443634",
+                "username": "tfgg",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Alex Robertson",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "email": "info@cista.org",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Cannabis is Safer than Alcohol",
+                      "id": "party:2552"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "id": "7206"
+                },
+                "version_id": "6c85aa9ec94d3d81"
+              },
+              {
+                "information_source": "http://cista.org",
+                "timestamp": "2015-04-08T17:48:30.586101",
+                "username": "bruce",
+                "data": {
+                  "facebook_page_url": "https://www.facebook.com/CISTA2015",
+                  "name": "Alex Robertson",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://cista.org/",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "email": "info@cista.org",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Cannabis is Safer than Alcohol",
+                      "id": "party:2552"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "id": "7206"
+                },
+                "version_id": "6645f5e6080f1f72"
+              },
+              {
+                "information_source": "http://cista.org",
+                "timestamp": "2015-04-08T17:47:41.088359",
+                "username": "bruce",
+                "data": {
+                  "facebook_page_url": "https://www.facebook.com/CISTA2015",
+                  "name": "Alex Robertson",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "http://cista.org/",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "email": "info@cista.org",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Cannabis is Safer than Alcohol",
+                      "id": "party:2552"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "id": "7206"
+                },
+                "version_id": "5a9f731747362374"
+              },
+              {
+                "information_source": "https://www.facebook.com/CISTA2015/photos/a.1587880768096741.1073741828.1585302585021226/1610323769185774/?type=1&permPage=1",
+                "timestamp": "2015-04-08T15:43:09.782649",
+                "username": "sjorford",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Alex Robertson",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "facebook_personal_url": "",
+                  "email": "",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2015": {
+                      "name": "Cannabis is Safer than Alcohol",
+                      "id": "party:2552"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "7206"
+                },
+                "version_id": "736fc6ceef1fe3f9"
+              }
+            ],
+            "id": "7206",
+            "honorific_prefix": "",
+            "standing_in": {
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "party_memberships": {
+              "2015": {
+                "name": "Cannabis is Safer than Alcohol",
+                "id": "party:2552"
+              }
+            },
+            "birth_date": null,
+            "email": "info@cista.org",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/7206",
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/7206",
+            "images": [],
+            "memberships": [],
+            "links": [
+              {
+                "note": "party PPC page",
+                "url": "http://cista.org/candidates/25",
+                "id": "55488bbcc922fa4814d261d0"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "CistaAlex",
+                "id": "55488bbcc922fa4814d261d1"
+              }
+            ],
+            "identifiers": [],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5550fef588ca18301c896219",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5550fef588ca18301c896219",
+          "election": "2015",
+          "id": "5550fef588ca18301c896219",
+          "end_date": "9999-12-31",
+          "start_date": "2010-05-07",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": "1950-07-30",
+            "email": "harrietharman2015@gmail.com",
+            "gender": "female",
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/3885",
+            "id": "3885",
+            "name": "Harriet Harman",
+            "party_memberships": {
+              "2010": {
+                "id": "party:53",
+                "name": "Labour Party"
+              },
+              "2015": {
+                "id": "party:53",
+                "name": "Labour Party"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              },
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/3885",
+            "versions": [
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:11:45.850680",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "facebook_personal_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fe2c88ca18301c89620c",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fe2c88ca18301c89620b",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "linkedin_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    },
+                    "2015": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "47605f0b672db41e"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:08:28.458718",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fd0688ca18301c896201",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fd0688ca18301c896200",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "58c1ca4994436a08"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:03:34.311788",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fcf188ca18301c8961f6",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fcf188ca18301c8961f5",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "1197d38cd54a8c66"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:03:13.377297",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fccf88ca18301c8961eb",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fccf88ca18301c8961ea",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "23370091d6dd9045"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:02:39.057426",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fcb488ca18301c8961e0",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fcb488ca18301c8961df",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "4079ad29a745eab2"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:02:12.032593",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fc3d88ca18301c8961d5",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fc3d88ca18301c8961d4",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "00c5565e72481002"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:00:13.076851",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "552f8723ed1c6ee164eedbf6",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "552f8723ed1c6ee164eedbf5",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "074433765c698407"
+              },
+              {
+                "information_source": "Approved a photo upload from louisecrow who provided the message: \"Photo from twitter profile https://twitter.com/harrietharman\"",
+                "timestamp": "2015-04-14T10:56:21.538700",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": null,
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "552bb4ac14bf03a83a346826",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "552bb4ac14bf03a83a346825",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": null,
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    },
+                    "2015": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "260fee696c13520b"
+              },
+              {
+                "information_source": "Called her office",
+                "timestamp": "2015-03-31T12:35:30.859897",
+                "username": "AlexLusted",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "54ff12af4e57ce9a0468fb60",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "54ff12af4e57ce9a0468fb5f",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "id": "3885",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "harrietharman",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    },
+                    "2015": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "767d50ca904d645d"
+              },
+              {
+                "username": "jackgovier",
+                "timestamp": "2015-03-10T15:50:07.372128",
+                "information_source": "Previous email address broken",
+                "data": {
+                  "honorific_prefix": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "54c67110c71694775bfd3558",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "54c67110c71694775bfd3557",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "harrietharman",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "email": "harmanh@parliament.uk",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    },
+                    "2015": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "facebook_page_url": "",
+                  "id": "3885"
+                },
+                "version_id": "13f40f41f52b1af0"
+              },
+              {
+                "information_source": "Updated candidate with parlparse person id",
+                "timestamp": "2015-01-26T16:53:36.533903",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5477881c737edc5252ce61d5",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "email": "harrietharman@london.com",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    },
+                    "2015": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "id": "3885"
+                },
+                "version_id": "0b220e32a5639ac0"
+              },
+              {
+                "username": "symroe",
+                "timestamp": "2014-11-25T23:16:29.098382",
+                "information_source": "Told me in a twitter DM, also is senior member of the party.",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "",
+                  "email": "harrietharman@london.com",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    },
+                    "2015": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "id": "3885"
+                },
+                "version_id": "2ca0a0d967113e18"
+              },
+              {
+                "username": "symroe",
+                "timestamp": "2014-11-24T19:55:49.380313",
+                "information_source": "Information from her web site",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "",
+                  "email": "harrietharman@london.com",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "id": "3885"
+                },
+                "version_id": "6854da4e4f511ff0"
+              },
+              {
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:27:04.991565",
+                "data": {
+                  "facebook_page_url": null,
+                  "name": "Harriet Harman",
+                  "phone": null,
+                  "party_ppc_page_url": null,
+                  "gender": "female",
+                  "id": "3885",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "2719"
+                    }
+                  ],
+                  "facebook_personal_url": null,
+                  "email": "harrietharman@london.com",
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": null,
+                  "wikipedia_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": null,
+                  "slug": "harriet-harman"
+                },
+                "version_id": "7638fe6f77cae9a1"
+              }
+            ],
+            "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+            "images": [
+              {
+                "mime_type": "image/png",
+                "uploaded_by_user": "louisecrow",
+                "user_justification_for_use": "Photo from twitter profile https://twitter.com/harrietharman",
+                "moderator_why_allowed": "profile-photo",
+                "md5sum": "5b04dca5e8347b71f565e23f0a2bb1a6",
+                "notes": "Approved from photo moderation queue",
+                "user_why_allowed": "profile-photo",
+                "index": "first",
+                "created": null,
+                "local_path": "55/2c/552cf2553d3371cf3592d9d6",
+                "local_path_base": "55/2c/552cf2553d3371cf3592d9d6",
+                "start_date": null,
+                "end_date": null,
+                "birth_date": null,
+                "death_date": null,
+                "founding_date": null,
+                "dissolution_date": null,
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                "url": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                "id": "552cf2553d3371cf3592d9d6"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "homepage",
+                "url": "http://www.harrietharman.org/",
+                "id": "5550fef588ca18301c896217"
+              },
+              {
+                "note": "wikipedia",
+                "url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                "id": "5550fef588ca18301c896216"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "harrietharman",
+                "id": "5550fef588ca18301c896218"
+              }
+            ],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "2719",
+                "id": "5550fef588ca18301c896215"
+              },
+              {
+                "scheme": "uk.org.publicwhip",
+                "identifier": "uk.org.publicwhip/person/10260",
+                "id": "5550fef588ca18301c896214"
+              }
+            ],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5547b35a02920e3221912453",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5547b35a02920e3221912453",
+          "election": "2010",
+          "id": "5547b35a02920e3221912453",
+          "end_date": "2010-05-06",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": null,
+            "gender": "male",
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/1088",
+            "id": "1088",
+            "name": "Joshua Ogunleye",
+            "party_memberships": {
+              "2010": {
+                "id": "party:184",
+                "name": "Workers Revolutionary Party"
+              },
+              "2015": {
+                "name": "Workers Revolutionary Party",
+                "id": "party:184"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              },
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/1088",
+            "versions": [
+              {
+                "information_source": "Approved a photo upload from andylolz who provided the message: \"From candidate’s election leaflet: https://electionleaflets.org/leaflets/11520/\"",
+                "timestamp": "2015-05-04T17:58:49.367121",
+                "username": "tfgg",
+                "data": {
+                  "facebook_page_url": "",
+                  "facebook_personal_url": "",
+                  "name": "Joshua Ogunleye",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/1088/image/5547b359c96b7d3221f3519e",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "55433331da460c2e5082876b",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "linkedin_url": "",
+                  "proxy_image": "http://yournextmp.popit.mysociety.org/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F1088%2Fimage%2F5547b359c96b7d3221f3519e",
+                  "id": "1088",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    },
+                    "2015": {
+                      "name": "Workers Revolutionary Party",
+                      "id": "party:184"
+                    }
+                  },
+                  "birth_date": null,
+                  "email": "votejoshuaogunleye@outlook.com"
+                },
+                "version_id": "36a51aa5026a9afd"
+              },
+              {
+                "information_source": "https://electionleaflets.org/leaflets/full/75923/",
+                "timestamp": "2015-05-01T08:02:57.138416",
+                "username": "Edward",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Joshua Ogunleye",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "552f8547ed1c6ee164eecb16",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "id": "1088",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "facebook_personal_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    },
+                    "2015": {
+                      "name": "Workers Revolutionary Party",
+                      "id": "party:184"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "email": "votejoshuaogunleye@outlook.com"
+                },
+                "version_id": "1dfe46352b9fe79f"
+              },
+              {
+                "information_source": "spelling, see http://www.southwark.gov.uk/info/1000/5_previous_election_results/1617/general_election_2010 and http://www.wrp.org.uk/images/photos/15-04-07-10813.jpg",
+                "timestamp": "2015-04-07T19:17:28.335766",
+                "username": "sjorford",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Joshua Ogunleye",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5523cbab0e8c99ac614664b8",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "id": "1088",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "",
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    },
+                    "2015": {
+                      "name": "Workers Revolutionary Party",
+                      "id": "party:184"
+                    }
+                  },
+                  "birth_date": null,
+                  "homepage_url": "",
+                  "email": ""
+                },
+                "version_id": "45f1bfedb5852959"
+              },
+              {
+                "information_source": "Confirmed as restanding by official WRP website: http://www.wrp.org.uk/images/photos/15-04-07-10813.jpg",
+                "timestamp": "2015-04-07T11:54:46.559308",
+                "username": "greensocialistalan",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Joshuwa Ogunleye",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "male",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5523b8060e8c99ac6145fc60",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "",
+                  "email": "",
+                  "twitter_username": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "wikipedia_url": "",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    },
+                    "2015": {
+                      "id": "party:184",
+                      "name": "Workers Revolutionary Party"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "1088"
+                },
+                "version_id": "76fe4be91d9a0a2f"
+              },
+              {
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:12:27.396738",
+                "data": {
+                  "facebook_page_url": null,
+                  "slug": "joshuwa-ogunleye",
+                  "name": "Joshuwa Ogunleye",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "party_ppc_page_url": null,
+                  "gender": "male",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "24620"
+                    }
+                  ],
+                  "facebook_personal_url": null,
+                  "email": null,
+                  "twitter_username": null,
+                  "phone": null,
+                  "homepage_url": null,
+                  "wikipedia_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Workers Revolutionary Party",
+                      "id": "party:184"
+                    }
+                  },
+                  "birth_date": null,
+                  "id": "1088"
+                },
+                "version_id": "1b57aed84f9dfb4d"
+              }
+            ],
+            "email": "votejoshuaogunleye@outlook.com",
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "image": "http://yournextmp.popit.mysociety.org/persons/1088/image/5547b359c96b7d3221f3519e",
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F1088%2Fimage%2F5547b359c96b7d3221f3519e",
+            "images": [
+              {
+                "mime_type": "image/png",
+                "notes": "Approved from photo moderation queue",
+                "user_justification_for_use": "From candidate’s election leaflet: https://electionleaflets.org/leaflets/11520/",
+                "md5sum": "7c4f553ff7f931eba763f5a85c9ab2e5",
+                "moderator_why_allowed": "other",
+                "user_why_allowed": "other",
+                "index": "first",
+                "uploaded_by_user": "andylolz",
+                "created": null,
+                "local_path": "55/47/5547b359c96b7d3221f3519e",
+                "local_path_base": "55/47/5547b359c96b7d3221f3519e",
+                "start_date": null,
+                "end_date": null,
+                "birth_date": null,
+                "death_date": null,
+                "founding_date": null,
+                "dissolution_date": null,
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F1088%2Fimage%2F5547b359c96b7d3221f3519e",
+                "url": "http://yournextmp.popit.mysociety.org/persons/1088/image/5547b359c96b7d3221f3519e",
+                "id": "5547b359c96b7d3221f3519e"
+              }
+            ],
+            "memberships": [],
+            "links": [],
+            "contact_details": [],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "24620",
+                "id": "5547b35a02920e322191244f"
+              }
+            ],
+            "other_names": []
+          }
+        },
+        {
+          "contact_details": [],
+          "links": [],
+          "images": [],
+          "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/memberships/5550fef588ca18301c89621a",
+          "html_url": "http://candidates.127.0.0.1.xip.io:3000/memberships/5550fef588ca18301c89621a",
+          "election": "2010",
+          "id": "5550fef588ca18301c89621a",
+          "end_date": "2010-05-06",
+          "start_date": "2005-05-06",
+          "role": "Candidate",
+          "post_id": "65913",
+          "person_id": {
+            "birth_date": "1950-07-30",
+            "email": "harrietharman2015@gmail.com",
+            "gender": "female",
+            "honorific_prefix": null,
+            "honorific_suffix": null,
+            "html_url": "http://candidates.127.0.0.1.xip.io:3000/persons/3885",
+            "id": "3885",
+            "name": "Harriet Harman",
+            "party_memberships": {
+              "2010": {
+                "id": "party:53",
+                "name": "Labour Party"
+              },
+              "2015": {
+                "id": "party:53",
+                "name": "Labour Party"
+              }
+            },
+            "standing_in": {
+              "2010": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              },
+              "2015": {
+                "post_id": "65913",
+                "name": "Camberwell and Peckham",
+                "mapit_url": "http://mapit.mysociety.org/area/65913"
+              }
+            },
+            "url": "http://candidates.127.0.0.1.xip.io:3000/api/v0.1/persons/3885",
+            "versions": [
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:11:45.850680",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "facebook_personal_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fe2c88ca18301c89620c",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fe2c88ca18301c89620b",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "linkedin_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    },
+                    "2015": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "47605f0b672db41e"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:08:28.458718",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fd0688ca18301c896201",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fd0688ca18301c896200",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "58c1ca4994436a08"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:03:34.311788",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fcf188ca18301c8961f6",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fcf188ca18301c8961f5",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "1197d38cd54a8c66"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:03:13.377297",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fccf88ca18301c8961eb",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fccf88ca18301c8961ea",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "23370091d6dd9045"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:02:39.057426",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fcb488ca18301c8961e0",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fcb488ca18301c8961df",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "4079ad29a745eab2"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:02:12.032593",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5550fc3d88ca18301c8961d5",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "5550fc3d88ca18301c8961d4",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "00c5565e72481002"
+              },
+              {
+                "information_source": "Just testing",
+                "timestamp": "2015-05-11T19:00:13.076851",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "552f8723ed1c6ee164eedbf6",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "552f8723ed1c6ee164eedbf5",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": "",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "074433765c698407"
+              },
+              {
+                "information_source": "Approved a photo upload from louisecrow who provided the message: \"Photo from twitter profile https://twitter.com/harrietharman\"",
+                "timestamp": "2015-04-14T10:56:21.538700",
+                "username": "mark",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": null,
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "552bb4ac14bf03a83a346826",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "552bb4ac14bf03a83a346825",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "id": "3885",
+                  "other_names": [],
+                  "honorific_prefix": null,
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    },
+                    "2015": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "260fee696c13520b"
+              },
+              {
+                "information_source": "Called her office",
+                "timestamp": "2015-03-31T12:35:30.859897",
+                "username": "AlexLusted",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "54ff12af4e57ce9a0468fb60",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "54ff12af4e57ce9a0468fb5f",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "other_names": [],
+                  "proxy_image": null,
+                  "id": "3885",
+                  "honorific_prefix": "",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "facebook_personal_url": "",
+                  "linkedin_url": "",
+                  "twitter_username": "harrietharman",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "id": "party:53",
+                      "name": "Labour Party"
+                    },
+                    "2015": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "email": "harrietharman2015@gmail.com"
+                },
+                "version_id": "767d50ca904d645d"
+              },
+              {
+                "username": "jackgovier",
+                "timestamp": "2015-03-10T15:50:07.372128",
+                "information_source": "Previous email address broken",
+                "data": {
+                  "honorific_prefix": "",
+                  "name": "Harriet Harman",
+                  "honorific_suffix": "",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "54c67110c71694775bfd3558",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "id": "54c67110c71694775bfd3557",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "harrietharman",
+                  "linkedin_url": "",
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "email": "harmanh@parliament.uk",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    },
+                    "2015": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "facebook_page_url": "",
+                  "id": "3885"
+                },
+                "version_id": "13f40f41f52b1af0"
+              },
+              {
+                "information_source": "Updated candidate with parlparse person id",
+                "timestamp": "2015-01-26T16:53:36.533903",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "image": null,
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "id": "5477881c737edc5252ce61d5",
+                      "identifier": "2719"
+                    },
+                    {
+                      "scheme": "uk.org.publicwhip",
+                      "identifier": "uk.org.publicwhip/person/10260"
+                    }
+                  ],
+                  "facebook_personal_url": "",
+                  "proxy_image": null,
+                  "other_names": [],
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "email": "harrietharman@london.com",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    },
+                    "2015": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "id": "3885"
+                },
+                "version_id": "0b220e32a5639ac0"
+              },
+              {
+                "username": "symroe",
+                "timestamp": "2014-11-25T23:16:29.098382",
+                "information_source": "Told me in a twitter DM, also is senior member of the party.",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "",
+                  "email": "harrietharman@london.com",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    },
+                    "2015": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "id": "3885"
+                },
+                "version_id": "2ca0a0d967113e18"
+              },
+              {
+                "username": "symroe",
+                "timestamp": "2014-11-24T19:55:49.380313",
+                "information_source": "Information from her web site",
+                "data": {
+                  "facebook_page_url": "",
+                  "name": "Harriet Harman",
+                  "party_ppc_page_url": "",
+                  "gender": "female",
+                  "facebook_personal_url": "",
+                  "email": "harrietharman@london.com",
+                  "twitter_username": "harrietharman",
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    },
+                    "2015": null
+                  },
+                  "homepage_url": "http://www.harrietharman.org/",
+                  "wikipedia_url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": "1950-07-30",
+                  "id": "3885"
+                },
+                "version_id": "6854da4e4f511ff0"
+              },
+              {
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:27:04.991565",
+                "data": {
+                  "facebook_page_url": null,
+                  "name": "Harriet Harman",
+                  "phone": null,
+                  "party_ppc_page_url": null,
+                  "gender": "female",
+                  "id": "3885",
+                  "identifiers": [
+                    {
+                      "scheme": "yournextmp-candidate",
+                      "identifier": "2719"
+                    }
+                  ],
+                  "facebook_personal_url": null,
+                  "email": "harrietharman@london.com",
+                  "twitter_username": null,
+                  "standing_in": {
+                    "2010": {
+                      "post_id": "65913",
+                      "name": "Camberwell and Peckham",
+                      "mapit_url": "http://mapit.mysociety.org/area/65913"
+                    }
+                  },
+                  "homepage_url": null,
+                  "wikipedia_url": null,
+                  "party_memberships": {
+                    "2010": {
+                      "name": "Labour Party",
+                      "id": "party:53"
+                    }
+                  },
+                  "birth_date": null,
+                  "slug": "harriet-harman"
+                },
+                "version_id": "7638fe6f77cae9a1"
+              }
+            ],
+            "image": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+            "proxy_image": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+            "images": [
+              {
+                "mime_type": "image/png",
+                "uploaded_by_user": "louisecrow",
+                "user_justification_for_use": "Photo from twitter profile https://twitter.com/harrietharman",
+                "moderator_why_allowed": "profile-photo",
+                "md5sum": "5b04dca5e8347b71f565e23f0a2bb1a6",
+                "notes": "Approved from photo moderation queue",
+                "user_why_allowed": "profile-photo",
+                "index": "first",
+                "created": null,
+                "local_path": "55/2c/552cf2553d3371cf3592d9d6",
+                "local_path_base": "55/2c/552cf2553d3371cf3592d9d6",
+                "start_date": null,
+                "end_date": null,
+                "birth_date": null,
+                "death_date": null,
+                "founding_date": null,
+                "dissolution_date": null,
+                "proxy_url": "http://candidates.127.0.0.1.xip.io:3000/image-proxy/http%3A%2F%2Fyournextmp.popit.mysociety.org%2Fpersons%2F3885%2Fimage%2F552cf2553d3371cf3592d9d6",
+                "url": "http://yournextmp.popit.mysociety.org/persons/3885/image/552cf2553d3371cf3592d9d6",
+                "id": "552cf2553d3371cf3592d9d6"
+              }
+            ],
+            "memberships": [],
+            "links": [
+              {
+                "note": "homepage",
+                "url": "http://www.harrietharman.org/",
+                "id": "5550fef588ca18301c896217"
+              },
+              {
+                "note": "wikipedia",
+                "url": "http://en.wikipedia.org/wiki/Harriet_Harman",
+                "id": "5550fef588ca18301c896216"
+              }
+            ],
+            "contact_details": [
+              {
+                "type": "twitter",
+                "value": "harrietharman",
+                "id": "5550fef588ca18301c896218"
+              }
+            ],
+            "identifiers": [
+              {
+                "scheme": "yournextmp-candidate",
+                "identifier": "2719",
+                "id": "5550fef588ca18301c896215"
+              },
+              {
+                "scheme": "uk.org.publicwhip",
+                "identifier": "uk.org.publicwhip/person/10260",
+                "id": "5550fef588ca18301c896214"
+              }
+            ],
+            "other_names": []
+          }
+        }
+      ],
+      "links": [],
+      "contact_details": []
     }
   ],
-  "total": 1
+  "total": 2
 }

--- a/candidates/tests/test_constituency_lock.py
+++ b/candidates/tests/test_constituency_lock.py
@@ -4,14 +4,16 @@ from django_webtest import WebTest
 
 from .auth import TestUserMixin
 from candidates.tests.fake_popit import (
-    FakePostCollection, FakePersonCollection
+    FakePostCollection, FakePersonCollection, fake_mp_post_search_results
 )
 
 @patch('candidates.popit.PopIt')
+@patch('candidates.popit.requests')
 class TestConstituencyLockAndUnlock(TestUserMixin, WebTest):
 
-    def test_constituency_lock_unauthorized(self, mock_popit):
+    def test_constituency_lock_unauthorized(self, mock_requests, mock_popit):
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         self.app.get(
             '/election/2015/post/65808/dulwich-and-west-norwood',
             user=self.user,
@@ -30,8 +32,9 @@ class TestConstituencyLockAndUnlock(TestUserMixin, WebTest):
         self.assertEqual(response.status_code, 403)
 
     @patch.object(FakePostCollection, 'put')
-    def test_constituency_lock(self, mocked_put, mock_popit):
+    def test_constituency_lock(self, mocked_put, mock_requests, mock_popit):
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         self.app.get(
             '/election/2015/post/65808/dulwich-and-west-norwood',
             user=self.user_who_can_lock,
@@ -77,8 +80,9 @@ class TestConstituencyLockAndUnlock(TestUserMixin, WebTest):
         )
 
     @patch.object(FakePostCollection, 'put')
-    def test_constituency_unlock(self, mocked_put, mock_popit):
+    def test_constituency_unlock(self, mocked_put, mock_requests, mock_popit):
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         self.app.get(
             '/election/2015/post/65808/dulwich-and-west-norwood',
             user=self.user_who_can_lock,
@@ -123,8 +127,9 @@ class TestConstituencyLockAndUnlock(TestUserMixin, WebTest):
             "http://localhost:80/election/2015/post/65808/dulwich-and-west-norwood"
         )
 
-    def test_constituencies_unlocked_list(self, mock_popit):
+    def test_constituencies_unlocked_list(self, mock_requests, mock_popit):
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/election/2015/constituencies/unlocked',
         )
@@ -133,14 +138,16 @@ class TestConstituencyLockAndUnlock(TestUserMixin, WebTest):
         self.assertNotIn('Camberwell', unicode(response))
 
 @patch('candidates.popit.PopIt')
+@patch('candidates.popit.requests')
 class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'post')
     def test_add_when_locked_unprivileged_disallowed(
-            self, mocked_post, mock_popit
+            self, mocked_post, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         # Just get that page for the csrftoken cookie; the form won't
         # appear on the page, since the constituency is locked:
         response = self.app.get(
@@ -166,10 +173,11 @@ class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'post')
     def test_add_when_locked_privileged_allowed(
-            self, mocked_post, mock_popit
+            self, mocked_post, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         mocked_post.return_value = {'result': {'id': '1234'}}
         response = self.app.get(
             '/election/2015/post/65913/camberwell-and-peckham',
@@ -189,10 +197,11 @@ class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'put')
     def test_move_into_locked_unprivileged_disallowed(
-            self, mocked_put, mock_popit
+            self, mocked_put, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4322/update',
             user=self.user
@@ -206,10 +215,11 @@ class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'put')
     def test_move_into_locked_privileged_allowed(
-            self, mocked_put, mock_popit
+            self, mocked_put, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4322/update',
             user=self.user_who_can_lock
@@ -227,10 +237,11 @@ class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'put')
     def test_move_out_of_locked_unprivileged_disallowed(
-            self, mocked_put, mock_popit
+            self, mocked_put, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4170/update',
             user=self.user
@@ -244,10 +255,11 @@ class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'put')
     def test_move_out_of_locked_privileged_allowed(
-            self, mocked_put, mock_popit
+            self, mocked_put, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4170/update',
             user=self.user_who_can_lock
@@ -268,10 +280,11 @@ class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'put')
     def test_change_party_in_locked_unprivileged_disallowed(
-            self, mocked_put, mock_popit
+            self, mocked_put, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4170/update',
             user=self.user
@@ -285,10 +298,11 @@ class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'put')
     def test_change_party_in_locked_privileged_allowed(
-            self, mocked_put, mock_popit
+            self, mocked_put, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4170/update',
             user=self.user_who_can_lock
@@ -306,10 +320,11 @@ class TestConstituencyLockWorks(TestUserMixin, WebTest):
 
     @patch.object(FakePersonCollection, 'put')
     def test_change_party_in_unlocked_unprivileged_allowed(
-            self, mocked_put, mock_popit
+            self, mocked_put, mock_requests, mock_popit
     ):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4322/update',
             user=self.user

--- a/candidates/tests/test_posts_view.py
+++ b/candidates/tests/test_posts_view.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.test.utils import override_settings
 from django_webtest import WebTest
 
-from .fake_popit import get_example_popit_json
+from .fake_popit import get_example_popit_json, FakePostCollection
 
 fake_elections = {
     '2010': {
@@ -63,11 +63,13 @@ def fake_post_search_results(url, **kwargs):
     return mock_requests_response
 
 
+@patch('candidates.popit.PopIt')
 class TestPostsView(WebTest):
 
     @patch('candidates.popit.requests')
-    def test_single_election_posts_page(self, mock_requests):
+    def test_single_election_posts_page(self, mock_requests, mock_popit):
         mock_requests.get.side_effect = fake_post_search_results
+        mock_popit.return_value.posts = FakePostCollection
 
         response = self.app.get('/posts')
 
@@ -86,8 +88,9 @@ class TestPostsView(WebTest):
 
     @override_settings(ELECTIONS_CURRENT=current_fake_elections)
     @patch('candidates.popit.requests')
-    def test_two_elections_posts_page(self, mock_requests):
+    def test_two_elections_posts_page(self, mock_requests, mock_popit):
         mock_requests.get.side_effect = fake_post_search_results
+        mock_popit.return_value.posts = FakePostCollection
 
         response = self.app.get('/posts')
 

--- a/candidates/tests/test_rename_restriction.py
+++ b/candidates/tests/test_rename_restriction.py
@@ -4,16 +4,20 @@ from django_webtest import WebTest
 from django.test.utils import override_settings
 
 from .auth import TestUserMixin
-from .fake_popit import FakePersonCollection, FakePostCollection
+from .fake_popit import (
+    FakePersonCollection, FakePostCollection, fake_mp_post_search_results
+)
 
 @patch('candidates.popit.PopIt')
+@patch('candidates.popit.requests')
 class TestRenameRestriction(TestUserMixin, WebTest):
 
     @override_settings(RESTRICT_RENAMES=True)
     @patch.object(FakePersonCollection, 'put')
-    def test_renames_restricted_unprivileged(self, mocked_put, mock_popit):
+    def test_renames_restricted_unprivileged(self, mocked_put, mock_requests, mock_popit):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4322/update',
             user=self.user
@@ -31,9 +35,10 @@ class TestRenameRestriction(TestUserMixin, WebTest):
 
     @override_settings(RESTRICT_RENAMES=True)
     @patch.object(FakePersonCollection, 'put')
-    def test_renames_restricted_privileged(self, mocked_put, mock_popit):
+    def test_renames_restricted_privileged(self, mocked_put, mock_requests, mock_popit):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4322/update',
             user=self.user_who_can_rename,
@@ -50,9 +55,10 @@ class TestRenameRestriction(TestUserMixin, WebTest):
         )
 
     @patch.object(FakePersonCollection, 'put')
-    def test_renames_unrestricted_unprivileged(self, mocked_put, mock_popit):
+    def test_renames_unrestricted_unprivileged(self, mocked_put, mock_requests, mock_popit):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4322/update',
             user=self.user,
@@ -69,10 +75,10 @@ class TestRenameRestriction(TestUserMixin, WebTest):
         )
 
     @patch.object(FakePersonCollection, 'put')
-    def test_renames_unrestricted_privileged(self, mocked_put, mock_popit):
+    def test_renames_unrestricted_privileged(self, mocked_put, mock_requests, mock_popit):
         mock_popit.return_value.persons = FakePersonCollection
         mock_popit.return_value.posts = FakePostCollection
-
+        mock_requests.get.side_effect = fake_mp_post_search_results
         response = self.app.get(
             '/person/4322/update',
             user=self.user,


### PR DESCRIPTION
This finishes the work of mocking and patching network-dependent
functionality in tests so that they don't rely on any external APIs.

Fixes #448