### PR TITLE
Posts need an 'elections' array attribute, not an 'election' string

### DIFF
--- a/candidates/example-popit-data/generic_posts_embed=.json
+++ b/candidates/example-popit-data/generic_posts_embed=.json
@@ -11,6 +11,7 @@
       },
       "candidates_locked": false,
       "contact_details": [],
+      "elections": ["2010", "2015"],
       "html_url": "http://candidates.127.0.0.1.xip.io:3000/posts/65808",
       "id": "65808",
       "images": [],

--- a/candidates/example-popit-data/search_mp_posts_page=1.json
+++ b/candidates/example-popit-data/search_mp_posts_page=1.json
@@ -11,6 +11,7 @@
       },
       "candidates_locked": false,
       "contact_details": [],
+      "elections": ["2010", "2015"],
       "html_url": "http://candidates.127.0.0.1.xip.io:3000/posts/65808",
       "id": "65808",
       "images": [],

--- a/candidates/management/commands/candidates_create_popit_posts.py
+++ b/candidates/management/commands/candidates_create_popit_posts.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
@@ -10,6 +12,58 @@ from candidates.election_specific import MAPIT_DATA, AREA_POST_DATA
 
 from slumber.exceptions import HttpServerError, HttpClientError
 
+
+class NoValuesError(Exception):
+    pass
+
+
+class NonUniqueValuesError(Exception):
+    pass
+
+
+def all_posts_in_all_elections():
+    """A generator function to yield data on every post for every election
+
+    The purpose of this generator function is to iterate over every
+    post that should exist and yield the post ID along with the
+    election and area data it should be associated with.
+
+    It might not be obvious that posts can appear in multiple
+    elections; this means that you might get the same post ID yielded
+    more than once, but with different election and area data."""
+
+    for election, election_data in settings.ELECTIONS.items():
+        for mapit_type in election_data['mapit_types']:
+            mapit_tuple = (mapit_type, election_data['mapit_generation'])
+            for area_id, area in MAPIT_DATA.areas_by_id[mapit_tuple].items():
+                post_id = AREA_POST_DATA.get_post_id(
+                    election, mapit_type, area_id
+                )
+                yield {
+                    'election': election,
+                    'election_data': election_data,
+                    'mapit_type': mapit_type,
+                    'area_id': area_id,
+                    'area': area,
+                    'post_id': post_id,
+                }
+
+
+def get_unique_value(seq):
+    """Make sure a sequence has only a single unique value and return that
+
+    If there are actually 0 or more than 1 distinct values in the
+    sequence, raise a NoValuesError or NonUniqueValuesError"""
+
+    unique_values = set(sorted(seq))
+    if not unique_values:
+        raise NoValuesError('No values in the sequence')
+    if len(unique_values) > 1:
+        msg = 'Non-unique values found: {0}'
+        raise NonUniqueValuesError(msg.format(seq))
+    return next(iter(unique_values))
+
+
 class Command(PopItApiMixin, BaseCommand):
     help = "Create or update the required posts in PopIt"
 
@@ -21,40 +75,64 @@ class Command(PopItApiMixin, BaseCommand):
         ),
     )
 
-    def handle_mapit_type(self, election, election_data, mapit_type, **options):
+    def handle(self, **options):
+        # Choose an appropriate format for the post labels:
         post_label_format = _('{post_role} for {area_name}')
         if options['post_label']:
             post_label_format = options['post_label']
-        mapit_tuple = (mapit_type, election_data['mapit_generation'])
-        for id, area in MAPIT_DATA.areas_by_id[mapit_tuple].items():
-            post_id = AREA_POST_DATA.get_post_id(
-                election, mapit_type, id
-            )
-            role = election_data['for_post_role']
-            area_mapit_url = settings.MAPIT_BASE_URL + 'area/' + str(area['id'])
-            post_data = {
-                'election': election,
-                'role': role,
-                'id': post_id,
-                'label': post_label_format.format(
-                    post_role=role, area_name=area['name']
-                ),
-                'area': {
-                    'name': area['name'],
-                    'id': 'mapit:' + str(area['id']),
-                    'identifier': area_mapit_url,
-                },
-                'organization_id': election_data['organization_id'],
-            }
-            create_or_update(self.api.posts, post_data)
-
-    def handle(self, **options):
+        # Find all the source data for each post:
+        post_id_to_all_data = defaultdict(list)
+        for data in all_posts_in_all_elections():
+            post_id_to_all_data[data['post_id']].append(data)
+        # Now we have a mapping from each post to all the data
+        # (e.g. elections, areas) it's associated with.  Now try to
+        # reconcile that data and create or update the posts:
         try:
-            for election, election_data in settings.ELECTIONS.items():
-                for mapit_type in election_data['mapit_types']:
-                    self.handle_mapit_type(
-                        election, election_data, mapit_type, **options
-                    )
+            for post_id, data_list in post_id_to_all_data.items():
+
+                # Since the post's creation can be required by multiple
+                # elections with different metadata, there might be
+                # contradictory values for the properties we want to set
+                # on the post. To detect this possibility, we use
+                # get_unique_value to extract these values:
+                role = get_unique_value(
+                    d['election_data']['for_post_role'] for d in data_list
+                )
+                organization_id = get_unique_value(
+                    d['election_data']['organization_id'] for d in data_list
+                )
+                area_id = get_unique_value(d['area_id'] for d in data_list)
+
+                # We can have, however, have multiple values in the
+                # 'elections' attribute, so it's fine to collect all of them:
+                elections = sorted(set(d['election'] for d in data_list))
+
+                # At this stage we know there's a unique area (since
+                # otherwise there wouldn't be a unique area_id) so we
+                # don't need to check the uniqueness of area, or the
+                # values derived from area.
+                area = data_list[0]['area']
+                area_mapit_url = \
+                    settings.MAPIT_BASE_URL + 'area/' + str(area['id'])
+                label = post_label_format.format(
+                    post_role=role, area_name=area['name']
+                )
+
+                post_data = {
+                    'elections': elections,
+                    'role': role,
+                    'id': post_id,
+                    'label': label,
+                    'area': {
+                        'name': area['name'],
+                        'id': 'mapit:' + str(area_id),
+                        'identifier': area_mapit_url,
+                    },
+                    'organization_id': organization_id,
+                }
+
+                create_or_update(self.api.posts, post_data)
+
         except (HttpServerError, HttpClientError) as hse:
             print "The body of the error was:", hse.content
             raise

--- a/candidates/popit.py
+++ b/candidates/popit.py
@@ -57,7 +57,7 @@ def unwrap_search_pagination(collection, query, **kwargs):
 
 def get_all_posts(election, role, **kwargs):
     kwargs.setdefault('embed', '')
-    search_query = u'election:"{election}" AND role:"{role}"'.format(
+    search_query = u'elections:"{election}" AND role:"{role}"'.format(
         election=election, role=role
     )
     return unwrap_search_pagination('posts', search_query, **kwargs)


### PR DESCRIPTION
The previous change (e9a502a0b) to store an 'election' attribute on
each post actually wasn't quite right, because people can be elected
to the same post in more than one election.  (The example we have at
the moment is that the UK site has both a 2010 and 2015 election
with exactly the same posts.)  The previous change meant that the
UK general election posts only ended up associated with one election
when they should be returned from searches for both.

This commit changes that, so that posts are expected to have a
'elections' array of election IDs instead of an 'election' string
with a single election ID.

After deploying this, you will need to run:

  ./manage.py candidates_create_popit_posts

... to make sure all the posts have the correct 'elections' attribute.