### PR TITLE
Fix so that the fingerprinted djangojs.js files can be found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /conf/httpd.conf
 /conf/httpd.conf.deployed
 /mysite/local_settings.py
+/mysite/static/jsi18n

--- a/bin/pre-deploy
+++ b/bin/pre-deploy
@@ -60,9 +60,11 @@ else
     echo done.
 fi
 
+# Generate the files of translated strings for Javascript to use
+./manage.py compilejsi18n
+
 # gather all the static files in one place
 ./manage.py collectstatic --noinput
 
 # Compile all translations from .po files into .mo files
 ./manage.py compilemessages
-./manage.py compilejsi18n

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -257,12 +257,13 @@ MEDIA_URL = '/media/'
 STATIC_URL = '/static/'
 
 STATIC_ROOT = join(BASE_DIR, 'static')
+STATICI18N_ROOT = join(BASE_DIR, 'mysite', 'static')
 
 if 'test' not in sys.argv:
     STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 
 STATICFILES_DIRS = (
-    join(BASE_DIR, 'mysite/static'),
+    join(BASE_DIR, 'mysite', 'static'),
 )
 
 STATICFILES_FINDERS = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ django-debug-toolbar==1.3.2
 django-debug-toolbar-template-timings==0.6.4
 django-nose==1.4.1
 django-pipeline==1.5.1
-django-statici18n==1.1.3
+django-statici18n==1.1.5
 django-webtest==1.7.7
 docutils==0.10
 -e git+https://github.com/django-extensions/django-extensions.git@44a39ccd882b31381c3da63861d70f0b3b5690f8#egg=django-extensions


### PR DESCRIPTION
The "./manage.py compilejsi18n" command just writes the djangojs.js
files under STATIC_ROOT rather than being processed by
staticfiles, so the fingerprinted versin of this file is never
ceated. It seems that to get staticfiles to process the output of
compilejsi18n you have to follow one of these approaches:

  https://django-statici18n.readthedocs.org/en/latest/faq.html#how-to-configure-static-files-with-django-statici18n

Since we already have mysite/static added to STATICFILES_DIRS this
commit takes the latter approach and gets compilejsi18n to output
to mysite/static/jsi18n/...

We also alter the order of the commands in bin/pre-deploy so that
these files are generated before collectstatic is run.

Fixes #525
