### PR TITLE
Updates to the call-to-action flash message after updating / creating a person

### DIFF
--- a/candidates/templates/candidates/_person_update_call_to_action.html
+++ b/candidates/templates/candidates/_person_update_call_to_action.html
@@ -1,0 +1,34 @@
+{% load i18n %}
+
+{% if new_person %}
+  {% blocktrans %}
+    Thank-you for adding <a href="{{ person_url }}">{{ person_name }}</a>!
+  {% endblocktrans %}
+{% else %}
+  {% blocktrans %}
+    Thank-you for updating <a href="{{ person_url }}">{{ person_name }}</a>!
+  {% endblocktrans %}
+{% endif %}
+
+Now you can carry on to:
+
+<ul>
+  <li>
+    {% blocktrans %}
+      <a href="{{ person_edit_url }}">Edit {{ person_name }} again</a>
+    {% endblocktrans %}
+  </li>
+  <li>
+    {% blocktrans %}
+      Add a candidate for <a href="{{ needing_attention_url }}">one of the
+      posts with fewest candidates</a>
+    {% endblocktrans %}
+  </li>
+  {% for person_create_url, election_name in create_for_election_options %}
+    <li>
+      {% blocktrans %}
+        <a href="{{ person_create_url }}">Add another candidate in the {{ election_name }}</a>
+      {% endblocktrans %}
+    </li>
+  {% endfor %}
+</ul>

--- a/candidates/tests/test_flash_calls_to_action.py
+++ b/candidates/tests/test_flash_calls_to_action.py
@@ -1,7 +1,12 @@
+import re
+
 from django.test import TestCase
 
 from candidates.models.popit import PopItPerson
-from candidates.views.people import get_flash_message
+from candidates.views.people import get_call_to_action_flash_message
+
+def normalize_whitespace(s):
+    return re.sub(r'(?ms)\s+', ' ', s)
 
 class TestGetFlashMessage(TestCase):
 
@@ -29,24 +34,28 @@ class TestGetFlashMessage(TestCase):
 
     def test_get_flash_message_new_person(self):
         self.assertEqual(
-            u'Thank-you for adding <a href="/person/42">Wreck-it-Ralph</a>! '
+            u' Thank-you for adding <a href="/person/42">Wreck-it-Ralph</a>! '
             u'Now you can carry on to:'
-            u'<ul><li><a href="/person/42/update">Edit Wreck-it-Ralph again</a></li>'
-            u'<li>Add a candidate for <a href="/numbers/attention-needed">one '
-            u'of the posts with fewest candidates</a></li>'
-            u'<li><a href="/election/2015/person/create/">Add another '
-            u'candidate in the 2015 General Election</a></li></ul>',
-            get_flash_message(self.fake_person, new_person=True)
+            u' <ul> <li> <a href="/person/42/update">Edit Wreck-it-Ralph again</a> </li>'
+            u' <li> Add a candidate for <a href="/numbers/attention-needed">one '
+            u'of the posts with fewest candidates</a> </li>'
+            u' <li> <a href="/election/2015/person/create/">Add another '
+            u'candidate in the 2015 General Election</a> </li> </ul> ',
+            normalize_whitespace(
+                get_call_to_action_flash_message(self.fake_person, new_person=True)
+            )
         )
 
     def test_get_flash_message_updated_person(self):
         self.assertEqual(
-            u'Thank-you for updating <a href="/person/42">Wreck-it-Ralph</a>! '
+            u' Thank-you for updating <a href="/person/42">Wreck-it-Ralph</a>! '
             u'Now you can carry on to:'
-            u'<ul><li><a href="/person/42/update">Edit Wreck-it-Ralph again</a></li>'
-            u'<li>Add a candidate for <a href="/numbers/attention-needed">one '
-            u'of the posts with fewest candidates</a></li>'
-            u'<li><a href="/election/2015/person/create/">Add another '
-            u'candidate in the 2015 General Election</a></li></ul>',
-            get_flash_message(self.fake_person, new_person=False)
+            u' <ul> <li> <a href="/person/42/update">Edit Wreck-it-Ralph again</a> </li>'
+            u' <li> Add a candidate for <a href="/numbers/attention-needed">one '
+            u'of the posts with fewest candidates</a> </li>'
+            u' <li> <a href="/election/2015/person/create/">Add another '
+            u'candidate in the 2015 General Election</a> </li> </ul> ',
+            normalize_whitespace(
+                get_call_to_action_flash_message(self.fake_person, new_person=False)
+            )
         )

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -8,6 +8,7 @@ from django.core.urlresolvers import reverse
 from django.http import (
     HttpResponseRedirect, HttpResponsePermanentRedirect
 )
