### PR TITLE
Avoid Sass compiler error when extending .radius

### DIFF
--- a/bin/pre-deploy
+++ b/bin/pre-deploy
@@ -60,12 +60,12 @@ fi
 mkdir -p "../gems"
 export GEM_HOME="$(cd ../gems && pwd -P)"
 export PATH="$GEM_HOME/bin:$PATH"
-if (sass --version | grep '3\.2\.19') > /dev/null
+if (sass --version | grep '3\.4\.21') > /dev/null
 then
     echo sass is already installed at the correct version
 else
     echo Installing sass...
-    gem install --no-ri --no-rdoc sass -v 3.2.19
+    gem install --no-ri --no-rdoc sass -v 3.4.21
     echo done.
 fi
 

--- a/candidates/static/candidates/_content.scss
+++ b/candidates/static/candidates/_content.scss
@@ -12,7 +12,7 @@
 }
 
 .button, input[type="submit"].button {
-  @extend .radius;
+  @include radius();
 }
 
 .code-sample {

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -370,7 +370,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'PIPELINE_COMPILERS': (
             'pipeline.compilers.sass.SASSCompiler',
         ),
-        'PIPELINE_SASS_ARGUMENTS': '--trace',
+        'PIPELINE_SASS_ARGUMENTS': '--trace --quiet',
         'PIPELINE_CSS_COMPRESSOR': 'pipeline.compressors.yui.YUICompressor',
         'PIPELINE_JS_COMPRESSOR': 'pipeline.compressors.yui.YUICompressor',
         # On some platforms this might be called "yuicompressor", so it may be


### PR DESCRIPTION
Fixes #537.

Versions of Sass greater than 3.2.19 would raise an exception (via Django pipeline) when attempting to `@extend` the `.radius` selector from Foundation.

`@include`-ing Foundation’s `radius()` mixin seems to work instead.

---

@mhl – I think this PR fixes the error from the original ticket, but I’m getting pretty broken looking styles in its place. I can't tell whether it's the new line of code (unlikely) or whether it's just a broken dev environment.

![screen shot 2015-09-30 at 16 59 20](https://cloud.githubusercontent.com/assets/739624/10198625/b8351fa6-6794-11e5-85e8-3438ca1bb118.png)
