### PR TITLE
Move generic popit creation commands into the 'candidates' app

### DIFF
--- a/candidates/management/commands/candidates_create_popit_organizations.py
+++ b/candidates/management/commands/candidates_create_popit_organizations.py
@@ -6,7 +6,7 @@ from candidates.models.popit import create_or_update
 from candidates.popit import PopItApiMixin
 
 class Command(PopItApiMixin, BaseCommand):
-    help = "Create the parties for the 2015 elections in Argentina"
+    help = "Create required organizations (parties / chambers) in PopIt"
 
     def handle(self, **options):
 

--- a/candidates/management/commands/candidates_create_popit_posts.py
+++ b/candidates/management/commands/candidates_create_popit_posts.py
@@ -10,7 +10,7 @@ from candidates.election_specific import MAPIT_DATA, AREA_POST_DATA
 from slumber.exceptions import HttpServerError, HttpClientError
 
 class Command(PopItApiMixin, BaseCommand):
-    help = "Create the posts for the 2015 elections in Argentina"
+    help = "Create or update the required posts in PopIt"
 
     def handle_mapit_type(self, election, election_data, mapit_type):
         mapit_tuple = (mapit_type, election_data['mapit_generation'])
@@ -36,24 +36,8 @@ class Command(PopItApiMixin, BaseCommand):
     def handle(self, **options):
         try:
             for election, election_data in settings.ELECTIONS.items():
-                if election == 'presidentes-argentina-paso-2015':
-                    create_or_update(
-                        self.api.posts,
-                        {
-                            'id': 'presidente',
-                            'label': election_data['for_post_role'],
-                            'role': election_data['for_post_role'],
-                            'area': {
-                                'name': 'Argentina',
-                                'id': 'mapit:0',
-                                'identifier': settings.MAPIT_BASE_URL + 'area/0',
-                            },
-                            'organization_id': election_data['organization_id'],
-                        }
-                    )
-                else:
-                    for mapit_type in election_data['mapit_types']:
-                        self.handle_mapit_type(election, election_data, mapit_type)
+                for mapit_type in election_data['mapit_types']:
+                    self.handle_mapit_type(election, election_data, mapit_type)
         except (HttpServerError, HttpClientError) as hse:
             print "The body of the error was:", hse.content
             raise


### PR DESCRIPTION
These are two generically useful commands which were only in the
Argentinian elections app - this PR moves them into the core
'candidates' app. (The only special case for Argentina is in fact
not needed.)