### PR TITLE
AR: Fix the UnknownPostException when viewing /areas/NAT-0

### DIFF
--- a/elections/ar_elections_2015/settings.py
+++ b/elections/ar_elections_2015/settings.py
@@ -71,7 +71,7 @@ ELECTIONS = {
         'mapit_types': ['NAT'], # The national level...
         'mapit_generation': 1,
         # There's only one such post:
-        'post_id_format': 'pres',
+        'post_id_format': 'presidente',
     },
 }
 


### PR DESCRIPTION
When viewing the national pseudo-area, at the URL /areas/NAT-0, the
code tries to find a post with ID 'pres' based on the post_id_format
in elections/ar_elections_2015/settings.py - however, the ID in
PopIt and in the rest of the code is 'presidente', so the post isn't
found.  The UnknownPostException is caught and (confusingly)
reported as a malformed area error.

This should be fixed just by changing the post_id_format for the
presidential post in the settings file, as this commit does.

Thanks to Matthew Somerville (@dracos) for diagnosing this problem
while I was away.