+from django.template.loader import render_to_string
 from django.utils.decorators import method_decorator
 from django.utils.http import urlquote
 from django.utils.translation import ugettext as _
@@ -32,46 +33,33 @@ from ..popit import (
     merge_popit_people, PopItApiMixin, get_base_url
 )
 
-def get_flash_message(person, new_person=False):
-    if new_person:
-        prompt_intro = _('Thank-you for adding <a href="{person_url}">{person_name}</a>!')
-    else:
-        prompt_intro = _('Thank-you for updating <a href="{person_url}">{person_name}</a>!')
+def get_call_to_action_flash_message(person, new_person=False):
+    """Get HTML for a flash message after a person has been created or updated"""
 
-    prompt_intro+= _(' Now you can carry on to:')
-
-    format_kwargs = {
-        'person_url': reverse('person-view', kwargs={'person_id': person.id}),
-        'person_edit_url': reverse('person-update', kwargs={'person_id': person.id}),
-        'person_name': person.name,
-        'needing_attention_url': reverse('attention_needed'),
-    }
-
-    election_li = _(
-        '<li><a href="{person_create_url}">Add another '
-        'candidate in the {election_name}</a></li>'
+    return render_to_string(
+        'candidates/_person_update_call_to_action.html',
+        {
+            'new_person': new_person,
+            'person_url':
+            reverse('person-view', kwargs={'person_id': person.id}),
+            'person_edit_url':
+            reverse('person-update', kwargs={'person_id': person.id}),
+            'person_name': person.name,
+            'needing_attention_url': reverse('attention_needed'),
+            # We want to offer the option to add another candidate in
+            # any of the elections that this candidate is standing in,
+            # which means we'll need the "create person" URL and
+            # election name for each of those elections:
+            'create_for_election_options': [
+                (
+                    reverse('person-create', kwargs={'election': election}),
+                    election_data['name']
+                )
+                for election, election_data in settings.ELECTIONS_CURRENT
+                if person.standing_in.get(election)
+            ]
+        }
     )
-    same_post_again = '\n'.join(
-        election_li.format(
-            person_create_url=reverse(
-                'person-create', kwargs={'election': election}
-            ),
-            election_name=election_data['name']
-        )
-        for election, election_data in settings.ELECTIONS_CURRENT
-        if person.standing_in.get(election)
-    )
-
-    return (
-        prompt_intro + \
-        '<ul>' + \
-        _('<li><a href="{person_edit_url}">Edit {person_name} '
-          'again</a></li>') + \
-        _('<li>Add a candidate for <a href="{needing_attention_url}">one of '
-          'the posts with fewest candidates</a></li>') + \
-        same_post_again + \
-        '</ul>'
-    ).format(**format_kwargs)
 
 
 class PersonView(PopItApiMixin, TemplateView):
@@ -311,7 +299,7 @@ class UpdatePersonView(LoginRequiredMixin, PopItApiMixin, FormView):
         messages.add_message(
             self.request,
             messages.SUCCESS,
-            get_flash_message(person, new_person=False),
+            get_call_to_action_flash_message(person, new_person=False),
             extra_tags='safe do-something-else'
         )
 
@@ -358,7 +346,7 @@ class NewPersonView(ElectionMixin, LoginRequiredMixin, PopItApiMixin, FormView):
         messages.add_message(
             self.request,
             messages.SUCCESS,
-            get_flash_message(person, new_person=True),
+            get_call_to_action_flash_message(person, new_person=True),
             extra_tags='safe do-something-else'
         )
 

--- a/mysite/templates/generic_base.html
+++ b/mysite/templates/generic_base.html
@@ -94,13 +94,13 @@
         <div class="messages">
           {% for message in messages %}
             {% if 'photo-review' in message.tags or 'do-something-else' in message.tags %}
-              <p class="message {% if message.tags %}{{ message.tags }}{% endif %}">
+              <div class="message {% if message.tags %}{{ message.tags }}{% endif %}">
                 {% if 'safe' in message.tags %}
                   {{ message|safe }}
                 {% else %}
                   {{ message }}
                 {% endif %}
-              </p>
+              </div>
             {% endif %}
           {% endfor %}
         </div>


### PR DESCRIPTION
As discussed with @struan / @duncanparkes in IRC, the function to create
this message was less than clear - hopefully switching that to use a partial
template helps with that.

This also fixes a long-standing bug in the rendering, where the flash
message was shown as:

![bad-flash](https://cloud.githubusercontent.com/assets/7907/10220913/b1251e1a-6842-11e5-842f-d818ebdc17f3.png)

... instead of:

![good-flash](https://cloud.githubusercontent.com/assets/7907/10220917/b5465cb6-6842-11e5-8f9c-5bcd26fffd65.png)
