### PR TITLE
Fix translation formatting

### DIFF
--- a/cached_counts/templates/reports.html
+++ b/cached_counts/templates/reports.html
@@ -12,7 +12,7 @@
   <h2>{% trans 'Which posts have fewest candidates so far?' %}</h2>
 
   <p>{% url 'attention_needed' as url %}
-     {% blocktrans %}
+     {% blocktrans trimmed %}
         You can see a list of all the posts in current elections
         <a href="{{ url }}">ordered starting with those with the fewest
         candidates</a>.

--- a/candidates/middleware.py
+++ b/candidates/middleware.py
@@ -39,13 +39,14 @@ class DisallowedUpdateMiddleware(object):
 
     def process_exception(self, request, exc):
         if isinstance(exc, NameChangeDisallowedException):
+            intro = _(u'As a precaution, an update was blocked:')
+            outro = _(u'If this update is appropriate, someone should apply it manually.')
             # Then email the support address about the name change...
-            message = _(u'''As a precaution, an update was blocked:
-
-  {0}
-
-If this update is appropriate, someone should apply it manually.
-''').format(unicode(exc))
+            message = u'{intro}\n\n  {message}\n\n{outro}'.format(
+                intro=intro,
+                message=unicode(exc),
+                outro=outro,
+            )
             send_mail(
                 _('Disallowed {site_name} update for checking').format(
                     site_name=Site.objects.get_current().name

--- a/candidates/templates/candidates/_person_update_call_to_action.html
+++ b/candidates/templates/candidates/_person_update_call_to_action.html
@@ -1,11 +1,11 @@
 {% load i18n %}
 
 {% if new_person %}
-  {% blocktrans %}
+  {% blocktrans trimmed %}
     Thank-you for adding <a href="{{ person_url }}">{{ person_name }}</a>!
   {% endblocktrans %}
 {% else %}
-  {% blocktrans %}
+  {% blocktrans trimmed %}
     Thank-you for updating <a href="{{ person_url }}">{{ person_name }}</a>!
   {% endblocktrans %}
 {% endif %}
@@ -14,19 +14,19 @@ Now you can carry on to:
 
 <ul>
   <li>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       <a href="{{ person_edit_url }}">Edit {{ person_name }} again</a>
     {% endblocktrans %}
   </li>
   <li>
-    {% blocktrans %}
+    {% blocktrans trimmed %}
       Add a candidate for <a href="{{ needing_attention_url }}">one of the
       posts with fewest candidates</a>
     {% endblocktrans %}
   </li>
   {% for person_create_url, election_name in create_for_election_options %}
     <li>
-      {% blocktrans %}
+      {% blocktrans trimmed %}
         <a href="{{ person_create_url }}">Add another candidate in the {{ election_name }}</a>
       {% endblocktrans %}
     </li>

--- a/candidates/templates/candidates/ask-for-copyright-assignment.html
+++ b/candidates/templates/candidates/ask-for-copyright-assignment.html
@@ -4,14 +4,14 @@
 {% block body_class %}{% endblock %}
 
 {% block title %}
-  {% blocktrans with site_name=site.name %}
+  {% blocktrans trimmed with site_name=site.name %}
     {{ site_name }} user agreement
   {% endblocktrans %}
 {% endblock %}
 
 {% block hero %}
   <h1>
-      {% blocktrans with site_name=site.name %}
+      {% blocktrans trimmed with site_name=site.name %}
         {{ site_name }} user agreement
       {% endblocktrans %}
   </h1>

--- a/candidates/templates/candidates/popit_down.html
+++ b/candidates/templates/candidates/popit_down.html
@@ -4,7 +4,7 @@
 {% block body_class %}popit-down{% endblock %}
 
 {% block title %}
-  {% blocktrans with site_name=site.name %}
+  {% blocktrans trimmed with site_name=site.name %}
     {{ site_name }} is Temporarily Unavailable
   {% endblocktrans %}
 {% endblock %}
@@ -18,7 +18,7 @@
 <div class="popit-down">
 
 <h2>
-  {% blocktrans with site_name=site.name %}
+  {% blocktrans trimmed with site_name=site.name %}
     Sorry, {{ site_name }} is temporarily unavailable
   {% endblocktrans %}
 </h2>

--- a/docs/transifex.md
+++ b/docs/transifex.md
@@ -44,7 +44,7 @@ Now update the `.po` files with any new strings that have been
 added to the project with:
 
 ```
-./manage.py makemessages -a \
+./manage.py makemessages -a --no-wrap \
     --ignore=data --ignore=candidates/static/foundation
 ```
 

--- a/elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html
+++ b/elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html
@@ -4,14 +4,14 @@
 {% block body_class %}{% endblock %}
 
 {% block title %}
-  {% blocktrans with site_name=site.name %}
+  {% blocktrans trimmed with site_name=site.name %}
     {{ site_name }} user agreement
   {% endblocktrans %}
 {% endblock %}
 
 {% block hero %}
   <h1>
-      {% blocktrans with site_name=site.name %}
+      {% blocktrans trimmed with site_name=site.name %}
         {{ site_name }} user agreement
       {% endblocktrans %}
   </h1>

--- a/locale/cy_GB/LC_MESSAGES/django.po
+++ b/locale/cy_GB/LC_MESSAGES/django.po
@@ -25,10 +25,7 @@ msgid "Permission denied"
 msgstr "Gwadwyd caniatâd"
 
 #: auth_helpers/templates/auth_helpers/group_permission_denied.html:14
-msgid ""
-"You must be in the member of a particular group in order to view that page. "
-"Please contact the administrators of the site if you feel that you should "
-"have access to this page."
+msgid "You must be in the member of a particular group in order to view that page. Please contact the administrators of the site if you feel that you should have access to this page."
 msgstr "Rhaid ichi fod yn aelod o grŵp penodol er mwyn gweld y dudalen honno. Cysylltwch â gweinyddwyr y safle os ydych yn teimlo y dylech gael mynediad i'r dudalen hon."
 
 #: cached_counts/templates/attention_needed.html:5
@@ -128,16 +125,12 @@ msgstr "Ymgeiswyr sy'n sefyll eto ers %(prior_election_name)s:"
 
 #: cached_counts/templates/reports.html:58
 #, python-format
-msgid ""
-"Candidates standing again from the %(prior_election_name)s for the same "
-"party:"
+msgid "Candidates standing again from the %(prior_election_name)s for the same party:"
 msgstr "Ymgeiswyr sy'n sefyll eto ers %(prior_election_name)s: ar gyfer yr un blaid:"
 
 #: cached_counts/templates/reports.html:62
 #, python-format
-msgid ""
-"Candidates standing again from the %(prior_election_name)s for a different "
-"party:"
+msgid "Candidates standing again from the %(prior_election_name)s for a different party:"
 msgstr "Ymgeiswyr sy'n sefyll eto ers %(prior_election_name)s ar gyfer plaid wahanol:"
 
 #: cached_counts/templates/reports.html:74
@@ -156,14 +149,12 @@ msgstr "oedd yn hysbys fel un a oedd yn sefyll dros y blaid  '{party}' yn {elect
 
 #: candidates/diffs.py:38
 #, python-brace-format
-msgid ""
-"is known to be standing for the party with ID {party} in the {election}"
+msgid "is known to be standing for the party with ID {party} in the {election}"
 msgstr "sy'n hysbys fel un sy'n sefyll dros y blaid gyda'r cyfeirnod '{party}' yn {election}"
 
 #: candidates/diffs.py:40
 #, python-brace-format
-msgid ""
-"was known to be standing for the party with ID {party} in the {election}"
+msgid "was known to be standing for the party with ID {party} in the {election}"
 msgstr "oedd yn hysbys fel un a oedd yn sefyll dros y blaid gyda'r cyfeirnod '{party}' yn {election}"
 
 #: candidates/diffs.py:43 candidates/diffs.py:91
@@ -193,28 +184,22 @@ msgstr "- gwyddys nad oedd yn sefyll yn {election}"
 
 #: candidates/diffs.py:64
 #, python-brace-format
-msgid ""
-"is known to be standing for the post with ID {post_id} in the {election}"
+msgid "is known to be standing for the post with ID {post_id} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:66
 #, python-brace-format
-msgid ""
-"was known to be standing for the post with ID {post_id} in the {election}"
+msgid "was known to be standing for the post with ID {post_id} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:70
 #, python-brace-format
-msgid ""
-"is known to be standing in the constituency with MapIt URL {mapit_url} in "
-"the {election}"
+msgid "is known to be standing in the constituency with MapIt URL {mapit_url} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:72
 #, python-brace-format
-msgid ""
-"was known to be standing in the constituency with MapIt URL {mapit_url} in "
-"the {election}"
+msgid "was known to be standing in the constituency with MapIt URL {mapit_url} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:76 candidates/diffs.py:97
@@ -363,16 +348,12 @@ msgid "Program"
 msgstr ""
 
 #: candidates/forms.py:155
-msgid ""
-"The Twitter username must only consist of alphanumeric characters or "
-"underscore"
+msgid "The Twitter username must only consist of alphanumeric characters or underscore"
 msgstr "Rhaid i'r enw defnyddiwr Twitter cynnwys llythrennau, rhifau a thanlinelliad yn unig"
 
 #: candidates/forms.py:177
 #, python-brace-format
-msgid ""
-"If you mark the candidate as standing in the {election}, you must select a "
-"post"
+msgid "If you mark the candidate as standing in the {election}, you must select a post"
 msgstr "Wrth nodi bod yr ymgeisydd yn sefyll yn {election}, rhaid i chi ddewis etholaeth"
 
 #: candidates/forms.py:186
@@ -382,8 +363,7 @@ msgstr "Nodwyd cyfeirnod etholaeth '{post_id}' sy'n anhysbys i ni"
 
 #: candidates/forms.py:192
 #, python-brace-format
-msgid ""
-"Could not find parties for the post with ID '{post_id}' in the {election}"
+msgid "Could not find parties for the post with ID '{post_id}' in the {election}"
 msgstr "Methu canfod pleidiau am yr etholaeth gyda'r cyfeirnod '{post_id}' yn {election}"
 
 #: candidates/forms.py:200
@@ -440,9 +420,7 @@ msgstr "Ffynhonnell wybodaeth ar gyfer y newid hwn ({0})"
 
 #: candidates/forms.py:425
 #, python-brace-format
-msgid ""
-"You can only edit data on {site_name} if you agree to this copyright "
-"assignment."
+msgid "You can only edit data on {site_name} if you agree to this copyright assignment."
 msgstr ""
 
 #: candidates/forms.py:449
@@ -499,9 +477,7 @@ msgid "Name change from '{0}' to '{1}' by user {2} disallowed"
 msgstr "Gwaharddwyd y newid enw gan ddefnyddiwr {2} o '{0}' i '{1}'  "
 
 #: candidates/models/auth.py:84
-msgid ""
-"That update isn't allowed because candidates for a locked post would be "
-"changed"
+msgid "That update isn't allowed because candidates for a locked post would be changed"
 msgstr "Ni chaniatawyd y diweddariad, neu bydda yna effaith ar ymgeiswyr ar gyfer tudalen etholaeth derfynol"
 
 #: candidates/models/db.py:29
@@ -556,10 +532,7 @@ msgid "(This list of candidates is currently <strong>unlocked</strong>.)"
 msgstr "(Mae'r rhestr o ymgeiswyr yma <strong> ar gael i'w olygu </strong>.)"
 
 #: candidates/templates/candidates/_candidates_for_post.html:74
-msgid ""
-"This list of candidates is now <strong>locked</strong>; you can still update"
-" contact details of candidates, but can't change the people standing in this"
-" constituency."
+msgid "This list of candidates is now <strong>locked</strong>; you can still update contact details of candidates, but can't change the people standing in this constituency."
 msgstr "Mae'r restr hon o ymgeiswyr bellach <strong>dan glo</strong>; gellir diwedaru manylion cyswllt ond nid enwau'r ymgeiswyr."
 
 #: candidates/templates/candidates/_candidates_for_post.html:83
@@ -609,9 +582,7 @@ msgstr "Enillodd yr ymgeisydd yma!"
 
 #: candidates/templates/candidates/_candidates_for_post.html:150
 #, python-format
-msgid ""
-"<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s "
-"for the %(election_name)s yet."
+msgid "<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s for the %(election_name)s yet."
 msgstr "<strong>Hen dro</strong>, nid ydym yn adnabod unrhyw ymgeiswyr yn  %(post_label)s ar gyfer %(election_name)s eto."
 
 #: candidates/templates/candidates/_candidates_for_post.html:154
@@ -647,8 +618,7 @@ msgid "Is a candidate from the 2010 election standing again?"
 msgstr "Oes yna ymgeisydd o ryw etholiad yn y gorffennol yn ail-eistedd?"
 
 #: candidates/templates/candidates/_candidates_for_post.html:200
-msgid ""
-"We don't know if these candidates from earlier elections are standing again"
+msgid "We don't know if these candidates from earlier elections are standing again"
 msgstr "Nid ydym yn gwybod os yw'r ymgeiswyr hyn o etholiadau cynharach yn sefyll unwaith eto"
 
 #: candidates/templates/candidates/_candidates_for_post.html:221
@@ -660,8 +630,7 @@ msgid "Not standing again"
 msgstr "Nid yw'n sefyll unwaith eto"
 
 #: candidates/templates/candidates/_candidates_for_post.html:247
-msgid ""
-"These candidates from earlier elections are known not to be standing again"
+msgid "These candidates from earlier elections are known not to be standing again"
 msgstr "Gwyddys nad yw ymgeiswyr hyn o etholiadau cynharach yn sefyll eto"
 
 #: candidates/templates/candidates/_candidates_for_post.html:267
@@ -670,9 +639,7 @@ msgstr "Ydyn nhw'n sefyll, go iawn?"
 
 #: candidates/templates/candidates/_edits_disallowed_message.html:2
 #, python-format
-msgid ""
-"Editing of data in %(site.name)s is now disabled, but if you have a "
-"correction, please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
+msgid "Editing of data in %(site.name)s is now disabled, but if you have a correction, please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:4
@@ -715,9 +682,7 @@ msgid "They commented: “%(user_comment)s”."
 msgstr "Eu sylw nhw oedd: “%(user_comment)s”."
 
 #: candidates/templates/candidates/_photo-credit.html:18
-msgid ""
-"The volunteer moderator who reviewed this photo picked a different "
-"justification for its use on the site, which was:"
+msgid "The volunteer moderator who reviewed this photo picked a different justification for its use on the site, which was:"
 msgstr "Dewisodd y cymedrolwr/aig gwirfoddolwyr cyfiawnhad gwahanol ar gyfer ei ddefnyddio ar y safle, sef:"
 
 #: candidates/templates/candidates/_photo-credit.html:27
@@ -731,22 +696,16 @@ msgid "Notes about this image: “%(notes)s”."
 msgstr "Nodiadau am y llun hwn: “%(notes)s”."
 
 #: candidates/templates/candidates/_photo-expand-reason.html:3
-msgid ""
-"the photo is free of copyright restrictions (i.e. has explictly been placed "
-"in the public domain)"
+msgid "the photo is free of copyright restrictions (i.e. has explictly been placed in the public domain)"
 msgstr "nid oes cyfyngiadau hawlfraint ar y llun hwn (h.y. Mae wedi'i osod yn benodol y parth cyhoeddus)"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:8
 #, python-format
-msgid ""
-"they have assigned the copyright of the image to %(site_owner)s so that we "
-"may use it on the site"
+msgid "they have assigned the copyright of the image to %(site_owner)s so that we may use it on the site"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-expand-reason.html:13
-msgid ""
-"this photo is the candidate's profile on social media, or is used to promote"
-" their candidacy on an official candidate or party website"
+msgid "this photo is the candidate's profile on social media, or is used to promote their candidacy on an official candidate or party website"
 msgstr "dyma lun proffil yr ymgeisydd ar gyfryngau cymdeithasol, neu i hyrwyddo eu hymgeisyddiaeth ar wefan ymgeisydd swyddogol neu wefan blaid"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:18
@@ -779,37 +738,22 @@ msgstr "Am y wefan hon"
 
 #: candidates/templates/candidates/about.html:17
 #, python-format
-msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or"
-" bug reports."
+msgid "Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or bug reports."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:22
 #: elections/uk_general_election_2015/templates/candidates/about.html:26
-msgid ""
-"The source code for this site is <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/\">available on "
-"GitHub</a>, and you can find a <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/issues\">list of "
-"known bugs</a> there as well."
+msgid "The source code for this site is <a href=\"https://github.com/mysociety/yournextrepresentative/\">available on GitHub</a>, and you can find a <a href=\"https://github.com/mysociety/yournextrepresentative/issues\">list of known bugs</a> there as well."
 msgstr "Mae cod ffynhonnell y safle hwn <a href=\"https://github.com/mysociety/yournextrepresentative/\">ar gael ar GitHub </a>, ynghyd a <a href=\"https://github.com/mysociety/yournextrepresentative/issues\">rhestr o wallau</a>."
 
 #: candidates/templates/candidates/about.html:30
-msgid ""
-"This site was originally developed by Mark Longair (mySociety), Sym Roe "
-"(Democracy Club) and Zarino Zappia (mySociety), and <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many"
-" other contributors</a>, to whom we owe a debt of gratitude."
+msgid "This site was originally developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety), and <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many other contributors</a>, to whom we owe a debt of gratitude."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:38
 #: elections/uk_general_election_2015/templates/candidates/about.html:49
 #, python-format
-msgid ""
-"You can use the data from this site, via the <a href=\"%(api_url)s\">API or "
-"CSV download</a>, under the terms of the Creative Commons license <a "
-"href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-"
-"ShareAlike (CC-BY-SA)</a> with the exception of:"
+msgid "You can use the data from this site, via the <a href=\"%(api_url)s\">API or CSV download</a>, under the terms of the Creative Commons license <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-ShareAlike (CC-BY-SA)</a> with the exception of:"
 msgstr "Gallwch ddefnyddio'r data o'r wefan hon drwy'r <a href=\"%(api_url)s\">API neu lawrlwythiad CSV</a>, dan amodau'r drwydded Creative Commons <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> ag eithrio:"
 
 #: candidates/templates/candidates/about.html:47
@@ -818,20 +762,13 @@ msgstr ""
 
 #: candidates/templates/candidates/about.html:48
 #: elections/uk_general_election_2015/templates/candidates/about.html:59
-msgid ""
-"Candidate photos, which are typically either submitted by the candidates "
-"themselves, or from sources where it seems reasonable that we might use them"
-" on this site, such as the party's official page for that candidate, or "
-"their social media profile picture."
+msgid "Candidate photos, which are typically either submitted by the candidates themselves, or from sources where it seems reasonable that we might use them on this site, such as the party's official page for that candidate, or their social media profile picture."
 msgstr "Mae lluniau ymgeiswyr fel arfer naill ai gan yr ymgeiswyr eu hunain, neu o ffynonellau lle mae'n ymddangos yn rhesymol y gallai eu defnyddio ar y safle hwn, fel tudalen swyddogol y blaid ar gyfer yr ymgeisydd hwnnw, neu eu llun proffil cyfryngau cymdeithasol."
 
 #: candidates/templates/candidates/about.html:56
 #: elections/uk_general_election_2015/templates/candidates/about.html:67
 #, python-format
-msgid ""
-"If the CC-BY-SA licence is problematic for you, but you feel that you have a"
-" worthwhile use of the data in mind, please <a "
-"href=\"mailto:%(email)s\">contact us</a> to discuss your situation further."
+msgid "If the CC-BY-SA licence is problematic for you, but you feel that you have a worthwhile use of the data in mind, please <a href=\"mailto:%(email)s\">contact us</a> to discuss your situation further."
 msgstr "Os nad yw'r drwydded CC-BY-SA yn eich plesio, ond yr ydych yn teimlo fod ganddoch defnydd gwerth chweil o'r data mewn golwg,  <a href=\"mailto:%(email)s\">cysylltwch â ni</a> i drafod eich sefyllfa ymhellach os gwelwch yn dda."
 
 #: candidates/templates/candidates/about.html:62
@@ -853,11 +790,7 @@ msgstr "Ymwadiad"
 #: candidates/templates/candidates/about.html:72
 #: elections/uk_general_election_2015/templates/candidates/about.html:95
 #, python-format
-msgid ""
-"The data on this website is crowd-sourced and may not be complete (or may "
-"contain inaccuracies). If you find an error, please either update the page "
-"yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the "
-"problem."
+msgid "The data on this website is crowd-sourced and may not be complete (or may contain inaccuracies). If you find an error, please either update the page yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the problem."
 msgstr "Mae data ar y wefan hon wedi'i dorfoli, felly ni fydd efallai yn gyflawn (neu gall gynnwys gwallau). Croeso i chi gywiro gwallau eich hun, neu <a href=\"mailto:%(email)s\">ebostiwch</a>  i adael inni wybod am broblemau."
 
 #: candidates/templates/candidates/all-edits-disallowed.html:6
@@ -878,11 +811,7 @@ msgid "Using this data via the API"
 msgstr "Defnyddio'r data drwy'r API"
 
 #: candidates/templates/candidates/api.html:16
-msgid ""
-"The data that's submitted to this site is available as a CSV/Excel download "
-"and programmatically via a RESTful web service called PopIt, which stores "
-"information about people and their positions in organizations. (You can <a "
-"href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
+msgid "The data that's submitted to this site is available as a CSV/Excel download and programmatically via a RESTful web service called PopIt, which stores information about people and their positions in organizations. (You can <a href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
 msgstr "Mae'r data a gyflwynir i'r safle hwn yn ar gael i'w lawrlwytho fel CSV/Excel ac fel gwasanaeth gwe RESTful o'r enw PopIt, sy'n storio gwybodaeth am bobl a'u swyddi mewn sefydliadau. (Gallwch <a href=\"http://popit.poplus.org/\"> ddarganfod mwy am PopIt yma </a>.)"
 
 #: candidates/templates/candidates/api.html:24
@@ -920,10 +849,7 @@ msgid "The base API URL for the data is:"
 msgstr "Bonyn cyfeiriad gwefan yr API ar gyfer y data yw:"
 
 #: candidates/templates/candidates/api.html:72
-msgid ""
-"You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic "
-"documentation for the PopIt API</a> or just follow the simple examples that "
-"follow."
+msgid "You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic documentation for the PopIt API</a> or just follow the simple examples that follow."
 msgstr "Gallwch ddarllen <a href=\"http://popit.poplus.org/docs/api/\">rhagor o ddogfennau cyffredinol ar gyfer API PopIt </a> neu dilynwch yr enghreifftiau syml sy'n dilyn."
 
 #: candidates/templates/candidates/api.html:78
@@ -931,11 +857,7 @@ msgid "Find a Constituency ID"
 msgstr "Dod o hyd i Gyfeirnod Etholaeth"
 
 #: candidates/templates/candidates/api.html:80
-msgid ""
-"In order to look up candidates for a constituency, you have to find the ID "
-"of that constituency. The IDs that we use for constituencies are the IDs for"
-" Westminster constituencies areas in another web service, <a "
-"href=\"http://mapit.mysociety.org\">MapIt</a>."
+msgid "In order to look up candidates for a constituency, you have to find the ID of that constituency. The IDs that we use for constituencies are the IDs for Westminster constituencies areas in another web service, <a href=\"http://mapit.mysociety.org\">MapIt</a>."
 msgstr "Er mwyn chwilio am ymgeiswyr ar gyfer etholaeth, rhaid canfod cyfeirnod (ID) yr etholaeth honno. Mae'r cyfeirnodau a ddefnyddiwn ar gyfer etholaethau yr un fath a'r rhai a defnyddir  ar gyfer ardaloedd etholaethau San Steffan, Llundain, ar wasanaeth gwe arall, <a href=\"http://mapit.mysociety.org\">MapIt</a>."
 
 #: candidates/templates/candidates/api.html:88
@@ -943,22 +865,15 @@ msgid "... from a postcode"
 msgstr "... o'r cod post"
 
 #: candidates/templates/candidates/api.html:90
-msgid ""
-"Suppose you want to find the constituency for the postcode SW1A&nbsp;1AA, "
-"then you would make a GET request to the following URL:"
+msgid "Suppose you want to find the constituency for the postcode SW1A&nbsp;1AA, then you would make a GET request to the following URL:"
 msgstr "Os am ddarganfod etholaeth ar gyfer y cod post SW1A&nbsp;1AA, byddech chi'n gwneud cais GET i'r gwegyfeiriad canlynol:"
 
 #: candidates/templates/candidates/api.html:100
-msgid ""
-"This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON "
-"object</a>, wherein the constituency ID can be found at "
-"<tt>.shortcuts.WMC</tt>."
+msgid "This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON object</a>, wherein the constituency ID can be found at <tt>.shortcuts.WMC</tt>."
 msgstr "Mae <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">hwn yn dychwelyd gwrthrych JSON</a>, yn <tt>.shortcuts.WMC</tt>. mae'r cyfeirnod etholaeth"
 
 #: candidates/templates/candidates/api.html:106
-msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org"
-"/#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
+msgid "There's more documentation available on <a href=\"http://mapit.mysociety.org/#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
 msgstr "Mae 'na ragor o fanylion  <a href=\"http://mapit.mysociety.org/#api-by_postcode\">ar adran cod post hafan MapIt</a>."
 
 #: candidates/templates/candidates/api.html:112
@@ -966,24 +881,15 @@ msgid "... from a latitude / longitude or other coordinate"
 msgstr "... o ledred / hydred neu cyfesuryn arall"
 
 #: candidates/templates/candidates/api.html:114
-msgid ""
-"You can look up constituencies in MapIt using a variety of coordinate "
-"systems. To give the most common example, you might have a WGS84 coordinate "
-"from a GPS or location API, in which can you should put the SRID 4326 in "
-"your lookup. For example, latitude 52.205083 and longitude 0.115194 could be"
-" looked up with:"
+msgid "You can look up constituencies in MapIt using a variety of coordinate systems. To give the most common example, you might have a WGS84 coordinate from a GPS or location API, in which can you should put the SRID 4326 in your lookup. For example, latitude 52.205083 and longitude 0.115194 could be looked up with:"
 msgstr "Gallwch chwilio am etholaethau yn MapIt gan ddefnyddio amrywiaeth o systemau cyfesuryn. E.e. os oes gennych cyfesuryn WGS84 o declyn llywio â lloeren neu o elfen leoliad API,  rhowch SRID 4326 yn eich ymholiad. E.e. gellid darganfod lledred o 52.205083  a hydred o 0.115194 gyda:"
 
 #: candidates/templates/candidates/api.html:126
-msgid ""
-"(Note that the longitude comes before the latitude, which might not be what "
-"you expect.) The only key in that object is the constituency ID."
+msgid "(Note that the longitude comes before the latitude, which might not be what you expect.) The only key in that object is the constituency ID."
 msgstr "(Noder bod yr hydred yn dod cyn y lledred, sy'n annisgwyl braidd) Yr unig allwedd yn y gwrthrych hwnnw yw cyfeirnod yr etholaeth."
 
 #: candidates/templates/candidates/api.html:132
-msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org"
-"/#api-by_point\">point lookups on the MapIt front-page</a>."
+msgid "There's more documentation available on <a href=\"http://mapit.mysociety.org/#api-by_point\">point lookups on the MapIt front-page</a>."
 msgstr "Ceir mwy o ddogfennaeth ar <a href=\"http://mapit.mysociety.org/#api-by_point\">dudalen 'point lookups' MapIt</a>."
 
 #: candidates/templates/candidates/api.html:138
@@ -991,18 +897,11 @@ msgid "... by selecting it from its name"
 msgstr "... drwy ei ddewis o'i enw"
 
 #: candidates/templates/candidates/api.html:140
-msgid ""
-"If you need to produce a list of all constituencies (e.g. for a select box) "
-"and allow the user to pick one, you can get a list of all Westminster "
-"constituencies in the UK from this request:"
+msgid "If you need to produce a list of all constituencies (e.g. for a select box) and allow the user to pick one, you can get a list of all Westminster constituencies in the UK from this request:"
 msgstr "Os oes rhaid i chi lunio rhestr o holl etholaethau (e.e. ar gyfer blwch dewis) a chaniatáu i'r defnyddiwr i ddewis un, gallwch gael rhestr o holl etholaethau San Steffan y DU o'r cais hwn:"
 
 #: candidates/templates/candidates/api.html:150
-msgid ""
-"The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that"
-" request</a> has the constituency ID as its keys; the values are objects "
-"that include (among other things) a <tt>name</tt> element that gives you the"
-" official name of the constituency."
+msgid "The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that request</a> has the constituency ID as its keys; the values are objects that include (among other things) a <tt>name</tt> element that gives you the official name of the constituency."
 msgstr "Mae gan <a href=\"http://mapit.mysociety.org/areas/WMC\">y data a ddychwelyd o'r cais hwnnw </a> cyfeirnod (ID) yr etholaeth fel ei allwedd; mae'r gwerthoedd yn wrthrychau sy'n cynnwys (ymhlith pethau eraill) yn elfen <tt>enw</tt> y bydd yn rhoi enw swyddogol yr etholaeth."
 
 #: candidates/templates/candidates/api.html:158
@@ -1010,12 +909,7 @@ msgid "Find Candidates for a Constituency"
 msgstr "Dod o hyd i Ymgeiswyr ar gyfer Etholaeth"
 
 #: candidates/templates/candidates/api.html:160
-msgid ""
-"There are broadly two ways you can approach getting candidate data for a "
-"constituency; one is slightly simpler, and just gives you the basic "
-"candidate and party information, while the second gives you the full data in"
-" Popolo format, which is more complex but useful if you're using tools that "
-"generically process Popolo data."
+msgid "There are broadly two ways you can approach getting candidate data for a constituency; one is slightly simpler, and just gives you the basic candidate and party information, while the second gives you the full data in Popolo format, which is more complex but useful if you're using tools that generically process Popolo data."
 msgstr "Mae yna dwy ffordd i gael data ymgeiswyr ar gyfer etholaeth: y naill sydd ychydig symlach, ac yn  rhoi gwybodaeth elfennol am yr ymgeisydd a'r blaid; a'r llall yn rhoi data llawn yn fformat Popolo, sydd yn fwy cymhleth ond yn ddefnyddiol os ydych chi'n defnyddio offer prosesu data Popolo."
 
 #: candidates/templates/candidates/api.html:169
@@ -1023,51 +917,28 @@ msgid "Simpler (Basic candidate information)"
 msgstr "Symlach (gwybodaeth ymgeisydd sylfaenol )"
 
 #: candidates/templates/candidates/api.html:171
-msgid ""
-"You can get all the candidates for a constituency, both in 2010 and 2015 by "
-"a query like:"
+msgid "You can get all the candidates for a constituency, both in 2010 and 2015 by a query like:"
 msgstr "Gallwch gael rhestr yr holl ymgeiswyr ar gyfer etholaeth, yn 2010 a 2015 drwy ymholiad megis:"
 
 #: candidates/templates/candidates/api.html:180
 #, python-format
-msgid ""
-"For example, for Dulwich and West Norwood, <a "
-"href=\"%(popit_url)sposts/65808?embed=membership.person\">these would be the"
-" results</a>."
+msgid "For example, for Dulwich and West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person\">these would be the results</a>."
 msgstr "E.e., ar gyfer Dulwich a Gorllewin Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person\">dyma'r canlyniadau</a>."
 
 #: candidates/templates/candidates/api.html:186
-msgid ""
-"If you iterate over the <tt>memberships</tt> in that result, each person "
-"will look something like:"
+msgid "If you iterate over the <tt>memberships</tt> in that result, each person will look something like:"
 msgstr "Wrth iteru dros yr <tt>aelodau</tt> yn y canlyniad, bydd pob person yn edrych rhywbeth yn debyg i:"
 
 #: candidates/templates/candidates/api.html:214
-msgid ""
-"(I've removed some fields there to keep the example simpler.) The two fields"
-" of particular interest are probably <tt>standing_in</tt> and "
-"<tt>party_memberships</tt>."
+msgid "(I've removed some fields there to keep the example simpler.) The two fields of particular interest are probably <tt>standing_in</tt> and <tt>party_memberships</tt>."
 msgstr "(Rydym wedi dileu rhai  meysydd er mwyn cadw'r enghraifft yn symlach.) Mae'n debyg mai <tt>standing_in</tt> a <tt>party_memberships</tt> sydd o ddiddordeb pennaf."
 
 #: candidates/templates/candidates/api.html:222
-msgid ""
-"This object will only have keys '2010' or '2015'. If one of these keys is "
-"present then we have known information about the candidate for the UK "
-"general election in that year.  If the value is <tt>null</tt> then we know "
-"that they're <em>not</em> standing. If they are (or were) standing in the "
-"general election in that year then there will be a dictionary giving you "
-"details of the constituency they were standing in. So, in the example above "
-"we can see that Tessa Jowell stood in 2010 in Dulwich and West Norwood, but "
-"we know isn't standing in any consituency in 2015."
+msgid "This object will only have keys '2010' or '2015'. If one of these keys is present then we have known information about the candidate for the UK general election in that year.  If the value is <tt>null</tt> then we know that they're <em>not</em> standing. If they are (or were) standing in the general election in that year then there will be a dictionary giving you details of the constituency they were standing in. So, in the example above we can see that Tessa Jowell stood in 2010 in Dulwich and West Norwood, but we know isn't standing in any consituency in 2015."
 msgstr "Bydd y gwrthrych hwn yn gael allweddi '2010' neu '2015' yn unig. Os yw un o allweddi hyn yn bresennol yna byddwn yn sicr  bod gennym wybodaeth am yr ymgeisydd ar gyfer etholiad cyffredinol y DU yn y flwyddyn honno. Os mai gwerth <tt>null</tt> sydd yna, gwyddom <em>nad</em> ydynt yn sefyll. Os ydynt (neu oeddent) yn sefyll yn yr etholiad cyffredinol yn y flwyddyn honno, yna bydd yna rhestr yn rhoi manylion am yr etholaeth y maent yn cystadlu. Felly, yn yr enghraifft uchod, gallwn weld bod Tessa Jowell wedi syfyll yn Dulwich a Gorllewin Norwood yn 2010, ond nid yw'n sefyll mewn unrhyw etholaeth yn 2015."
 
 #: candidates/templates/candidates/api.html:236
-msgid ""
-"This object will similarly only have keys '2010' or '2015' and tells you "
-"what party the candidate is / was standing for in the general election of "
-"that year.  So in the example above, you can see that Tessa Jowell stood for"
-" the Labour Party in 2010, but has no entry for 2015 (because, as the "
-"<tt>standing_in</tt> tells us) she's not standing in 2015."
+msgid "This object will similarly only have keys '2010' or '2015' and tells you what party the candidate is / was standing for in the general election of that year.  So in the example above, you can see that Tessa Jowell stood for the Labour Party in 2010, but has no entry for 2015 (because, as the <tt>standing_in</tt> tells us) she's not standing in 2015."
 msgstr "Yn yr un modd bydd gan y gwrthrych hwn yr allweddi '2010' neu '2015' ac yn dweud wrthych pa blaid oedd/mae yr ymgeisydd yn sefyll yn yr etholiad cyffredinol y flwyddyn honno. Fel yn yr enghraifft uchod, gallwch weld bod Tessa Jowell wedi sefyll dros y Blaid Lafur yn 2010, ond does dim cofnod ohoni ar gyfer 2015 (oherwydd, fel noder y <tt>standing_in</tt>) doedd hi ddim yn sefyll yn 2015."
 
 #: candidates/templates/candidates/api.html:245
@@ -1075,38 +946,20 @@ msgid "More complex (Full Popolo information)"
 msgstr "Mwy cymhleth (GwybodaethPopolo cyflawn)"
 
 #: candidates/templates/candidates/api.html:247
-msgid ""
-"All the candidates we know about for a constituency can be returned by "
-"making a GET request to a URL of this form, where you should substitute in "
-"the constituency ID for CONSTITUENCY_ID:"
+msgid "All the candidates we know about for a constituency can be returned by making a GET request to a URL of this form, where you should substitute in the constituency ID for CONSTITUENCY_ID:"
 msgstr "Gellir gweld pob un o'r ymgeiswyr a gwyddom am ar gyfer etholaeth drwy wneud cais GET i wegyfeiriad  y ffurflen hon, lle dylech roi CONSTITUENCY_ID yn lle cyfeirnod yr etholaeth:"
 
 #: candidates/templates/candidates/api.html:258
 #, python-format
-msgid ""
-"For example, for Dulwich and West Norwood, <a "
-"href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">these"
-" would be the results</a>. To explain further, that's showing information "
-"about the <em>post</em> \"MP for Dulwich and West Norwood\". Under the "
-"<tt>memberships</tt> key of the <tt>result</tt> dictionary you can find all "
-"memberships of this post - those that have the <tt>role</tt> \"Candidate\" "
-"were candidates at one point."
+msgid "For example, for Dulwich and West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">these would be the results</a>. To explain further, that's showing information about the <em>post</em> \"MP for Dulwich and West Norwood\". Under the <tt>memberships</tt> key of the <tt>result</tt> dictionary you can find all memberships of this post - those that have the <tt>role</tt> \"Candidate\" were candidates at one point."
 msgstr "Er enghraifft, ar gyfer Dulwich a Gorllewin Norwood,  <a href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\"> dyma fydda'r canlyniadau</a>. I esbonio ymhellach, mae'n dangos gwybodaeth am yr <em>etholaeth</em>\"MP Dulwich a Gorllewin Norwood\".  O dan allwedd <tt>memberships</tt> o rhestr <tt>result</tt> gallwch ddod o hyd i holl aelodaethau ar gyfer yr etholaeth - pob un gyda  <tt>role</tt> Roedd y rhai a enwir yn \"Candidate\"yn ymgeiswyr ar un adeg."
 
 #: candidates/templates/candidates/api.html:268
-msgid ""
-"You should then look at the start and end dates of that membership, which "
-"will tell you whether they're a candidate for the 2015 election or were a "
-"past candidate for the 2010 election:"
+msgid "You should then look at the start and end dates of that membership, which will tell you whether they're a candidate for the 2015 election or were a past candidate for the 2010 election:"
 msgstr "Yna dylech edrych ar y dyddiadau dechrau a diwedd yr aelodaeth honno, a bydd yn dweud wrthych p'un a ydyn nhw yn ymgeisydd ar gyfer etholiad 2015 neu 2010:"
 
 #: candidates/templates/candidates/api.html:281
-msgid ""
-"Under <tt>person_id</tt> attribute of each of those membership you can find "
-"information about that candidate, like their name, contact details and (in "
-"another nested <tt>memberships</tt> object) their memberships of political "
-"parties. The party memberships use the same date values as above to indicate"
-" whether it's their party membership at the 2010 or 2015 election."
+msgid "Under <tt>person_id</tt> attribute of each of those membership you can find information about that candidate, like their name, contact details and (in another nested <tt>memberships</tt> object) their memberships of political parties. The party memberships use the same date values as above to indicate whether it's their party membership at the 2010 or 2015 election."
 msgstr "O dan briodoledd person <tt>person_id</tt> pob un o'r aelodaethau hynny, cewch wybodaeth am yr ymgeisydd hwnnw, fel enw, manylion cyswllt ac (o fewn gwrthrych <tt>memberships</tt> arall) eu haelodaeth o'r pleidiau gwleidyddol. Mae aelodaeth y blaid yn defnyddio'r un gwerthoedd dyddiad fel uchod i ddangos aelodaeth plaid/pleidiau yn  etholiadau'r gorffennol (2010 neu 2015)."
 
 #: candidates/templates/candidates/api.html:293
@@ -1114,19 +967,12 @@ msgid "Find a candidate by name"
 msgstr "Darganfod ymgeisydd o'r enw"
 
 #: candidates/templates/candidates/api.html:295
-msgid ""
-"You can use the <tt>search/persons</tt> endpoint with a query paramter like "
-"<tt>q=name:\"John Doe\"</tt>."
+msgid "You can use the <tt>search/persons</tt> endpoint with a query paramter like <tt>q=name:\"John Doe\"</tt>."
 msgstr "I ddarganfod unigolyn gallwch ddefnyddio <tt>chwilio/personau</tt> gydag ymholiad megis <tt>q=name:\"John Doe\"</tt>."
 
 #: candidates/templates/candidates/api.html:304
 #, python-format
-msgid ""
-"For example, you can find every David Jones in the database with <a "
-"href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this "
-"query</a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt>"
-" elements will give you details about which constituencies they are / were "
-"standing in, and for which parties."
+msgid "For example, you can find every David Jones in the database with <a href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this query</a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt> elements will give you details about which constituencies they are / were standing in, and for which parties."
 msgstr "Er enghraifft, gallwch weld pob David Jones yn y gronfa ddata gyda chwiliad <a href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">fel hyn</a>. Fel y nodir uchod, bydd yr elfennau <tt>standing_in</tt> a <tt>party_memberships</tt>   yn datgelu manylion ynghylch pa etholaethau maent yn neu wedi cystadlu, ac am y pleidiau."
 
 #: candidates/templates/candidates/api.html:313
@@ -1135,19 +981,12 @@ msgstr "Gael pob ymgeisydd 2015 o'r bas data"
 
 #: candidates/templates/candidates/api.html:315
 #, python-format
-msgid ""
-"You can also use the <tt>search/persons</tt> endpoint to find all the "
-"candidates that we think are standing in 2015, with <a "
-"href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id "
-"\">this query</a>:"
+msgid "You can also use the <tt>search/persons</tt> endpoint to find all the candidates that we think are standing in 2015, with <a href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id \">this query</a>:"
 msgstr "Gallwch hefyd ddefnyddio <tt>search/persons</tt> i ddod o hyd i holl ymgeiswyr yr ydym yn credu sy'n sefyll yn 2015, gyda'r <a href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id \"> ymholiad hwn</a>:"
 
 #: candidates/templates/candidates/api.html:326
 #, python-format
-msgid ""
-"(This question was raised on the <a href=\"%(url)s\">Democracy Club Google "
-"Group</a>, which may be of interest if you're developing software that uses "
-"the %(site.name)s data.)"
+msgid "(This question was raised on the <a href=\"%(url)s\">Democracy Club Google Group</a>, which may be of interest if you're developing software that uses the %(site.name)s data.)"
 msgstr ""
 
 #: candidates/templates/candidates/areas-of-type.html:10
@@ -1173,22 +1012,13 @@ msgstr ""
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:22
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:22
 #, python-format
-msgid ""
-"Before you carry on to edit data in %(site_name)s, we need you to agree that"
-" your contributions to this site (with the exception of photo uploads) are "
-"owned by %(copyright_holder)s. In return, we agree to make the complete "
-"database available under an open licence such as <a "
-"href=\"http://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or "
-"remove copyright restrictions by releasing into the public domain (<a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
+msgid "Before you carry on to edit data in %(site_name)s, we need you to agree that your contributions to this site (with the exception of photo uploads) are owned by %(copyright_holder)s. In return, we agree to make the complete database available under an open licence such as <a href=\"http://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or remove copyright restrictions by releasing into the public domain (<a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:42
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:42
 #, python-format
-msgid ""
-"I assign the copyright of my contributions to %(site_name)s (apart from "
-"photo uploads) to %(copyright_holder)s."
+msgid "I assign the copyright of my contributions to %(site_name)s (apart from photo uploads) to %(copyright_holder)s."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:49
@@ -1199,10 +1029,7 @@ msgstr "Pahau"
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:53
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:53
 #, python-format
-msgid ""
-"Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a "
-"href=\"mailto:%(email)s\">email us</a> if you have any questions about this "
-"agreement."
+msgid "Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a href=\"mailto:%(email)s\">email us</a> if you have any questions about this agreement."
 msgstr "Nau gallwch  <a href=\"%(url)s\">allgofnodi</a>. Croeso ichi <a href=\"mailto:%(email)s\">ebostio</a> gydag ymholiadau am y cytundeb."
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:61
@@ -1212,12 +1039,7 @@ msgstr "Pam yr ydym yn gofyn ichi gytuno i hyn?"
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:63
 #, python-format
-msgid ""
-"This is the simplest way to ensure that we can make this data as widely "
-"available as possible while preventing the hard work of contributors to "
-"%(site_name)s being unfairly co-opted by companies building closed candidate"
-" databases. This also allows us the flexibility to release the data under "
-"different open licenses in the future."
+msgid "This is the simplest way to ensure that we can make this data as widely available as possible while preventing the hard work of contributors to %(site_name)s being unfairly co-opted by companies building closed candidate databases. This also allows us the flexibility to release the data under different open licenses in the future."
 msgstr ""
 
 #: candidates/templates/candidates/candidacy-create.html:6
@@ -1228,10 +1050,7 @@ msgstr "Sut ydych chi'n gwybod bod %(name)s yn sefyll?"
 
 #: candidates/templates/candidates/candidacy-create.html:14
 #, python-format
-msgid ""
-"Before updating our records we need to know the source for your information "
-"that %(name)s is standing for election to the post of %(post_label)s in the "
-"%(election_name)s."
+msgid "Before updating our records we need to know the source for your information that %(name)s is standing for election to the post of %(post_label)s in the %(election_name)s."
 msgstr "Cyn diweddaru ein cofnodion mae angen inni wybod y ffynhonnell ar gyfer eich gwybodaeth bod %(name)s  yn sefyll ar gyfer etholiad i'r etholaeth %(post_label)s yn %(election_name)s."
 
 #: candidates/templates/candidates/candidacy-delete.html:6
@@ -1242,10 +1061,7 @@ msgstr "Sut ydych chi'n gwybod nad yw  %(name)s  yn sefyll?"
 
 #: candidates/templates/candidates/candidacy-delete.html:14
 #, python-format
-msgid ""
-"Before updating our records we need to know the source for your information "
-"that %(name)s <strong>isn’t</strong> standing for election to the post of "
-"%(post_label)s in the %(election_name)s."
+msgid "Before updating our records we need to know the source for your information that %(name)s <strong>isn’t</strong> standing for election to the post of %(post_label)s in the %(election_name)s."
 msgstr "Cyn diweddaru ein cofnodion mae angen inni wybod y ffynhonnell ar gyfer eich gwybodaeth <strong>nad</strong> yw %(name)s  yn sefyll ar gyfer  %(post_label)s yn %(election_name)s."
 
 #: candidates/templates/candidates/constituencies-declared.html:6
@@ -1287,9 +1103,7 @@ msgid "All Constituencies for the 2015 General Election"
 msgstr "Holl etholaethau ar gyfer yr etholiad cyffredinol 2015"
 
 #: candidates/templates/candidates/constituencies.html:14
-msgid ""
-"Follow one of the links below to see the known candidates for that "
-"constituency:"
+msgid "Follow one of the links below to see the known candidates for that constituency:"
 msgstr "Ddilyn un o'r dolenni isod i weld yr ymgeiswyr hysbys ar gyfer yr etholaeth honno:"
 
 #: candidates/templates/candidates/constituency.html:9
@@ -1323,8 +1137,7 @@ msgstr "@yournextmp"
 
 #: candidates/templates/candidates/constituency.html:35
 #, python-format
-msgid ""
-"Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
+msgid "Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr "Ymgeiswyr <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 
 #: candidates/templates/candidates/constituency.html:47
@@ -1335,10 +1148,7 @@ msgid "Invalidate Cache"
 msgstr "Annilysu'r Storfa (Cache)"
 
 #: candidates/templates/candidates/constituency.html:48
-msgid ""
-"As a staff user, you can invalidate any cached data for this constituency. "
-"This may <em>occasionally</em> be necessary if the page is showing stale "
-"information for more than 10 seconds."
+msgid "As a staff user, you can invalidate any cached data for this constituency. This may <em>occasionally</em> be necessary if the page is showing stale information for more than 10 seconds."
 msgstr "Fel defnyddiwr staff, gallwch annilysu unrhyw ddata sydd wedi'i storio ar gyfer yr etholaeth hon. Mae angen gwneud hyn <em>weithiau</em>  os yw'r dudalen yn dangos hen wybodaeth am 10 eiliad neu'n hirach."
 
 #: candidates/templates/candidates/frontpage.html:14
@@ -1352,9 +1162,7 @@ msgid "Find candidates to be your next representative"
 msgstr "Dod o hyd i ymgeiswyr i fod yn eich cynrychiolydd nesaf"
 
 #: candidates/templates/candidates/frontpage.html:34
-msgid ""
-"Don’t pay for a candidate database sold by a data vendor — it’s a waste of "
-"money."
+msgid "Don’t pay for a candidate database sold by a data vendor — it’s a waste of money."
 msgstr "Peidiwch dalu am fas ddata o ymgeiswyr gan werthwyr data - mae'n wastraff arian."
 
 #: candidates/templates/candidates/frontpage.html:44
@@ -1368,11 +1176,7 @@ msgstr "Dyma gronfa ddata sydd wedi ei dorfoli o ymgeiswyr yn yr etholiad."
 
 #: candidates/templates/candidates/frontpage.html:57
 #, python-format
-msgid ""
-"The database is transparently sourced and available as structured data, "
-"suitable for building other election websites. <a href=\"%(api_url)s\">Get "
-"the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new "
-"candidate details.</a>"
+msgid "The database is transparently sourced and available as structured data, suitable for building other election websites. <a href=\"%(api_url)s\">Get the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new candidate details.</a>"
 msgstr "Mae ffynonellau data'r gronfa ddata mor dryloyw â phosib ac mae o ar gael fel data strwythuredig, yn addas ar gyfer creu gwefannau etholiad eraill.  <a href=\"%(api_url)s\">Mynnwch gopi o'r data</a>, neu <a href=\"%(tasks_url)s\">gallwch ein helpu drwy gyfrannu manylion ymgeiswyr newydd.</a>"
 
 #: candidates/templates/candidates/frontpage.html:70
@@ -1381,102 +1185,67 @@ msgstr "Newidiadau diweddar"
 
 #: candidates/templates/candidates/frontpage.html:77
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new "
-"candidate</a> <span class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new candidate</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "Ychwanegodd y defnyddiwr <strong>%(username)s</strong> <a href=\"%(person_url)s\">ymgeisydd newydd</a> <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:83
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> is creating a new candidate <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> is creating a new candidate <span class=\"when\">%(when)s ago</span>"
 msgstr "Mae <strong>%(username)s</strong> wrthi'n ychwanegu ymgeisydd newydd ers <span class=\"when\">%(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:89
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> merged another candidate into <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> merged another candidate into <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "Cyfunodd defnyddiwr  <strong>%(username)s</strong> manylion ymgeisydd arall gyda  <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:95
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> uploaded a photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> uploaded a photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span class=\"when\">%(when)s ago</span>"
 msgstr "Llwythodd <strong>%(username)s</strong> llun o <a href=\"%(person_url)s\">ymgeisydd #%(person_id)s</a> i'w gymedroli <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:101
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> approved an uploaded photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> approved an uploaded photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "Cymeradwyodd defnyddiwr <strong>%(username)s</strong> llun a oedd wedi ei lwytho o <a href=\"%(person_url)s\">ymgeisydd #%(person_id)s</a> <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:107
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> rejected an uploaded photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> rejected an uploaded photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "Gwrthododd defnyddiwr <strong>%(username)s</strong> llun a oedd wedi ei lwytho o <a href=\"%(person_url)s\">ymgeisydd #%(person_id)s</a> <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:113
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> reverted to an earlier version of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> reverted to an earlier version of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "Penderfynodd defnyddiwr <strong>%(username)s</strong> mynd yn ôl at fersiwn cynharach o lun o <a href=\"%(person_url)s\">ymgeisydd #%(person_id)s</a> <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:119
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> confirmed candidacy for <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> confirmed candidacy for <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "Cadarnhaodd <strong>%(username)s</strong> ymgeisyddiaeth  <a href=\"%(person_url)s\">ymgeisydd #%(person_id)s</a> ers <span class=\"when\">%(when)s </span>"
 
 #: candidates/templates/candidates/frontpage.html:125
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> removed candidacy for <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> removed candidacy for <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "Tynnodd neu negyddodd <strong>%(username)s</strong> ymgeisyddiaeth  <a href=\"%(person_url)s\">ymgeisydd #%(person_id)s</a> <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:131
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> locked a constituency <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> locked a constituency <span class=\"when\">%(when)s ago</span>"
 msgstr "Gwnaeth <strong>%(username)s</strong> gloi etholaeth  <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:135
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> unlocked a constituency <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> unlocked a constituency <span class=\"when\">%(when)s ago</span>"
 msgstr "Gwnaeth <strong>%(username)s</strong> dad-gloi etholaeth  <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:139
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> marked <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> as the winner <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> marked <a href=\"%(person_url)s\">candidate #%(person_id)s</a> as the winner <span class=\"when\">%(when)s ago</span>"
 msgstr "Nododd <strong>%(username)s</strong> fod <a href=\"%(person_url)s\">ymgeisydd #%(person_id)s</a> wedi ennill  <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:145
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> updated <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> updated <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "Diweddarodd <strong>%(username)s</strong>  <a href=\"%(person_url)s\">ymgeisydd #%(person_id)s</a> <span class=\"when\">%(when)s yn ôl</span>"
 
 #: candidates/templates/candidates/frontpage.html:154
@@ -1517,24 +1286,19 @@ msgstr "Nifer o olygyddiadau"
 #: candidates/templates/candidates/ordered-party-list.html:9
 #: candidates/templates/candidates/ordered-party-list.html:32
 #, python-format
-msgid ""
-"Party list of %(party_name)s for %(post_label_shorter)s in the "
-"%(election_name)s"
+msgid "Party list of %(party_name)s for %(post_label_shorter)s in the %(election_name)s"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:16
 #: candidates/templates/candidates/ordered-party-list.html:22
 #: candidates/templates/candidates/ordered-party-list.html:27
 #, python-format
-msgid ""
-"Party list of %(party_name)s for %(post_label_shorter)s in the %(election)s"
+msgid "Party list of %(party_name)s for %(post_label_shorter)s in the %(election)s"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:35
 #, python-format
-msgid ""
-"Party list of %(party_name)s for <span id=\"constituency-"
-"name\">%(post_label_shorter)s</span>"
+msgid "Party list of %(party_name)s for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:45
@@ -1544,9 +1308,7 @@ msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:85
 #, python-format
-msgid ""
-"<strong>Oh no!</strong> We don’t know of any candidates from %(party.name)s "
-"for %(post_label)s for the %(election_name)s yet."
+msgid "<strong>Oh no!</strong> We don’t know of any candidates from %(party.name)s for %(post_label)s for the %(election_name)s yet."
 msgstr ""
 
 #: candidates/templates/candidates/party-list.html:6
@@ -1564,43 +1326,30 @@ msgstr "Holl bleidiau ag unrhyw ymgeiswyr sy'n sefyll yn %(election_name)s"
 
 #: candidates/templates/candidates/party.html:8
 #, python-format
-msgid ""
-"%(party_name)s &#8212; Candidates by constituency for the UK 2015 General "
-"Election"
+msgid "%(party_name)s &#8212; Candidates by constituency for the UK 2015 General Election"
 msgstr "%(party_name)s &#8212;  Ymgeiswyr fesul etholaeth ar gyfer etholiad cyffredinol 2015 y DU"
 
 #: candidates/templates/candidates/party.html:20
-msgid ""
-"This shows all the constituencies that have independent candidates standing "
-"in them at the 2015 general election"
+msgid "This shows all the constituencies that have independent candidates standing in them at the 2015 general election"
 msgstr "Mae hyn yn dangos yr etholaethau gydag ymgeiswyr annibynnol yn sefyll ynddynt yn etholiad cyffredinol 2015"
 
 #: candidates/templates/candidates/party.html:25
-msgid ""
-"The Speaker of the House of Commons stands as a \"The Speaker seeking re-"
-"election\" rather than a particular party at a general election; for more "
-"information, please see <a href=\"http://www.parliament.uk/about/faqs/house-"
-"of-commons-faqs/speakers-election/\">Parliament's website</a>."
+msgid "The Speaker of the House of Commons stands as a \"The Speaker seeking re-election\" rather than a particular party at a general election; for more information, please see <a href=\"http://www.parliament.uk/about/faqs/house-of-commons-faqs/speakers-election/\">Parliament's website</a>."
 msgstr "Saif Llefarydd Tŷ'r Cyffredin fel 'Llefarydd sy'n ceisio ail-etholiad' yn hytrach na blaid benodol yn yr etholiad cyffredinol; am fwy o wybodaeth, gweler <a href=\"http://www.parliament.uk/about/faqs/house-of-commons-faqs/speakers-election/\"> gwefan y Senedd yn Llundain</a>."
 
 #: candidates/templates/candidates/party.html:33
 #, python-format
-msgid ""
-"%(party_name)s is on the Electoral Commission's register for %(register)s."
+msgid "%(party_name)s is on the Electoral Commission's register for %(register)s."
 msgstr "Mae %(party_name)s ar gofrestr Y Comisiwn Etholiadol ar gyfer  %(register)s."
 
 #: candidates/templates/candidates/party.html:35
 #, python-format
-msgid ""
-"You can find more data about the party's registration at the <a "
-"href=\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
+msgid "You can find more data about the party's registration at the <a href=\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
 msgstr "Mae 'na fwy o ddata am gofrestriad y blaid ar <a href=\"%(ec_url)s\">dudalen y Comisiwn Etholiadol %(party_name)s</a>."
 
 #: candidates/templates/candidates/party.html:51
 #, python-format
-msgid ""
-"<a href=\"%(person_url)s\">%(name)s</a> is standing in <a "
-"href=\"%(post_url)s\">%(post)s</a>"
+msgid "<a href=\"%(person_url)s\">%(name)s</a> is standing in <a href=\"%(post_url)s\">%(post)s</a>"
 msgstr "<a href=\"%(person_url)s\">%(name)s</a> is standing in <a href=\"%(post_url)s\">%(post)s</a>"
 
 #: candidates/templates/candidates/party.html:55
@@ -1610,16 +1359,12 @@ msgstr "Dim ymgeiswyr yn  <a href=\"%(post_url)s\">%(constituency_name)s</a>"
 
 #: candidates/templates/candidates/party.html:63
 #, python-format
-msgid ""
-"There were also %(missing)s posts in %(country)s that %(party_name)s aren't "
-"standing a candidate for."
+msgid "There were also %(missing)s posts in %(country)s that %(party_name)s aren't standing a candidate for."
 msgstr "Roedd yna hefyd  %(missing)s etholaeth yn %(country)s ble nad yw  %(party_name)s yn cystadlu."
 
 #: candidates/templates/candidates/party.html:68
 #, python-format
-msgid ""
-"There were also %(missing)s posts that %(party_name)s aren't standing a "
-"candidate for."
+msgid "There were also %(missing)s posts that %(party_name)s aren't standing a candidate for."
 msgstr "Roedd yna hefyd  %(missing)s etholaeth nad yw  %(party_name)s yn cystadlu."
 
 #: candidates/templates/candidates/party.html:75
@@ -1680,9 +1425,7 @@ msgid "Additional information:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:246
-msgid ""
-"<strong>You forgot to reference a source!</strong> Can you show us "
-"<em>where</em> you got this information?"
+msgid "<strong>You forgot to reference a source!</strong> Can you show us <em>where</em> you got this information?"
 msgstr "<strong>Mae angen nodi'r ffynhonell</strong> O <em>ble </em> ddaethoch o hyd i'r wybodaeth?"
 
 #: candidates/templates/candidates/person-edit.html:248
@@ -1694,10 +1437,7 @@ msgid "Thanks for helping out!"
 msgstr "Diolch am eich cymorth."
 
 #: candidates/templates/candidates/person-edit.html:265
-msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
-"fields</a>."
+msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields</a>."
 msgstr "Darllenwch ein  <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">canllaw ar ddarganfod y maesydd amrywiol</a>."
 
 #: candidates/templates/candidates/person-edit.html:271
@@ -1706,9 +1446,7 @@ msgstr "Yn ceisio lanlwytho llun?"
 
 #: candidates/templates/candidates/person-edit.html:273
 #, python-format
-msgid ""
-"There’s a separate page for <a href=\"%(url)s\">uploading a photo of "
-"%(name)s</a>."
+msgid "There’s a separate page for <a href=\"%(url)s\">uploading a photo of %(name)s</a>."
 msgstr "Mae yna dudalen penodol ar gyfer <a href=\"%(url)s\">llwytho llun o %(name)s</a>."
 
 #: candidates/templates/candidates/person-edit.html:281
@@ -1814,9 +1552,7 @@ msgstr "Ni etholwyd %(name)s"
 
 #: candidates/templates/candidates/person-view.html:95
 #, python-format
-msgid ""
-"We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by"
-" adding one</a>!"
+msgid "We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by adding one</a>!"
 msgstr "Nid oes gennym gyfeiriad ebost ar gyfer %(name)s, <a href=\"%(url)s\"> helpwch ni drwy ychwanegu un</a>!"
 
 #: candidates/templates/candidates/person-view.html:104
@@ -1901,8 +1637,7 @@ msgid "Our database is built by people like you."
 msgstr "Mae ein cronfa ddata wedi'i hadeiladu gan bobl fel chi."
 
 #: candidates/templates/candidates/person-view.html:215
-msgid ""
-"Please do add extra details about this candidate – it only takes a moment."
+msgid "Please do add extra details about this candidate – it only takes a moment."
 msgstr "Ychwanegwch fanylion am yr ymgeisydd - jobyn dau funud."
 
 #: candidates/templates/candidates/person-view.html:218
@@ -1923,16 +1658,11 @@ msgstr "Data agored API JSON:"
 
 #: candidates/templates/candidates/person-view.html:238
 #, python-format
-msgid ""
-"More details about getting <a href=\"%(api_url)s\">the data</a> and <a "
-"href=\"%(about_url)s\">its license</a>."
+msgid "More details about getting <a href=\"%(api_url)s\">the data</a> and <a href=\"%(about_url)s\">its license</a>."
 msgstr "Rhagor o fanylion am gael  <a href=\"%(api_url)s\">y data</a> a'i <a href=\"%(about_url)s\">drwydded</a>."
 
 #: candidates/templates/candidates/person-view.html:247
-msgid ""
-"As a staff user, you can invalidate any cached data for this user. This may "
-"<em>occasionally</em> be necessary if the page is showing stale information "
-"for more than 10 seconds."
+msgid "As a staff user, you can invalidate any cached data for this user. This may <em>occasionally</em> be necessary if the page is showing stale information for more than 10 seconds."
 msgstr "Fel defnyddiwr staff, gallwch annilysu unrhyw ddata sydd wedi'i storio ar gyfer y defnyddiwr hwn.  Mae angen gwneud hwn <em> weithiau< /em > pan mae'r dudalen yn dangos hen wybodaeth am 10 eiliad neu ragor."
 
 #: candidates/templates/candidates/popit_down.html:7
@@ -1950,9 +1680,7 @@ msgid "Sorry, %(site_name)s is temporarily unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:26
-msgid ""
-"This usually means that we’re having to do some brief maintenance, and the "
-"site will be back soon."
+msgid "This usually means that we’re having to do some brief maintenance, and the site will be back soon."
 msgstr "Cynnal a chadw yn mynd rhagddi, mwy na thebyg."
 
 #: candidates/templates/candidates/posts.html:9
@@ -1962,8 +1690,7 @@ msgstr "Holl etholaethau etholiadau cyfredol"
 
 #: candidates/templates/candidates/posts.html:14
 #: elections/st_paul_municipal_2015/templates/candidates/posts.html:14
-msgid ""
-"Follow one of the links below to see the known candidates for that post:"
+msgid "Follow one of the links below to see the known candidates for that post:"
 msgstr "Dilynwch un o'r dolenni isod i weld rhestr o'r ymgeiswyr sy'n hysbys inni ar gyfer yr etholaeth:"
 
 #: candidates/templates/candidates/privacy.html:6
@@ -1988,29 +1715,20 @@ msgid "This site is run by %(site_owner)s."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:28
-msgid ""
-"We make the following promises about your personal information as a user of "
-"the site:"
+msgid "We make the following promises about your personal information as a user of the site:"
 msgstr "Dyma ein hymroddiad i ddiogelu eich gwybodaeth bersonol fel defnyddiwr y wefan hon:"
 
 #: candidates/templates/candidates/privacy.html:34
-msgid ""
-"We will not sell or distribute your email address or other personal "
-"information."
+msgid "We will not sell or distribute your email address or other personal information."
 msgstr "Byddwn ni ddim yn gwerthu neu ddosbarthu eich cyfeiriad ebost neu wybodaeth bersonol arall."
 
 #: candidates/templates/candidates/privacy.html:38
-msgid ""
-"We will gladly show you the personal data we store about you in order to run"
-" the website."
+msgid "We will gladly show you the personal data we store about you in order to run the website."
 msgstr "Byddwn yn ddigon fodlon i rannu eich data personol gyda chi - y data rydym yn storio amdanoch chi er mwyn rhedeg y wefan."
 
 #: candidates/templates/candidates/privacy.html:44
 #, python-format
-msgid ""
-"We may use your email address to contact you about your use of the site if "
-"it's problematic (or particularly helpful!), or with occasional "
-"announcements about %(site_name)s and other %(site_owner)s projects."
+msgid "We may use your email address to contact you about your use of the site if it's problematic (or particularly helpful!), or with occasional announcements about %(site_name)s and other %(site_owner)s projects."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:51
@@ -2018,27 +1736,15 @@ msgid "Details"
 msgstr "Manylion"
 
 #: candidates/templates/candidates/privacy.html:53
-msgid ""
-"As well as your login details, we store your IP address along with any "
-"changes you make to the data on the site.  All this information is "
-"accessible to administrators of the site."
+msgid "As well as your login details, we store your IP address along with any changes you make to the data on the site.  All this information is accessible to administrators of the site."
 msgstr "Yn ogystal ag eich manylion mewngofnodi, rydym yn storio eich cyfeiriad IP ynghyd ag unrhyw newidiadau a wnewch i'r data ar y safle. Mae'r holl wybodaeth hyn ar gael i weinyddwyr y safle."
 
 #: candidates/templates/candidates/privacy.html:59
-msgid ""
-"Please note that this policy refers to the personal information arising from"
-" creating a login on the site, not the personal information about candidates"
-" for elections - the reason for the site to exist is to make information "
-"about those candidates available to members of the public and website "
-"developers so that they can find out more about those candidates, their "
-"promises and policy positions."
+msgid "Please note that this policy refers to the personal information arising from creating a login on the site, not the personal information about candidates for elections - the reason for the site to exist is to make information about those candidates available to members of the public and website developers so that they can find out more about those candidates, their promises and policy positions."
 msgstr "Nodwch fod y polisi hwn yn cyfeirio at y wybodaeth bersonol sy'n deillio o greu cyfleuster mewngofnodi ar y safle, nid y wybodaeth bersonol am ymgeiswyr ar gyfer etholiadau. Mae'r wefan  yn bodoli er mwyn hwyluso argaeledd gwybodaeth am ymgeiswyr i'r cyhoedd ac i ddatblygwyr gwefannau fel y gallant ganfod mwy am yr ymgeiswyr hynny, eu haddewidion a safbwyntiau polisi."
 
 #: candidates/templates/candidates/privacy.html:69
-msgid ""
-"We also use Google Analytics to aggregate and track data about usage of the "
-"site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a "
-"browser plugin to opt out of having data collected by Google Analytics</a>."
+msgid "We also use Google Analytics to aggregate and track data about usage of the site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a browser plugin to opt out of having data collected by Google Analytics</a>."
 msgstr "Rydym hefyd yn defnyddio Google Analytics i gasglu a dilyn data am ddefnydd o'r safle. Gallwch ddefnyddio <a href=\"https://tools.google.com/dlpage/gaoptout/\"> ategyn porwr er mwyn peidio â rhannu data a gasglwyd gyda Google Analytics</a>."
 
 #: candidates/templates/candidates/recent-changes.html:6
@@ -2096,11 +1802,7 @@ msgstr "Ie wir, %(name)s (%(party)s) enillodd yn  %(constituency_name)s"
 
 #: candidates/templates/candidates/update-disallowed.html:16
 #, python-format
-msgid ""
-"As a precaution, this update hasn't been allowed, but details have been "
-"emailed to the team of %(site.name)s volunteers; they will apply the change "
-"after checking it. If you have any questions about this, please email <a "
-"href=\"%(email)s\">%(email)s</a>."
+msgid "As a precaution, this update hasn't been allowed, but details have been emailed to the team of %(site.name)s volunteers; they will apply the change after checking it. If you have any questions about this, please email <a href=\"%(email)s\">%(email)s</a>."
 msgstr ""
 
 #: candidates/templatetags/metadescription.py:23
@@ -2120,8 +1822,7 @@ msgstr "Safodd %(name)s ar gyfer %(party)s yn %(post)s in %(election)s"
 
 #: candidates/templatetags/metadescription.py:29
 #, python-format
-msgid ""
-"%(name)s is standing as an independent candidate in %(post)s in %(election)s"
+msgid "%(name)s is standing as an independent candidate in %(post)s in %(election)s"
 msgstr "Mae %(name)s yn sefyll fel ymgeisydd annibynnol yn %(post)s yn %(election)s"
 
 #: candidates/templatetags/metadescription.py:31
@@ -2330,75 +2031,39 @@ msgid "Unknown MapIt error for postcode \"{0}\""
 msgstr "Gwall MapIt annisgwyl ar gyfer y cod post  \"{0}\""
 
 #: elections/uk_general_election_2015/templates/base.html:24
-msgid ""
-"Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a "
-"href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a "
-"href=\"https://mysociety.org\">mySociety</a>."
+msgid "Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a href=\"https://mysociety.org\">mySociety</a>."
 msgstr "Cefnogwyd gan  <a href=\"https://fullfact.org\">Full Fact</a>, <a href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, a <a href=\"https://mysociety.org\">mySociety</a>."
 
 #: elections/uk_general_election_2015/templates/base.html:31
 #, python-format
-msgid ""
-"Built by <a href=\"%(site_managers_url)s\"> <img src=\"%(logo_url)s\" %%} "
-"alt=\"%(site_managers)s\" class=\"dc-logo\"></a>"
+msgid "Built by <a href=\"%(site_managers_url)s\"> <img src=\"%(logo_url)s\" %%} alt=\"%(site_managers)s\" class=\"dc-logo\"></a>"
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:17
 #, python-format
-msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or"
-" bug reports. If you'd like to discuss this site or any other project "
-"relating to elections in the UK, we'd suggest that you post to the <a "
-"href=\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy "
-"Club Google Group</a>."
+msgid "Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or bug reports. If you'd like to discuss this site or any other project relating to elections in the UK, we'd suggest that you post to the <a href=\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy Club Google Group</a>."
 msgstr "Ebostiwch <a href=\"mailto:%(email)s\">%(email)s</a> er mwyn rhoi adborth neu i son am unrhyw wallau. Os hoffech chi drafod y safle hwn, neu unrhyw brosiect arall sy'n ymwneud ag etholiadau yn y DU, byddem yn awgrymu eich bod yn postio ar <a href=\"https://groups.google.com/forum/#!forum/democracy-club\">Grŵp GoogleDemocracy Club </a>."
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:34
-msgid ""
-"This site was originally developed by Mark Longair (mySociety), Sym Roe "
-"(Democracy Club) and Zarino Zappia (mySociety) and <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many"
-" other contributors</a>, to whom we owe a debt of gratitude."
+msgid "This site was originally developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety) and <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many other contributors</a>, to whom we owe a debt of gratitude."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:41
-msgid ""
-"The data on candidates from the last UK general election in 2010 is all "
-"taken from Edmund von der Burg's <a "
-"href=\"http://www.yournextmp.com\">YourNextMP.com</a>, with many thanks."
+msgid "The data on candidates from the last UK general election in 2010 is all taken from Edmund von der Burg's <a href=\"http://www.yournextmp.com\">YourNextMP.com</a>, with many thanks."
 msgstr "Daw'r holl ddata am ymgeiswyr yn etholiad cyffredinol y DU yn 2010 o <a href=\"http://www.yournextmp.com\">YourNextMP.com</a>,  Edmund von der Burg, gyda llawer o ddiolch."
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:58
-msgid ""
-"The party logos, which are taken from the Electoral Commission's website"
+msgid "The party logos, which are taken from the Electoral Commission's website"
 msgstr "Daw logos y pleidiau o wefan y Comisiwn Etholiadol"
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:73
 #, python-format
-msgid ""
-"For complicated reasons relating to database licensing, we have put the data"
-" as of the 4th of March 2015 into the public domain by declaring it to be <a"
-" href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This "
-"data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-"
-"date/\">here</a> but please be warned that this snapshot will become "
-"inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date "
-"data</a> instead."
+msgid "For complicated reasons relating to database licensing, we have put the data as of the 4th of March 2015 into the public domain by declaring it to be <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-date/\">here</a> but please be warned that this snapshot will become inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date data</a> instead."
 msgstr "Am resymau yn ymwneud a thrwyddedu'r bas-ddata, rydym wedi trosglwyddo data ers 4 Mawrth 2015 i'r parth cyhoeddus dan drwydded <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. Mae'r ddata ar gael <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-date/\">yma</a> ond cofiwch bydd pethau'n newid yn gyflym. Gwell defnyddio <a href=\"%(api_url)s\">y data diweddaraf</a>."
 
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:63
 #, python-format
-msgid ""
-"When we originally set up %(site_name)s for the 2015 UK general election we "
-"didn't get legal advice about the best way to deal with copyright and "
-"licensing. It turns out that the way that the user agreement that was worded"
-" on the 'About' page had a few problems, and in particular restricted what "
-"we could do with the data such that we couldn't license the database to some"
-" partners who we thought would make good use of the data but who needed "
-"slightly different licensing. The simplest way to ensure that we can make "
-"the data as widely available as possible while preventing the hard work of "
-"contributors to %(site_name)s being co-opted by companies building closed "
-"candidate databases is to ask you to assign the copyright of your "
-"contributions to %(copyright_holder)s."
+msgid "When we originally set up %(site_name)s for the 2015 UK general election we didn't get legal advice about the best way to deal with copyright and licensing. It turns out that the way that the user agreement that was worded on the 'About' page had a few problems, and in particular restricted what we could do with the data such that we couldn't license the database to some partners who we thought would make good use of the data but who needed slightly different licensing. The simplest way to ensure that we can make the data as widely available as possible while preventing the hard work of contributors to %(site_name)s being co-opted by companies building closed candidate databases is to ask you to assign the copyright of your contributions to %(copyright_holder)s."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/finder.html:14
@@ -2412,9 +2077,7 @@ msgid "The popit_person_id must be all digits"
 msgstr "Rhaid mai dim ond rhifau sydd yn y popit_person_id "
 
 #: moderation_queue/forms.py:39
-msgid ""
-"If you checked 'Other' then you must provide a justification for why we can "
-"use it."
+msgid "If you checked 'Other' then you must provide a justification for why we can use it."
 msgstr "Wedi dewis 'Arall' rhaid cyfiawnhau pam mae modd ei ddefnyddio."
 
 #: moderation_queue/models.py:20
@@ -2438,15 +2101,11 @@ msgid "This photograph is free of any copyright restrictions"
 msgstr "Does dim rhwystrau hawlfraint ar y llun yma"
 
 #: moderation_queue/models.py:35
-msgid ""
-"I own copyright of this photo and I assign the copyright to Democracy Club "
-"Limited in return for it being displayed on this site"
+msgid "I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on this site"
 msgstr ""
 
 #: moderation_queue/models.py:39
-msgid ""
-"This is the candidate's public profile photo from social media (e.g. "
-"Twitter, Facebook) or their official campaign page"
+msgid "This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page"
 msgstr "Daw'r llun hwn o'r ymgeisydd o'u cyfrif cyfryngau cymdeithasol (e.e. Twitter, Facebook) neu dudalen ymgyrch swyddogol"
 
 #: moderation_queue/models.py:43
@@ -2460,12 +2119,8 @@ msgstr "Rhanwyd y llun o {popit_person_id} gan y defnyddiwr  {user}"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:7
 #, python-format
-msgid ""
-"<strong>Warning:</strong> there is already %(queued_images)s photo of "
-"%(name)s in the queue, waiting to be moderated:"
-msgid_plural ""
-"<strong>Warning:</strong> there are already %(queued_images)s photos of "
-"%(name)s in the queue, waiting to be moderated:"
+msgid "<strong>Warning:</strong> there is already %(queued_images)s photo of %(name)s in the queue, waiting to be moderated:"
+msgid_plural "<strong>Warning:</strong> there are already %(queued_images)s photos of %(name)s in the queue, waiting to be moderated:"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
@@ -2478,9 +2133,7 @@ msgstr "Llwythwyr y llun gan %(name)s - %(created)s"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:25
 #, python-format
-msgid ""
-"If you still want to upload another photo of %(name)s, first select an image"
-" from your computer:"
+msgid "If you still want to upload another photo of %(name)s, first select an image from your computer:"
 msgstr "Os am lwytho llun arall o %(name)s, dewiswch lun o'ch cyfrifiadur i gychwyn:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:29
@@ -2488,15 +2141,11 @@ msgid "First, select an image from your computer:"
 msgstr "Dewis delwedd o'ch cyfrifiadur i gychwyn:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:38
-msgid ""
-"Now let us know about the copyright of this image by selecting one of these "
-"options or explaining why we can use it:"
+msgid "Now let us know about the copyright of this image by selecting one of these options or explaining why we can use it:"
 msgstr "Gadewch inni wybod am hawlfraint y delwedd gan ddewis un o'r opsiynau ac egluro pam ei fod yn iawn inni ei ddefnyddio:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:47
-msgid ""
-"Here is my justification for why this photo may be reasonably used on the "
-"website, including the source URL:"
+msgid "Here is my justification for why this photo may be reasonably used on the website, including the source URL:"
 msgstr "Cyfiawnhad gyda chyfeiriad gwefan i egluro pam y gellid cyhoeddi'r llun yma:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:54
@@ -2536,19 +2185,12 @@ msgstr "Adolygu a thocio llun"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:30
 #, python-format
-msgid ""
-"Please check that this is really <a href=\"%(url)s\">%(name)s</a> "
-"(%(party)s) before approving the upload. This <a "
-"href=\"%(google_image_search_url)s\">Google Image search for candidate "
-"details</a> may be a good start."
+msgid "Please check that this is really <a href=\"%(url)s\">%(name)s</a> (%(party)s) before approving the upload. This <a href=\"%(google_image_search_url)s\">Google Image search for candidate details</a> may be a good start."
 msgstr "Gwirwch mai lun o  <a href=\"%(url)s\">%(name)s</a> (%(party)s) yw hyn cyn ei gymeradwyo. Beth am ddechrau gyda'r <a href=\"%(google_image_search_url)s\">archwiliad delwedd Google am ymgeisydd</a>?"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:36
 #, python-format
-msgid ""
-"If you're trying to find the likely <em>source</em> of this image, you can "
-"also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image "
-"search</a> on the uploaded image."
+msgid "If you're trying to find the likely <em>source</em> of this image, you can also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image search</a> on the uploaded image."
 msgstr "Os am chwilio am  <em>ffynhonnell</em> tebyg ar gyfer y ddelwedd, mae'n bosib <a href=\"%(google_reverse_image_search_url)s\">chwilio ar Google am fanylion y llun</a>."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:41
@@ -2556,9 +2198,7 @@ msgid "Click and drag in the image to crop"
 msgstr "Clicio a llusgo delwedd i'w dorri"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:43
-msgid ""
-"Please crop to just around the candidate's head, since they're displayed in "
-"thumbnail form on the site."
+msgid "Please crop to just around the candidate's head, since they're displayed in thumbnail form on the site."
 msgstr "Tociwch i ddangos pen yr ymgeisydd yn unig, am mai llun bach fydd ar y wefan."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:68
@@ -2603,16 +2243,12 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:113
 #, python-format
-msgid ""
-"%(username)s said that this is the candidate's public profile photo from "
-"social media or their official campaign page"
+msgid "%(username)s said that this is the candidate's public profile photo from social media or their official campaign page"
 msgstr "Dywedodd %(username)s mai dyma lun cyhoeddus yr ymgeisydd o broffil cyfryngau cymdeithasol neu dudalen ymgyrch swyddogol."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:120
 #, python-format
-msgid ""
-"%(username)s's justification for use of this photo was: "
-"&#8220;%(justification)s&#8221;"
+msgid "%(username)s's justification for use of this photo was: &#8220;%(justification)s&#8221;"
 msgstr "Cyfiawnhad %(username)s's dros ddefnyddio'r llun hwn oedd: &#8220;%(justification)s&#8221;"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:128
@@ -2632,9 +2268,7 @@ msgid "Why <em>you</em> think it's allowed:"
 msgstr "Y rheswm eich bod <em>chi</em> yn teimlo fod hyn yn iawn: "
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:151
-msgid ""
-"Reason for rejection (<strong>Warning:</strong> this will be emailed to the "
-"user):"
+msgid "Reason for rejection (<strong>Warning:</strong> this will be emailed to the user):"
 msgstr "Rheswm dros ei wrthod.  (<strong>Rhybudd:</strong> ceir ei ebostio ar y defnyddiwr):"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:158
@@ -2665,10 +2299,7 @@ msgstr "Mae'r llun yn barod ar gyfer cymedroli"
 
 #: moderation_queue/templates/moderation_queue/photo-upload-success.html:15
 #, python-format
-msgid ""
-"Thank-you for uploading a photo - you will receive an email when it is "
-"approved to be added to the site, or an explanation for why it cannot be "
-"used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
+msgid "Thank-you for uploading a photo - you will receive an email when it is approved to be added to the site, or an explanation for why it cannot be used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
 msgstr "Diolch am lanlwytho llun. Wedi iddo cael ei gymeradwyo byddwch yn derbyn ebost, neu esboniad am pam na ellir ei ddefnyddio. <a href=\"%(url)s\">Dychwelyd i dudalen  %(name)s.</a> "
 
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
@@ -2682,9 +2313,7 @@ msgstr "Cymeradwywyd o'r pwll o luniau a gymeradwywyd"
 
 #: moderation_queue/views.py:290
 #, python-brace-format
-msgid ""
-"Approved a photo upload from {uploading_user} who provided the message: "
-"\"{message}\""
+msgid "Approved a photo upload from {uploading_user} who provided the message: \"{message}\""
 msgstr "Cymeradwywyd: llun a lanlwythwyd gan {uploading_user} gyda'r neges : \"{message}\""
 
 #: moderation_queue/views.py:316
@@ -2737,9 +2366,7 @@ msgstr "Gadawsoch lun o {0} yn y rhestr i'w gymedroli"
 
 #: moderation_queue/views.py:407
 #, python-brace-format
-msgid ""
-"Ignored a photo upload from {uploading_user} (This usually means it was a "
-"duplicate)"
+msgid "Ignored a photo upload from {uploading_user} (This usually means it was a duplicate)"
 msgstr "Anwybyddwyd llun a lanlwythwyd gan {uploading_user} (Fel arfer, i osgoi ailadrodd llun yw'r rheswm)"
 
 #: moderation_queue/views.py:420
@@ -2795,8 +2422,7 @@ msgstr "Cofrestri"
 
 #: mysite/templates/account/signup.html:13
 #, python-format
-msgid ""
-"Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
+msgid "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr "Os oes gennych gyfrif,  <a href=\"%(login_url)s\">mewngofnodwch</a> os gwelwch chi'n dda."
 
 #: mysite/templates/generic_base.html:71
@@ -2834,9 +2460,7 @@ msgstr "Does dim  %(type)s ar gyfer yr etholaeth  %(post_data.label)s."
 
 #: official_documents/templates/official_documents/_post.html:30
 #, python-format
-msgid ""
-"As you have permission to upload documents, you can <a "
-"href=\"%(url)s\">upload a %(type)s</a>."
+msgid "As you have permission to upload documents, you can <a href=\"%(url)s\">upload a %(type)s</a>."
 msgstr "Am fod gennych ganiatâd i lanlwytho dogfennau, gallwch  <a href=\"%(url)s\">lanlwytho %(type)s</a>."
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:16
@@ -2846,16 +2470,12 @@ msgstr "%(type)s ar gyfer <a href=\"%(url)s\">%(post_label)s</a>."
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:19
 #, python-format
-msgid ""
-"The source URL for this document was: <a "
-"href=\"%(source_url)s\">%(source_url)s</a>"
+msgid "The source URL for this document was: <a href=\"%(source_url)s\">%(source_url)s</a>"
 msgstr "Gwegyfeiriad ffynhonnell y ddogfen hon oedd : <a href=\"%(source_url)s\">%(source_url)s</a>"
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:32
 #, python-format
-msgid ""
-"You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to "
-"delete it)"
+msgid "You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to delete it)"
 msgstr "Gallwch <a href=\"%(url)s\">olygu hon yn rhyngwyneb y gweithredwr/aig </a> (e.e. os am ei ddileu)"
 
 #: official_documents/templates/official_documents/upload_document_form.html:5
@@ -2882,9 +2502,7 @@ msgstr "Enillodd {name} ({party}) yn {cons}"
 
 #: results/feeds.py:28
 #, python-brace-format
-msgid ""
-"A {site_name} volunteer recorded at {datetime} that {name} ({party}) won the"
-" ballot in {cons}, quoting the source '{source}')."
+msgid "A {site_name} volunteer recorded at {datetime} that {name} ({party}) won the ballot in {cons}, quoting the source '{source}')."
 msgstr ""
 
 #: results/feeds.py:84
@@ -2907,17 +2525,12 @@ msgstr[3] ""
 
 #: tasks/templates/tasks/field.html:14
 #, python-format
-msgid ""
-"Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
+msgid "Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
 msgstr "Allan o %(num_candidates_2015)s ymgeisydd,  mae  (%(percent_empty)s%% blank) ar goll"
 
 #: tasks/templates/tasks/field.html:21
 #, python-format
-msgid ""
-"Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make"
-" sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
-"fields.</a>"
+msgid "Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields.</a>"
 msgstr "Rhowch <a href=\"%(url)s\"> gymorth</a> drwy ychwanegu gwybodaeth sydd ar goll. Gwnewch yn siŵr ichi ddarllen ein <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\"> canllawiau ar gyrchu meysydd. </a>"
 
 #: tasks/templates/tasks/field.html:35
@@ -2926,9 +2539,7 @@ msgstr "golygu"
 
 #: tasks/templates/tasks/field.html:38
 #, python-format
-msgid ""
-"Hi @%(username)s could you add your %(field)s to your %(site_name)s page "
-"please? https://yournextmp.com/person/%(id)s/"
+msgid "Hi @%(username)s could you add your %(field)s to your %(site_name)s page please? https://yournextmp.com/person/%(id)s/"
 msgstr ""
 
 #: tasks/templates/tasks/field.html:41
@@ -2958,15 +2569,11 @@ msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:12
 #, python-format
-msgid ""
-"%(site_name)s is a volunteer-sourced database, and that means we constantly "
-"need help in making it better."
+msgid "%(site_name)s is a volunteer-sourced database, and that means we constantly need help in making it better."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:17
-msgid ""
-"There is a lot of useful information on candidates out there, so if you find"
-" any please do add it to our site."
+msgid "There is a lot of useful information on candidates out there, so if you find any please do add it to our site."
 msgstr "Mae llawer o wybodaeth ddefnyddiol ar gael am yr ymgeiswyr, felly croeso ichi ei ychwanegu at ein safle."
 
 #: tasks/templates/tasks/tasks_home.html:22
@@ -2974,15 +2581,11 @@ msgid "Emails"
 msgstr "Ebyst"
 
 #: tasks/templates/tasks/tasks_home.html:24
-msgid ""
-"At the moment we're trying to get as many email addresses on candidates as "
-"we can."
+msgid "At the moment we're trying to get as many email addresses on candidates as we can."
 msgstr "Ar hyn o bryd, rydym yn ceisio cael cynifer o gyfeiriadau ebost ymgeiswyr ag y gallwn."
 
 #: tasks/templates/tasks/tasks_home.html:29
-msgid ""
-"This will allow us to email them directly to ask them to add their own "
-"details."
+msgid "This will allow us to email them directly to ask them to add their own details."
 msgstr "Bydd hyn yn caniatáu inni eu hebostio  yn uniongyrchol er mwyn gofyn iddynt ychwanegu manylion eu hunain."
 
 #: tasks/templates/tasks/tasks_home.html:34
@@ -2991,49 +2594,29 @@ msgstr "Sut i gynorthwyo"
 
 #: tasks/templates/tasks/tasks_home.html:37
 #, python-format
-msgid ""
-"First off you'll need to <a href=\"%(url)s\">log in</a> in order to start "
-"making edits."
+msgid "First off you'll need to <a href=\"%(url)s\">log in</a> in order to start making edits."
 msgstr "Cyn dechrau golygu <a href=\"%(url)s\">mewngofnodwch</a>"
 
 #: tasks/templates/tasks/tasks_home.html:43
 #, python-format
-msgid ""
-"We've added clear banners on the candidate and constituently pages "
-"indicating where we're missing email addresses, so you can start adding "
-"email addresses by <a href=\"%(url)s\">looking up your constituency on the "
-"home page</a>"
+msgid "We've added clear banners on the candidate and constituently pages indicating where we're missing email addresses, so you can start adding email addresses by <a href=\"%(url)s\">looking up your constituency on the home page</a>"
 msgstr "Rydym wedi fflagio bylchau ar dudalennau ymgeiswyr ac etholaethau fel y gallwch ychwanegu cyfeiriadau ebyst.  <a href=\"%(url)s\">Gallwch ddod o hyd i'ch etholaeth ar yr hafan</a> "
 
 #: tasks/templates/tasks/tasks_home.html:50
-msgid ""
-"Once you've found a candidate without an email address, you can go searching"
-" for it!"
+msgid "Once you've found a candidate without an email address, you can go searching for it!"
 msgstr "Unwaith eich bod wedi canfod ymgeisydd heb gyfeiriad ebost, gallwch fynd ati i chwilio amdano!"
 
 #: tasks/templates/tasks/tasks_home.html:55
-msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing "
-"fields</a>, and specifically the part about what sort of email addresses we "
-"accept."
+msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing fields</a>, and specifically the part about what sort of email addresses we accept."
 msgstr "Darllenwch ein <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\"> canllawiau ar gyrchu caeau</a>, ac yn benodol y rhan ynghylch pa fath o gyfeiriadau ebost a dderbyniwn."
 
 #: tasks/templates/tasks/tasks_home.html:62
-msgid ""
-"In short, we only want email addresses could be considered public and "
-"related to the candidate's campaign. <code>@parliament.uk</code> email "
-"addresses will stop working once Parliament is disbanded, so try to find a "
-"different email address for them if you can. If not, we can always email "
-"everyone with a <code>@parliament.uk</code> address asking them for a better"
-" one."
+msgid "In short, we only want email addresses could be considered public and related to the candidate's campaign. <code>@parliament.uk</code> email addresses will stop working once Parliament is disbanded, so try to find a different email address for them if you can. If not, we can always email everyone with a <code>@parliament.uk</code> address asking them for a better one."
 msgstr "Yn fyr, dim ond ebyst gellid eu hystyried yn gyfeiriadau cyhoeddus a chysylltiedig ag ymgyrch yr ymgeisydd yr ydym am gyhoeddi. Daw cyfeiriadau <code>@parliament.uk</code> i ben unwaith i'r senedd yno cael ei ddiddymu. Felly ceisiwch ddod o hyd i gyfeiriad ebost gwahanol ar eu cyfer os gallwch. Os nad yw hyn yn bosib, gallem ebostio pawn gydag ebost  <code>@parliament.uk</code> a gofyn iddynt am gyfeiriad hir-dymor."
 
 #: tasks/templates/tasks/tasks_home.html:72
 #, python-format
-msgid ""
-"Once your constituency has all the email addresses entered, you can look at "
-"our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
+msgid "Once your constituency has all the email addresses entered, you can look at our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
 msgstr "Unwaith mae holl gyfeiriadau ebost eich etholaeth wedi eu cofnodi, gallwch edrych ar ein <a href=\"%(url)s\"> rhestr o'r holl ymgeiswyr sydd heb gyfeiriad ebost</a>!"
 
 #~ msgid "%(site_name)s"

--- a/locale/cy_GB/LC_MESSAGES/django.po
+++ b/locale/cy_GB/LC_MESSAGES/django.po
@@ -73,13 +73,8 @@ msgstr "Pa etholaethau sydd gyda'r nifer lleiaf o ymgeiswyr hyd yma?"
 
 #: cached_counts/templates/reports.html:15
 #, python-format
-msgid ""
-"\n"
-"        You can see a list of all the posts in current elections\n"
-"        <a href=\"%(url)s\">ordered starting with those with the fewest\n"
-"        candidates</a>.\n"
-"     "
-msgstr "\nEdrychwch ar restr trefnus o etholaethau\n<a href=\"%(url)s\">gan ddechrau gyda'r rhai gyda'r nifer leiaf o ymgeiswyr</a>."
+msgid "You can see a list of all the posts in current elections <a href=\"%(url)s\">ordered starting with those with the fewest candidates</a>."
+msgstr "Edrychwch ar restr trefnus o etholaethau <a href=\"%(url)s\">gan ddechrau gyda'r rhai gyda'r nifer leiaf o ymgeiswyr</a>."
 
 #: cached_counts/templates/reports.html:26
 msgid "Current Elections"
@@ -684,43 +679,27 @@ msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:4
 #, python-format
-msgid ""
-"\n"
-"    Thank-you for adding <a href=\"%(person_url)s\">%(person_name)s</a>!\n"
-"  "
+msgid "Thank-you for adding <a href=\"%(person_url)s\">%(person_name)s</a>!"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:8
 #, python-format
-msgid ""
-"\n"
-"    Thank-you for updating <a href=\"%(person_url)s\">%(person_name)s</a>!\n"
-"  "
+msgid "Thank-you for updating <a href=\"%(person_url)s\">%(person_name)s</a>!"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:17
 #, python-format
-msgid ""
-"\n"
-"      <a href=\"%(person_edit_url)s\">Edit %(person_name)s again</a>\n"
-"    "
+msgid "<a href=\"%(person_edit_url)s\">Edit %(person_name)s again</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:22
 #, python-format
-msgid ""
-"\n"
-"      Add a candidate for <a href=\"%(needing_attention_url)s\">one of the\n"
-"      posts with fewest candidates</a>\n"
-"    "
+msgid "Add a candidate for <a href=\"%(needing_attention_url)s\">one of the posts with fewest candidates</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:29
 #, python-format
-msgid ""
-"\n"
-"        <a href=\"%(person_create_url)s\">Add another candidate in the %(election_name)s</a>\n"
-"      "
+msgid "<a href=\"%(person_create_url)s\">Add another candidate in the %(election_name)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-credit.html:8
@@ -1186,21 +1165,11 @@ msgid "Areas: %(all_area_names)s"
 msgstr "Ardaloedd: %(all_area_names)s"
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:7
-#: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:7
-#, python-format
-msgid ""
-"\n"
-"    %(site_name)s user agreement\n"
-"  "
-msgstr ""
-
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:14
+#: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:7
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:14
 #, python-format
-msgid ""
-"\n"
-"        %(site_name)s user agreement\n"
-"      "
+msgid "%(site_name)s user agreement"
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:22
@@ -1970,10 +1939,7 @@ msgstr "Fel defnyddiwr staff, gallwch annilysu unrhyw ddata sydd wedi'i storio a
 
 #: candidates/templates/candidates/popit_down.html:7
 #, python-format
-msgid ""
-"\n"
-"    %(site_name)s is Temporarily Unavailable\n"
-"  "
+msgid "%(site_name)s is Temporarily Unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:13
@@ -1982,10 +1948,7 @@ msgstr "Gwall"
 
 #: candidates/templates/candidates/popit_down.html:21
 #, python-format
-msgid ""
-"\n"
-"    Sorry, %(site_name)s is temporarily unavailable\n"
-"  "
+msgid "Sorry, %(site_name)s is temporarily unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:26
@@ -2797,11 +2760,9 @@ msgstr "Anwybyddwyd llun a lanlwythwyd gan {uploading_user} (Fel arfer, i osgoi 
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr "Gwnaethoch chi argymell fod llun {0} yn cael ei anwybyddu"
 
-#: mysite/settings.py:368
-msgid ""
-"Please don't quote third-party candidate sites —\n"
-"we prefer URLs of news stories or official candidate pages."
-msgstr "Peidiwch ddyfynu gwefannau trydydd parti os gwelwch chi'n dda —\nmae'n well gennym gwegyfeiriadau straeon newyddion neu o dudalennau swyddogol ymgeiswyr."
+#: mysite/settings.py:369
+msgid "Please don't quote third-party candidate sites — we prefer URLs of news stories or official candidate pages."
+msgstr "Peidiwch ddyfynu gwefannau trydydd parti os gwelwch chi'n dda — mae'n well gennym gwegyfeiriadau straeon newyddion neu o dudalennau swyddogol ymgeiswyr."
 
 #: mysite/templates/account/login.html:6 mysite/templates/account/login.html:9
 #: mysite/templates/account/login.html:42
@@ -2810,11 +2771,8 @@ msgstr "Mewngofnodi"
 
 #: mysite/templates/account/login.html:15
 #, python-format
-msgid ""
-"Please sign in with one\n"
-"of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign up</a>\n"
-"for a %(site_name)s account and sign in below:"
-msgstr "Mewngofnodwch gydag un o'ch\ncyfrifon trydydd parti. Neu,  <a href=\"%(signup_url)s\">ymunwch</a>\nar gyfer cyfrif  %(site_name)s a mewngofnodi isod:"
+msgid "Please sign in with one of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign up</a> for a %(site_name)s account and sign in below:"
+msgstr "Mewngofnodwch gydag un o'ch cyfrifon trydydd parti. Neu, <a href=\"%(signup_url)s\">ymunwch</a> ar gyfer cyfrif %(site_name)s a mewngofnodi isod:"
 
 #: mysite/templates/account/login.html:25
 msgid "or"
@@ -2822,10 +2780,8 @@ msgstr "neu"
 
 #: mysite/templates/account/login.html:32
 #, python-format
-msgid ""
-"If you have not created an account yet, then please\n"
-"<a href=\"%(signup_url)s\">sign up</a> first."
-msgstr "Os nad ydych wedi creu cyfrir eto\n<a href=\"%(signup_url)s\">ymaelodwch</a> yn gyntaf."
+msgid "If you have not created an account yet, then please <a href=\"%(signup_url)s\">sign up</a> first."
+msgstr "Os nad ydych wedi creu cyfrir eto <a href=\"%(signup_url)s\">ymaelodwch</a> yn gyntaf."
 
 #: mysite/templates/account/login.html:43
 msgid "Forgot Password?"
@@ -2858,11 +2814,8 @@ msgstr "Os oes gennych gyfrif,  <a href=\"%(login_url)s\">mewngofnodwch</a> os g
 
 #: mysite/templates/generic_base.html:37
 #, python-format
-msgid ""
-"\n"
-"           %(site_name)s\n"
-"        "
-msgstr ""
+msgid "%(site_name)s"
+msgstr "%(site_name)s"
 
 #: mysite/templates/generic_base.html:75
 msgid "Posts"

--- a/locale/cy_GB/LC_MESSAGES/django.po
+++ b/locale/cy_GB/LC_MESSAGES/django.po
@@ -1969,7 +1969,7 @@ msgstr "Dilynwch un o'r dolenni isod i weld rhestr o'r ymgeiswyr sy'n hysbys inn
 #: candidates/templates/candidates/privacy.html:6
 #: candidates/templates/candidates/privacy.html:9
 #: elections/ar_elections_2015/templates/base.html:110
-#: mysite/templates/generic_base.html:125
+#: mysite/templates/generic_base.html:121
 msgid "Privacy policy"
 msgstr "Polisi Preifatrwydd"
 
@@ -2237,29 +2237,29 @@ msgid "Provinces"
 msgstr "Taleithiau"
 
 #: elections/ar_elections_2015/templates/base.html:58
-#: mysite/templates/generic_base.html:82
+#: mysite/templates/generic_base.html:78
 #, python-format
 msgid "Signed in as <strong>%(username)s</strong>"
 msgstr "Wedi mewngofnodi i gyfrif <strong>%(username)s</strong>"
 
 #: elections/ar_elections_2015/templates/base.html:60
-#: mysite/templates/generic_base.html:83
+#: mysite/templates/generic_base.html:79
 msgid "Sign out"
 msgstr "Allgofnodi"
 
 #: elections/ar_elections_2015/templates/base.html:63
-#: mysite/templates/generic_base.html:87
+#: mysite/templates/generic_base.html:83
 msgid "Sign in to edit"
 msgstr "Mewngofnodi i olygu"
 
 #: elections/ar_elections_2015/templates/base.html:108
-#: mysite/templates/generic_base.html:122
+#: mysite/templates/generic_base.html:118
 msgid "Open data API"
 msgstr "Data agored yr API"
 
 #: elections/ar_elections_2015/templates/base.html:109
-#: mysite/templates/generic_base.html:74
-#: mysite/templates/generic_base.html:123
+#: mysite/templates/generic_base.html:70
+#: mysite/templates/generic_base.html:119
 msgid "About"
 msgstr "Amdanom Ni"
 
@@ -2799,20 +2799,15 @@ msgid ""
 "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr "Os oes gennych gyfrif,  <a href=\"%(login_url)s\">mewngofnodwch</a> os gwelwch chi'n dda."
 
-#: mysite/templates/generic_base.html:37
-#, python-format
-msgid "%(site_name)s"
-msgstr "%(site_name)s"
-
-#: mysite/templates/generic_base.html:75
+#: mysite/templates/generic_base.html:71
 msgid "Posts"
 msgstr "Etholaethau"
 
-#: mysite/templates/generic_base.html:76
+#: mysite/templates/generic_base.html:72
 msgid "Numbers"
 msgstr "Niferoedd"
 
-#: mysite/templates/generic_base.html:124
+#: mysite/templates/generic_base.html:120
 msgid "Issue tracker"
 msgstr "Traciwr materion"
 
@@ -3040,3 +3035,6 @@ msgid ""
 "Once your constituency has all the email addresses entered, you can look at "
 "our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
 msgstr "Unwaith mae holl gyfeiriadau ebost eich etholaeth wedi eu cofnodi, gallwch edrych ar ein <a href=\"%(url)s\"> rhestr o'r holl ymgeiswyr sydd heb gyfeiriad ebost</a>!"
+
+#~ msgid "%(site_name)s"
+#~ msgstr "%(site_name)s"

--- a/locale/cy_GB/LC_MESSAGES/django.po
+++ b/locale/cy_GB/LC_MESSAGES/django.po
@@ -460,17 +460,15 @@ msgstr "Ffynhonnell o wybodaeth eu bod nhw wedi ennill"
 msgid "{post_role} for {area_name}"
 msgstr "{post_role} ar gyfer {area_name}"
 
-#: candidates/middleware.py:43
-#, python-brace-format
-msgid ""
-"As a precaution, an update was blocked:\n"
-"\n"
-"  {0}\n"
-"\n"
-"If this update is appropriate, someone should apply it manually.\n"
-msgstr "Rhag ofn, rhwystwyd diweddariad\n\n{0}\n\nOs yw'r diweddariad yn briodol, dylie rhywun ei ychwanegu.\n"
+#: candidates/middleware.py:42
+msgid "As a precaution, an update was blocked:"
+msgstr "Rhag ofn, rhwystwyd diweddariad"
 
-#: candidates/middleware.py:50
+#: candidates/middleware.py:43
+msgid "If this update is appropriate, someone should apply it manually."
+msgstr "Os yw'r diweddariad yn briodol, dylie rhywun ei ychwanegu."
+
+#: candidates/middleware.py:51
 #, python-brace-format
 msgid "Disallowed {site_name} update for checking"
 msgstr ""
@@ -2673,36 +2671,7 @@ msgid ""
 "used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
 msgstr "Diolch am lanlwytho llun. Wedi iddo cael ei gymeradwyo byddwch yn derbyn ebost, neu esboniad am pam na ellir ei ddefnyddio. <a href=\"%(url)s\">Dychwelyd i dudalen  %(name)s.</a> "
 
-#: moderation_queue/templates/moderation_queue/photo_approved_email.txt:1
-#, python-format
-msgid ""
-"Thank-you for submitting a photo to %(site_name)s; that's been\n"
-"uploaded now for the candidate page here:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_approved_email.txt:6
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
-#, python-format
-msgid ""
-"Many thanks,\n"
-"The %(site_name)s volunteers"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:1
-#, python-format
-msgid ""
-"Thank-you for uploading a photo of %(candidate_name)s\n"
-"to %(site_name)s, but unfortunately we can't use that image because:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:6
-msgid ""
-"You can just reply to this email if you want to discuss that\n"
-"further, or you can try uploading a photo with a different reason\n"
-"or justification for its use using this link:"
-msgstr "Ymatebwch i'r ebost hwn os am drafod ymhellach, neu gallwch lanlwytho llun gwahanol gyda chyfiawnhad ar gyfer ei ddefnyddio gan ddefnyddio'r ddolen hon:"
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:16
 #, python-format
 msgid "For administrators' use: %(photo_review_url)s"
 msgstr "At ddefnydd gweinyddwyr: %(photo_review_url)s"
@@ -2711,51 +2680,69 @@ msgstr "At ddefnydd gweinyddwyr: %(photo_review_url)s"
 msgid "Approved from photo moderation queue"
 msgstr "Cymeradwywyd o'r pwll o luniau a gymeradwywyd"
 
-#: moderation_queue/views.py:289
+#: moderation_queue/views.py:290
 #, python-brace-format
 msgid ""
 "Approved a photo upload from {uploading_user} who provided the message: "
 "\"{message}\""
 msgstr "Cymeradwywyd: llun a lanlwythwyd gan {uploading_user} gyda'r neges : \"{message}\""
 
-#: moderation_queue/views.py:315
+#: moderation_queue/views.py:316
 #, python-brace-format
 msgid "{site_name} image upload approved"
 msgstr ""
 
-#: moderation_queue/views.py:328
+#: moderation_queue/views.py:325
+#, python-brace-format
+msgid "Thank-you for submitting a photo to {site_name}; that's been uploaded now for the candidate page here:"
+msgstr ""
+
+#: moderation_queue/views.py:330 moderation_queue/views.py:385
+msgid "Many thanks from the {{ site_name }} volunteers"
+msgstr ""
+
+#: moderation_queue/views.py:337
 #, python-format
 msgid "You approved a photo upload for %s"
 msgstr "Wnaethoch chi gymeradwyo lanlwythiad llun %s"
 
-#: moderation_queue/views.py:333
+#: moderation_queue/views.py:342
 #, python-brace-format
 msgid "Rejected a photo upload from {uploading_user}"
 msgstr "Gwrthodwyd lanlwythiad llun gan {uploading_user}"
 
-#: moderation_queue/views.py:352
+#: moderation_queue/views.py:361
 #, python-brace-format
 msgid "{site_name} image moderation results"
 msgstr ""
 
-#: moderation_queue/views.py:369
+#: moderation_queue/views.py:371
+#, python-brace-format
+msgid "Thank-you for uploading a photo of {candidate_name} to {site_name}, but unfortunately we can't use that image because:"
+msgstr ""
+
+#: moderation_queue/views.py:379
+msgid "You can just reply to this email if you want to discuss that further, or you can try uploading a photo with a different reason or justification for its use using this link:"
+msgstr "Ymatebwch i'r ebost hwn os am drafod ymhellach, neu gallwch lanlwytho llun gwahanol gyda chyfiawnhad ar gyfer ei ddefnyddio gan ddefnyddio'r ddolen hon:"
+
+#: moderation_queue/views.py:393
 #, python-format
 msgid "You rejected a photo upload for %s"
 msgstr "Gwnaethoch chi wrthod lanlwythiad llun am %s"
 
-#: moderation_queue/views.py:376
+#: moderation_queue/views.py:400
 #, python-brace-format
 msgid "You left a photo upload for {0} in the queue"
 msgstr "Gadawsoch lun o {0} yn y rhestr i'w gymedroli"
 
-#: moderation_queue/views.py:383
+#: moderation_queue/views.py:407
 #, python-brace-format
 msgid ""
 "Ignored a photo upload from {uploading_user} (This usually means it was a "
 "duplicate)"
 msgstr "Anwybyddwyd llun a lanlwythwyd gan {uploading_user} (Fel arfer, i osgoi ailadrodd llun yw'r rheswm)"
 
-#: moderation_queue/views.py:396
+#: moderation_queue/views.py:420
 #, python-brace-format
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr "Gwnaethoch chi argymell fod llun {0} yn cael ei anwybyddu"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -457,17 +457,15 @@ msgstr ""
 msgid "{post_role} for {area_name}"
 msgstr ""
 
-#: candidates/middleware.py:43
-#, python-brace-format
-msgid ""
-"As a precaution, an update was blocked:\n"
-"\n"
-"  {0}\n"
-"\n"
-"If this update is appropriate, someone should apply it manually.\n"
+#: candidates/middleware.py:42
+msgid "As a precaution, an update was blocked:"
 msgstr ""
 
-#: candidates/middleware.py:50
+#: candidates/middleware.py:43
+msgid "If this update is appropriate, someone should apply it manually."
+msgstr ""
+
+#: candidates/middleware.py:51
 #, python-brace-format
 msgid "Disallowed {site_name} update for checking"
 msgstr ""
@@ -2667,36 +2665,7 @@ msgid ""
 "used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
 msgstr ""
 
-#: moderation_queue/templates/moderation_queue/photo_approved_email.txt:1
-#, python-format
-msgid ""
-"Thank-you for submitting a photo to %(site_name)s; that's been\n"
-"uploaded now for the candidate page here:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_approved_email.txt:6
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
-#, python-format
-msgid ""
-"Many thanks,\n"
-"The %(site_name)s volunteers"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:1
-#, python-format
-msgid ""
-"Thank-you for uploading a photo of %(candidate_name)s\n"
-"to %(site_name)s, but unfortunately we can't use that image because:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:6
-msgid ""
-"You can just reply to this email if you want to discuss that\n"
-"further, or you can try uploading a photo with a different reason\n"
-"or justification for its use using this link:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:16
 #, python-format
 msgid "For administrators' use: %(photo_review_url)s"
 msgstr ""
@@ -2705,51 +2674,69 @@ msgstr ""
 msgid "Approved from photo moderation queue"
 msgstr ""
 
-#: moderation_queue/views.py:289
+#: moderation_queue/views.py:290
 #, python-brace-format
 msgid ""
 "Approved a photo upload from {uploading_user} who provided the message: "
 "\"{message}\""
 msgstr ""
 
-#: moderation_queue/views.py:315
+#: moderation_queue/views.py:316
 #, python-brace-format
 msgid "{site_name} image upload approved"
 msgstr ""
 
-#: moderation_queue/views.py:328
+#: moderation_queue/views.py:325
+#, python-brace-format
+msgid "Thank-you for submitting a photo to {site_name}; that's been uploaded now for the candidate page here:"
+msgstr ""
+
+#: moderation_queue/views.py:330 moderation_queue/views.py:385
+msgid "Many thanks from the {{ site_name }} volunteers"
+msgstr ""
+
+#: moderation_queue/views.py:337
 #, python-format
 msgid "You approved a photo upload for %s"
 msgstr ""
 
-#: moderation_queue/views.py:333
+#: moderation_queue/views.py:342
 #, python-brace-format
 msgid "Rejected a photo upload from {uploading_user}"
 msgstr ""
 
-#: moderation_queue/views.py:352
+#: moderation_queue/views.py:361
 #, python-brace-format
 msgid "{site_name} image moderation results"
 msgstr ""
 
-#: moderation_queue/views.py:369
+#: moderation_queue/views.py:371
+#, python-brace-format
+msgid "Thank-you for uploading a photo of {candidate_name} to {site_name}, but unfortunately we can't use that image because:"
+msgstr ""
+
+#: moderation_queue/views.py:379
+msgid "You can just reply to this email if you want to discuss that further, or you can try uploading a photo with a different reason or justification for its use using this link:"
+msgstr ""
+
+#: moderation_queue/views.py:393
 #, python-format
 msgid "You rejected a photo upload for %s"
 msgstr ""
 
-#: moderation_queue/views.py:376
+#: moderation_queue/views.py:400
 #, python-brace-format
 msgid "You left a photo upload for {0} in the queue"
 msgstr ""
 
-#: moderation_queue/views.py:383
+#: moderation_queue/views.py:407
 #, python-brace-format
 msgid ""
 "Ignored a photo upload from {uploading_user} (This usually means it was a "
 "duplicate)"
 msgstr ""
 
-#: moderation_queue/views.py:396
+#: moderation_queue/views.py:420
 #, python-brace-format
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr ""

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -71,12 +71,7 @@ msgstr ""
 
 #: cached_counts/templates/reports.html:15
 #, python-format
-msgid ""
-"\n"
-"        You can see a list of all the posts in current elections\n"
-"        <a href=\"%(url)s\">ordered starting with those with the fewest\n"
-"        candidates</a>.\n"
-"     "
+msgid "You can see a list of all the posts in current elections <a href=\"%(url)s\">ordered starting with those with the fewest candidates</a>."
 msgstr ""
 
 #: cached_counts/templates/reports.html:26
@@ -681,44 +676,27 @@ msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:4
 #, python-format
-msgid ""
-"\n"
-"    Thank-you for adding <a href=\"%(person_url)s\">%(person_name)s</a>!\n"
-"  "
+msgid "Thank-you for adding <a href=\"%(person_url)s\">%(person_name)s</a>!"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:8
 #, python-format
-msgid ""
-"\n"
-"    Thank-you for updating <a href=\"%(person_url)s\">%(person_name)s</a>!\n"
-"  "
+msgid "Thank-you for updating <a href=\"%(person_url)s\">%(person_name)s</a>!"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:17
 #, python-format
-msgid ""
-"\n"
-"      <a href=\"%(person_edit_url)s\">Edit %(person_name)s again</a>\n"
-"    "
+msgid "<a href=\"%(person_edit_url)s\">Edit %(person_name)s again</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:22
 #, python-format
-msgid ""
-"\n"
-"      Add a candidate for <a href=\"%(needing_attention_url)s\">one of the\n"
-"      posts with fewest candidates</a>\n"
-"    "
+msgid "Add a candidate for <a href=\"%(needing_attention_url)s\">one of the posts with fewest candidates</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:29
 #, python-format
-msgid ""
-"\n"
-"        <a href=\"%(person_create_url)s\">Add another candidate in the "
-"%(election_name)s</a>\n"
-"      "
+msgid "<a href=\"%(person_create_url)s\">Add another candidate in the %(election_name)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-credit.html:8
@@ -1183,21 +1161,11 @@ msgid "Areas: %(all_area_names)s"
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:7
-#: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:7
-#, python-format
-msgid ""
-"\n"
-"    %(site_name)s user agreement\n"
-"  "
-msgstr ""
-
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:14
+#: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:7
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:14
 #, python-format
-msgid ""
-"\n"
-"        %(site_name)s user agreement\n"
-"      "
+msgid "%(site_name)s user agreement"
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:22
@@ -1965,10 +1933,7 @@ msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:7
 #, python-format
-msgid ""
-"\n"
-"    %(site_name)s is Temporarily Unavailable\n"
-"  "
+msgid "%(site_name)s is Temporarily Unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:13
@@ -1977,10 +1942,7 @@ msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:21
 #, python-format
-msgid ""
-"\n"
-"    Sorry, %(site_name)s is temporarily unavailable\n"
-"  "
+msgid "Sorry, %(site_name)s is temporarily unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:26
@@ -2792,10 +2754,8 @@ msgstr ""
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr ""
 
-#: mysite/settings.py:368
-msgid ""
-"Please don't quote third-party candidate sites —\n"
-"we prefer URLs of news stories or official candidate pages."
+#: mysite/settings.py:369
+msgid "Please don't quote third-party candidate sites — we prefer URLs of news stories or official candidate pages."
 msgstr ""
 
 #: mysite/templates/account/login.html:6 mysite/templates/account/login.html:9
@@ -2805,11 +2765,7 @@ msgstr ""
 
 #: mysite/templates/account/login.html:15
 #, python-format
-msgid ""
-"Please sign in with one\n"
-"of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign "
-"up</a>\n"
-"for a %(site_name)s account and sign in below:"
+msgid "Please sign in with one of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign up</a> for a %(site_name)s account and sign in below:"
 msgstr ""
 
 #: mysite/templates/account/login.html:25
@@ -2818,9 +2774,7 @@ msgstr ""
 
 #: mysite/templates/account/login.html:32
 #, python-format
-msgid ""
-"If you have not created an account yet, then please\n"
-"<a href=\"%(signup_url)s\">sign up</a> first."
+msgid "If you have not created an account yet, then please <a href=\"%(signup_url)s\">sign up</a> first."
 msgstr ""
 
 #: mysite/templates/account/login.html:43
@@ -2854,10 +2808,7 @@ msgstr ""
 
 #: mysite/templates/generic_base.html:37
 #, python-format
-msgid ""
-"\n"
-"           %(site_name)s\n"
-"        "
+msgid "%(site_name)s"
 msgstr ""
 
 #: mysite/templates/generic_base.html:75

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -23,10 +23,7 @@ msgid "Permission denied"
 msgstr ""
 
 #: auth_helpers/templates/auth_helpers/group_permission_denied.html:14
-msgid ""
-"You must be in the member of a particular group in order to view that page. "
-"Please contact the administrators of the site if you feel that you should "
-"have access to this page."
+msgid "You must be in the member of a particular group in order to view that page. Please contact the administrators of the site if you feel that you should have access to this page."
 msgstr ""
 
 #: cached_counts/templates/attention_needed.html:5
@@ -126,16 +123,12 @@ msgstr ""
 
 #: cached_counts/templates/reports.html:58
 #, python-format
-msgid ""
-"Candidates standing again from the %(prior_election_name)s for the same "
-"party:"
+msgid "Candidates standing again from the %(prior_election_name)s for the same party:"
 msgstr ""
 
 #: cached_counts/templates/reports.html:62
 #, python-format
-msgid ""
-"Candidates standing again from the %(prior_election_name)s for a different "
-"party:"
+msgid "Candidates standing again from the %(prior_election_name)s for a different party:"
 msgstr ""
 
 #: cached_counts/templates/reports.html:74
@@ -159,8 +152,7 @@ msgstr ""
 
 #: candidates/diffs.py:40
 #, python-brace-format
-msgid ""
-"was known to be standing for the party with ID {party} in the {election}"
+msgid "was known to be standing for the party with ID {party} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:43 candidates/diffs.py:91
@@ -190,28 +182,22 @@ msgstr ""
 
 #: candidates/diffs.py:64
 #, python-brace-format
-msgid ""
-"is known to be standing for the post with ID {post_id} in the {election}"
+msgid "is known to be standing for the post with ID {post_id} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:66
 #, python-brace-format
-msgid ""
-"was known to be standing for the post with ID {post_id} in the {election}"
+msgid "was known to be standing for the post with ID {post_id} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:70
 #, python-brace-format
-msgid ""
-"is known to be standing in the constituency with MapIt URL {mapit_url} in "
-"the {election}"
+msgid "is known to be standing in the constituency with MapIt URL {mapit_url} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:72
 #, python-brace-format
-msgid ""
-"was known to be standing in the constituency with MapIt URL {mapit_url} in "
-"the {election}"
+msgid "was known to be standing in the constituency with MapIt URL {mapit_url} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:76 candidates/diffs.py:97
@@ -360,16 +346,12 @@ msgid "Program"
 msgstr ""
 
 #: candidates/forms.py:155
-msgid ""
-"The Twitter username must only consist of alphanumeric characters or "
-"underscore"
+msgid "The Twitter username must only consist of alphanumeric characters or underscore"
 msgstr ""
 
 #: candidates/forms.py:177
 #, python-brace-format
-msgid ""
-"If you mark the candidate as standing in the {election}, you must select a "
-"post"
+msgid "If you mark the candidate as standing in the {election}, you must select a post"
 msgstr ""
 
 #: candidates/forms.py:186
@@ -379,8 +361,7 @@ msgstr ""
 
 #: candidates/forms.py:192
 #, python-brace-format
-msgid ""
-"Could not find parties for the post with ID '{post_id}' in the {election}"
+msgid "Could not find parties for the post with ID '{post_id}' in the {election}"
 msgstr ""
 
 #: candidates/forms.py:200
@@ -437,9 +418,7 @@ msgstr ""
 
 #: candidates/forms.py:425
 #, python-brace-format
-msgid ""
-"You can only edit data on {site_name} if you agree to this copyright "
-"assignment."
+msgid "You can only edit data on {site_name} if you agree to this copyright assignment."
 msgstr ""
 
 #: candidates/forms.py:449
@@ -496,9 +475,7 @@ msgid "Name change from '{0}' to '{1}' by user {2} disallowed"
 msgstr ""
 
 #: candidates/models/auth.py:84
-msgid ""
-"That update isn't allowed because candidates for a locked post would be "
-"changed"
+msgid "That update isn't allowed because candidates for a locked post would be changed"
 msgstr ""
 
 #: candidates/models/db.py:29
@@ -553,10 +530,7 @@ msgid "(This list of candidates is currently <strong>unlocked</strong>.)"
 msgstr ""
 
 #: candidates/templates/candidates/_candidates_for_post.html:74
-msgid ""
-"This list of candidates is now <strong>locked</strong>; you can still update "
-"contact details of candidates, but can't change the people standing in this "
-"constituency."
+msgid "This list of candidates is now <strong>locked</strong>; you can still update contact details of candidates, but can't change the people standing in this constituency."
 msgstr ""
 
 #: candidates/templates/candidates/_candidates_for_post.html:83
@@ -606,9 +580,7 @@ msgstr ""
 
 #: candidates/templates/candidates/_candidates_for_post.html:150
 #, python-format
-msgid ""
-"<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s "
-"for the %(election_name)s yet."
+msgid "<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s for the %(election_name)s yet."
 msgstr ""
 
 #: candidates/templates/candidates/_candidates_for_post.html:154
@@ -644,8 +616,7 @@ msgid "Is a candidate from the 2010 election standing again?"
 msgstr ""
 
 #: candidates/templates/candidates/_candidates_for_post.html:200
-msgid ""
-"We don't know if these candidates from earlier elections are standing again"
+msgid "We don't know if these candidates from earlier elections are standing again"
 msgstr ""
 
 #: candidates/templates/candidates/_candidates_for_post.html:221
@@ -657,8 +628,7 @@ msgid "Not standing again"
 msgstr ""
 
 #: candidates/templates/candidates/_candidates_for_post.html:247
-msgid ""
-"These candidates from earlier elections are known not to be standing again"
+msgid "These candidates from earlier elections are known not to be standing again"
 msgstr ""
 
 #: candidates/templates/candidates/_candidates_for_post.html:267
@@ -667,9 +637,7 @@ msgstr ""
 
 #: candidates/templates/candidates/_edits_disallowed_message.html:2
 #, python-format
-msgid ""
-"Editing of data in %(site.name)s is now disabled, but if you have a "
-"correction, please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
+msgid "Editing of data in %(site.name)s is now disabled, but if you have a correction, please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:4
@@ -712,9 +680,7 @@ msgid "They commented: “%(user_comment)s”."
 msgstr ""
 
 #: candidates/templates/candidates/_photo-credit.html:18
-msgid ""
-"The volunteer moderator who reviewed this photo picked a different "
-"justification for its use on the site, which was:"
+msgid "The volunteer moderator who reviewed this photo picked a different justification for its use on the site, which was:"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-credit.html:27
@@ -728,22 +694,16 @@ msgid "Notes about this image: “%(notes)s”."
 msgstr ""
 
 #: candidates/templates/candidates/_photo-expand-reason.html:3
-msgid ""
-"the photo is free of copyright restrictions (i.e. has explictly been placed "
-"in the public domain)"
+msgid "the photo is free of copyright restrictions (i.e. has explictly been placed in the public domain)"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-expand-reason.html:8
 #, python-format
-msgid ""
-"they have assigned the copyright of the image to %(site_owner)s so that we "
-"may use it on the site"
+msgid "they have assigned the copyright of the image to %(site_owner)s so that we may use it on the site"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-expand-reason.html:13
-msgid ""
-"this photo is the candidate's profile on social media, or is used to promote "
-"their candidacy on an official candidate or party website"
+msgid "this photo is the candidate's profile on social media, or is used to promote their candidacy on an official candidate or party website"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-expand-reason.html:18
@@ -776,36 +736,22 @@ msgstr ""
 
 #: candidates/templates/candidates/about.html:17
 #, python-format
-msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or "
-"bug reports."
+msgid "Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or bug reports."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:22
 #: elections/uk_general_election_2015/templates/candidates/about.html:26
-msgid ""
-"The source code for this site is <a href=\"https://github.com/mysociety/"
-"yournextrepresentative/\">available on GitHub</a>, and you can find a <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/issues\">list of "
-"known bugs</a> there as well."
+msgid "The source code for this site is <a href=\"https://github.com/mysociety/yournextrepresentative/\">available on GitHub</a>, and you can find a <a href=\"https://github.com/mysociety/yournextrepresentative/issues\">list of known bugs</a> there as well."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:30
-msgid ""
-"This site was originally developed by Mark Longair (mySociety), Sym Roe "
-"(Democracy Club) and Zarino Zappia (mySociety), and <a href=\"https://github."
-"com/mysociety/yournextrepresentative/graphs/contributors\">many other "
-"contributors</a>, to whom we owe a debt of gratitude."
+msgid "This site was originally developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety), and <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many other contributors</a>, to whom we owe a debt of gratitude."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:38
 #: elections/uk_general_election_2015/templates/candidates/about.html:49
 #, python-format
-msgid ""
-"You can use the data from this site, via the <a href=\"%(api_url)s\">API or "
-"CSV download</a>, under the terms of the Creative Commons license <a href="
-"\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-ShareAlike "
-"(CC-BY-SA)</a> with the exception of:"
+msgid "You can use the data from this site, via the <a href=\"%(api_url)s\">API or CSV download</a>, under the terms of the Creative Commons license <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-ShareAlike (CC-BY-SA)</a> with the exception of:"
 msgstr ""
 
 #: candidates/templates/candidates/about.html:47
@@ -814,20 +760,13 @@ msgstr ""
 
 #: candidates/templates/candidates/about.html:48
 #: elections/uk_general_election_2015/templates/candidates/about.html:59
-msgid ""
-"Candidate photos, which are typically either submitted by the candidates "
-"themselves, or from sources where it seems reasonable that we might use them "
-"on this site, such as the party's official page for that candidate, or their "
-"social media profile picture."
+msgid "Candidate photos, which are typically either submitted by the candidates themselves, or from sources where it seems reasonable that we might use them on this site, such as the party's official page for that candidate, or their social media profile picture."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:56
 #: elections/uk_general_election_2015/templates/candidates/about.html:67
 #, python-format
-msgid ""
-"If the CC-BY-SA licence is problematic for you, but you feel that you have a "
-"worthwhile use of the data in mind, please <a href=\"mailto:%(email)s"
-"\">contact us</a> to discuss your situation further."
+msgid "If the CC-BY-SA licence is problematic for you, but you feel that you have a worthwhile use of the data in mind, please <a href=\"mailto:%(email)s\">contact us</a> to discuss your situation further."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:62
@@ -838,8 +777,7 @@ msgstr ""
 #: candidates/templates/candidates/about.html:65
 #: elections/uk_general_election_2015/templates/candidates/about.html:88
 #, python-format
-msgid ""
-"The privacy policy of this site can be found <a href=\"%(url)s\">here</a>."
+msgid "The privacy policy of this site can be found <a href=\"%(url)s\">here</a>."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:70
@@ -850,10 +788,7 @@ msgstr ""
 #: candidates/templates/candidates/about.html:72
 #: elections/uk_general_election_2015/templates/candidates/about.html:95
 #, python-format
-msgid ""
-"The data on this website is crowd-sourced and may not be complete (or may "
-"contain inaccuracies). If you find an error, please either update the page "
-"yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the problem."
+msgid "The data on this website is crowd-sourced and may not be complete (or may contain inaccuracies). If you find an error, please either update the page yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the problem."
 msgstr ""
 
 #: candidates/templates/candidates/all-edits-disallowed.html:6
@@ -874,11 +809,7 @@ msgid "Using this data via the API"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:16
-msgid ""
-"The data that's submitted to this site is available as a CSV/Excel download "
-"and programmatically via a RESTful web service called PopIt, which stores "
-"information about people and their positions in organizations. (You can <a "
-"href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
+msgid "The data that's submitted to this site is available as a CSV/Excel download and programmatically via a RESTful web service called PopIt, which stores information about people and their positions in organizations. (You can <a href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:24
@@ -916,10 +847,7 @@ msgid "The base API URL for the data is:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:72
-msgid ""
-"You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic "
-"documentation for the PopIt API</a> or just follow the simple examples that "
-"follow."
+msgid "You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic documentation for the PopIt API</a> or just follow the simple examples that follow."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:78
@@ -927,11 +855,7 @@ msgid "Find a Constituency ID"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:80
-msgid ""
-"In order to look up candidates for a constituency, you have to find the ID "
-"of that constituency. The IDs that we use for constituencies are the IDs for "
-"Westminster constituencies areas in another web service, <a href=\"http://"
-"mapit.mysociety.org\">MapIt</a>."
+msgid "In order to look up candidates for a constituency, you have to find the ID of that constituency. The IDs that we use for constituencies are the IDs for Westminster constituencies areas in another web service, <a href=\"http://mapit.mysociety.org\">MapIt</a>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:88
@@ -939,22 +863,15 @@ msgid "... from a postcode"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:90
-msgid ""
-"Suppose you want to find the constituency for the postcode SW1A&nbsp;1AA, "
-"then you would make a GET request to the following URL:"
+msgid "Suppose you want to find the constituency for the postcode SW1A&nbsp;1AA, then you would make a GET request to the following URL:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:100
-msgid ""
-"This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON "
-"object</a>, wherein the constituency ID can be found at <tt>.shortcuts.WMC</"
-"tt>."
+msgid "This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON object</a>, wherein the constituency ID can be found at <tt>.shortcuts.WMC</tt>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:106
-msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org/"
-"#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
+msgid "There's more documentation available on <a href=\"http://mapit.mysociety.org/#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:112
@@ -962,24 +879,15 @@ msgid "... from a latitude / longitude or other coordinate"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:114
-msgid ""
-"You can look up constituencies in MapIt using a variety of coordinate "
-"systems. To give the most common example, you might have a WGS84 coordinate "
-"from a GPS or location API, in which can you should put the SRID 4326 in "
-"your lookup. For example, latitude 52.205083 and longitude 0.115194 could be "
-"looked up with:"
+msgid "You can look up constituencies in MapIt using a variety of coordinate systems. To give the most common example, you might have a WGS84 coordinate from a GPS or location API, in which can you should put the SRID 4326 in your lookup. For example, latitude 52.205083 and longitude 0.115194 could be looked up with:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:126
-msgid ""
-"(Note that the longitude comes before the latitude, which might not be what "
-"you expect.) The only key in that object is the constituency ID."
+msgid "(Note that the longitude comes before the latitude, which might not be what you expect.) The only key in that object is the constituency ID."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:132
-msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org/"
-"#api-by_point\">point lookups on the MapIt front-page</a>."
+msgid "There's more documentation available on <a href=\"http://mapit.mysociety.org/#api-by_point\">point lookups on the MapIt front-page</a>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:138
@@ -987,18 +895,11 @@ msgid "... by selecting it from its name"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:140
-msgid ""
-"If you need to produce a list of all constituencies (e.g. for a select box) "
-"and allow the user to pick one, you can get a list of all Westminster "
-"constituencies in the UK from this request:"
+msgid "If you need to produce a list of all constituencies (e.g. for a select box) and allow the user to pick one, you can get a list of all Westminster constituencies in the UK from this request:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:150
-msgid ""
-"The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that "
-"request</a> has the constituency ID as its keys; the values are objects that "
-"include (among other things) a <tt>name</tt> element that gives you the "
-"official name of the constituency."
+msgid "The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that request</a> has the constituency ID as its keys; the values are objects that include (among other things) a <tt>name</tt> element that gives you the official name of the constituency."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:158
@@ -1006,12 +907,7 @@ msgid "Find Candidates for a Constituency"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:160
-msgid ""
-"There are broadly two ways you can approach getting candidate data for a "
-"constituency; one is slightly simpler, and just gives you the basic "
-"candidate and party information, while the second gives you the full data in "
-"Popolo format, which is more complex but useful if you're using tools that "
-"generically process Popolo data."
+msgid "There are broadly two ways you can approach getting candidate data for a constituency; one is slightly simpler, and just gives you the basic candidate and party information, while the second gives you the full data in Popolo format, which is more complex but useful if you're using tools that generically process Popolo data."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:169
@@ -1019,51 +915,28 @@ msgid "Simpler (Basic candidate information)"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:171
-msgid ""
-"You can get all the candidates for a constituency, both in 2010 and 2015 by "
-"a query like:"
+msgid "You can get all the candidates for a constituency, both in 2010 and 2015 by a query like:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:180
 #, python-format
-msgid ""
-"For example, for Dulwich and West Norwood, <a href="
-"\"%(popit_url)sposts/65808?embed=membership.person\">these would be the "
-"results</a>."
+msgid "For example, for Dulwich and West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person\">these would be the results</a>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:186
-msgid ""
-"If you iterate over the <tt>memberships</tt> in that result, each person "
-"will look something like:"
+msgid "If you iterate over the <tt>memberships</tt> in that result, each person will look something like:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:214
-msgid ""
-"(I've removed some fields there to keep the example simpler.) The two fields "
-"of particular interest are probably <tt>standing_in</tt> and "
-"<tt>party_memberships</tt>."
+msgid "(I've removed some fields there to keep the example simpler.) The two fields of particular interest are probably <tt>standing_in</tt> and <tt>party_memberships</tt>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:222
-msgid ""
-"This object will only have keys '2010' or '2015'. If one of these keys is "
-"present then we have known information about the candidate for the UK "
-"general election in that year.  If the value is <tt>null</tt> then we know "
-"that they're <em>not</em> standing. If they are (or were) standing in the "
-"general election in that year then there will be a dictionary giving you "
-"details of the constituency they were standing in. So, in the example above "
-"we can see that Tessa Jowell stood in 2010 in Dulwich and West Norwood, but "
-"we know isn't standing in any consituency in 2015."
+msgid "This object will only have keys '2010' or '2015'. If one of these keys is present then we have known information about the candidate for the UK general election in that year.  If the value is <tt>null</tt> then we know that they're <em>not</em> standing. If they are (or were) standing in the general election in that year then there will be a dictionary giving you details of the constituency they were standing in. So, in the example above we can see that Tessa Jowell stood in 2010 in Dulwich and West Norwood, but we know isn't standing in any consituency in 2015."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:236
-msgid ""
-"This object will similarly only have keys '2010' or '2015' and tells you "
-"what party the candidate is / was standing for in the general election of "
-"that year.  So in the example above, you can see that Tessa Jowell stood for "
-"the Labour Party in 2010, but has no entry for 2015 (because, as the "
-"<tt>standing_in</tt> tells us) she's not standing in 2015."
+msgid "This object will similarly only have keys '2010' or '2015' and tells you what party the candidate is / was standing for in the general election of that year.  So in the example above, you can see that Tessa Jowell stood for the Labour Party in 2010, but has no entry for 2015 (because, as the <tt>standing_in</tt> tells us) she's not standing in 2015."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:245
@@ -1071,38 +944,20 @@ msgid "More complex (Full Popolo information)"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:247
-msgid ""
-"All the candidates we know about for a constituency can be returned by "
-"making a GET request to a URL of this form, where you should substitute in "
-"the constituency ID for CONSTITUENCY_ID:"
+msgid "All the candidates we know about for a constituency can be returned by making a GET request to a URL of this form, where you should substitute in the constituency ID for CONSTITUENCY_ID:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:258
 #, python-format
-msgid ""
-"For example, for Dulwich and West Norwood, <a href="
-"\"%(popit_url)sposts/65808?embed=membership.person.membership.organization"
-"\">these would be the results</a>. To explain further, that's showing "
-"information about the <em>post</em> \"MP for Dulwich and West Norwood\". "
-"Under the <tt>memberships</tt> key of the <tt>result</tt> dictionary you can "
-"find all memberships of this post - those that have the <tt>role</tt> "
-"\"Candidate\" were candidates at one point."
+msgid "For example, for Dulwich and West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">these would be the results</a>. To explain further, that's showing information about the <em>post</em> \"MP for Dulwich and West Norwood\". Under the <tt>memberships</tt> key of the <tt>result</tt> dictionary you can find all memberships of this post - those that have the <tt>role</tt> \"Candidate\" were candidates at one point."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:268
-msgid ""
-"You should then look at the start and end dates of that membership, which "
-"will tell you whether they're a candidate for the 2015 election or were a "
-"past candidate for the 2010 election:"
+msgid "You should then look at the start and end dates of that membership, which will tell you whether they're a candidate for the 2015 election or were a past candidate for the 2010 election:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:281
-msgid ""
-"Under <tt>person_id</tt> attribute of each of those membership you can find "
-"information about that candidate, like their name, contact details and (in "
-"another nested <tt>memberships</tt> object) their memberships of political "
-"parties. The party memberships use the same date values as above to indicate "
-"whether it's their party membership at the 2010 or 2015 election."
+msgid "Under <tt>person_id</tt> attribute of each of those membership you can find information about that candidate, like their name, contact details and (in another nested <tt>memberships</tt> object) their memberships of political parties. The party memberships use the same date values as above to indicate whether it's their party membership at the 2010 or 2015 election."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:293
@@ -1110,19 +965,12 @@ msgid "Find a candidate by name"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:295
-msgid ""
-"You can use the <tt>search/persons</tt> endpoint with a query paramter like "
-"<tt>q=name:\"John Doe\"</tt>."
+msgid "You can use the <tt>search/persons</tt> endpoint with a query paramter like <tt>q=name:\"John Doe\"</tt>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:304
 #, python-format
-msgid ""
-"For example, you can find every David Jones in the database with <a href="
-"\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this query</"
-"a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt> "
-"elements will give you details about which constituencies they are / were "
-"standing in, and for which parties."
+msgid "For example, you can find every David Jones in the database with <a href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this query</a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt> elements will give you details about which constituencies they are / were standing in, and for which parties."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:313
@@ -1131,19 +979,12 @@ msgstr ""
 
 #: candidates/templates/candidates/api.html:315
 #, python-format
-msgid ""
-"You can also use the <tt>search/persons</tt> endpoint to find all the "
-"candidates that we think are standing in 2015, with <a href="
-"\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id \">this "
-"query</a>:"
+msgid "You can also use the <tt>search/persons</tt> endpoint to find all the candidates that we think are standing in 2015, with <a href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id \">this query</a>:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:326
 #, python-format
-msgid ""
-"(This question was raised on the <a href=\"%(url)s\">Democracy Club Google "
-"Group</a>, which may be of interest if you're developing software that uses "
-"the %(site.name)s data.)"
+msgid "(This question was raised on the <a href=\"%(url)s\">Democracy Club Google Group</a>, which may be of interest if you're developing software that uses the %(site.name)s data.)"
 msgstr ""
 
 #: candidates/templates/candidates/areas-of-type.html:10
@@ -1169,22 +1010,13 @@ msgstr ""
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:22
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:22
 #, python-format
-msgid ""
-"Before you carry on to edit data in %(site_name)s, we need you to agree that "
-"your contributions to this site (with the exception of photo uploads) are "
-"owned by %(copyright_holder)s. In return, we agree to make the complete "
-"database available under an open licence such as <a href=\"http://"
-"creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or remove copyright "
-"restrictions by releasing into the public domain (<a href=\"https://"
-"creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
+msgid "Before you carry on to edit data in %(site_name)s, we need you to agree that your contributions to this site (with the exception of photo uploads) are owned by %(copyright_holder)s. In return, we agree to make the complete database available under an open licence such as <a href=\"http://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or remove copyright restrictions by releasing into the public domain (<a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:42
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:42
 #, python-format
-msgid ""
-"I assign the copyright of my contributions to %(site_name)s (apart from "
-"photo uploads) to %(copyright_holder)s."
+msgid "I assign the copyright of my contributions to %(site_name)s (apart from photo uploads) to %(copyright_holder)s."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:49
@@ -1195,10 +1027,7 @@ msgstr ""
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:53
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:53
 #, python-format
-msgid ""
-"Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a href="
-"\"mailto:%(email)s\">email us</a> if you have any questions about this "
-"agreement."
+msgid "Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a href=\"mailto:%(email)s\">email us</a> if you have any questions about this agreement."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:61
@@ -1208,12 +1037,7 @@ msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:63
 #, python-format
-msgid ""
-"This is the simplest way to ensure that we can make this data as widely "
-"available as possible while preventing the hard work of contributors to "
-"%(site_name)s being unfairly co-opted by companies building closed candidate "
-"databases. This also allows us the flexibility to release the data under "
-"different open licenses in the future."
+msgid "This is the simplest way to ensure that we can make this data as widely available as possible while preventing the hard work of contributors to %(site_name)s being unfairly co-opted by companies building closed candidate databases. This also allows us the flexibility to release the data under different open licenses in the future."
 msgstr ""
 
 #: candidates/templates/candidates/candidacy-create.html:6
@@ -1224,10 +1048,7 @@ msgstr ""
 
 #: candidates/templates/candidates/candidacy-create.html:14
 #, python-format
-msgid ""
-"Before updating our records we need to know the source for your information "
-"that %(name)s is standing for election to the post of %(post_label)s in the "
-"%(election_name)s."
+msgid "Before updating our records we need to know the source for your information that %(name)s is standing for election to the post of %(post_label)s in the %(election_name)s."
 msgstr ""
 
 #: candidates/templates/candidates/candidacy-delete.html:6
@@ -1238,10 +1059,7 @@ msgstr ""
 
 #: candidates/templates/candidates/candidacy-delete.html:14
 #, python-format
-msgid ""
-"Before updating our records we need to know the source for your information "
-"that %(name)s <strong>isn’t</strong> standing for election to the post of "
-"%(post_label)s in the %(election_name)s."
+msgid "Before updating our records we need to know the source for your information that %(name)s <strong>isn’t</strong> standing for election to the post of %(post_label)s in the %(election_name)s."
 msgstr ""
 
 #: candidates/templates/candidates/constituencies-declared.html:6
@@ -1283,9 +1101,7 @@ msgid "All Constituencies for the 2015 General Election"
 msgstr ""
 
 #: candidates/templates/candidates/constituencies.html:14
-msgid ""
-"Follow one of the links below to see the known candidates for that "
-"constituency:"
+msgid "Follow one of the links below to see the known candidates for that constituency:"
 msgstr ""
 
 #: candidates/templates/candidates/constituency.html:9
@@ -1319,8 +1135,7 @@ msgstr ""
 
 #: candidates/templates/candidates/constituency.html:35
 #, python-format
-msgid ""
-"Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
+msgid "Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr ""
 
 #: candidates/templates/candidates/constituency.html:47
@@ -1331,10 +1146,7 @@ msgid "Invalidate Cache"
 msgstr ""
 
 #: candidates/templates/candidates/constituency.html:48
-msgid ""
-"As a staff user, you can invalidate any cached data for this constituency. "
-"This may <em>occasionally</em> be necessary if the page is showing stale "
-"information for more than 10 seconds."
+msgid "As a staff user, you can invalidate any cached data for this constituency. This may <em>occasionally</em> be necessary if the page is showing stale information for more than 10 seconds."
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:14
@@ -1348,9 +1160,7 @@ msgid "Find candidates to be your next representative"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:34
-msgid ""
-"Don’t pay for a candidate database sold by a data vendor — it’s a waste of "
-"money."
+msgid "Don’t pay for a candidate database sold by a data vendor — it’s a waste of money."
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:44
@@ -1364,11 +1174,7 @@ msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:57
 #, python-format
-msgid ""
-"The database is transparently sourced and available as structured data, "
-"suitable for building other election websites. <a href=\"%(api_url)s\">Get "
-"the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new "
-"candidate details.</a>"
+msgid "The database is transparently sourced and available as structured data, suitable for building other election websites. <a href=\"%(api_url)s\">Get the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new candidate details.</a>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:70
@@ -1377,101 +1183,67 @@ msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:77
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new "
-"candidate</a> <span class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new candidate</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:83
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> is creating a new candidate <span class="
-"\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> is creating a new candidate <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:89
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> merged another candidate into <a href="
-"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
-"%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> merged another candidate into <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:95
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> uploaded a photo of <a href="
-"\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span class="
-"\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> uploaded a photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:101
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> approved an uploaded photo of <a href="
-"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
-"%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> approved an uploaded photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:107
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> rejected an uploaded photo of <a href="
-"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
-"%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> rejected an uploaded photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:113
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> reverted to an earlier version of <a href="
-"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
-"%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> reverted to an earlier version of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:119
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> confirmed candidacy for <a href="
-"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
-"%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> confirmed candidacy for <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:125
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> removed candidacy for <a href="
-"\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">"
-"%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> removed candidacy for <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:131
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> locked a constituency <span class=\"when"
-"\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> locked a constituency <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:135
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> unlocked a constituency <span class=\"when"
-"\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> unlocked a constituency <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:139
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> marked <a href=\"%(person_url)s"
-"\">candidate #%(person_id)s</a> as the winner <span class=\"when\">%(when)s "
-"ago</span>"
+msgid "User <strong>%(username)s</strong> marked <a href=\"%(person_url)s\">candidate #%(person_id)s</a> as the winner <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:145
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> updated <a href=\"%(person_url)s"
-"\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> updated <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:154
@@ -1510,37 +1282,29 @@ msgstr ""
 #: candidates/templates/candidates/ordered-party-list.html:9
 #: candidates/templates/candidates/ordered-party-list.html:32
 #, python-format
-msgid ""
-"Party list of %(party_name)s for %(post_label_shorter)s in the "
-"%(election_name)s"
+msgid "Party list of %(party_name)s for %(post_label_shorter)s in the %(election_name)s"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:16
 #: candidates/templates/candidates/ordered-party-list.html:22
 #: candidates/templates/candidates/ordered-party-list.html:27
 #, python-format
-msgid ""
-"Party list of %(party_name)s for %(post_label_shorter)s in the %(election)s"
+msgid "Party list of %(party_name)s for %(post_label_shorter)s in the %(election)s"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:35
 #, python-format
-msgid ""
-"Party list of %(party_name)s for <span id=\"constituency-name\">"
-"%(post_label_shorter)s</span>"
+msgid "Party list of %(party_name)s for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:45
 #, python-format
-msgid ""
-"%(party_name)s candidates for <a href=\"%(post_url)s\">%(post_label)s</a>"
+msgid "%(party_name)s candidates for <a href=\"%(post_url)s\">%(post_label)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:85
 #, python-format
-msgid ""
-"<strong>Oh no!</strong> We don’t know of any candidates from %(party.name)s "
-"for %(post_label)s for the %(election_name)s yet."
+msgid "<strong>Oh no!</strong> We don’t know of any candidates from %(party.name)s for %(post_label)s for the %(election_name)s yet."
 msgstr ""
 
 #: candidates/templates/candidates/party-list.html:6
@@ -1558,43 +1322,30 @@ msgstr ""
 
 #: candidates/templates/candidates/party.html:8
 #, python-format
-msgid ""
-"%(party_name)s &#8212; Candidates by constituency for the UK 2015 General "
-"Election"
+msgid "%(party_name)s &#8212; Candidates by constituency for the UK 2015 General Election"
 msgstr ""
 
 #: candidates/templates/candidates/party.html:20
-msgid ""
-"This shows all the constituencies that have independent candidates standing "
-"in them at the 2015 general election"
+msgid "This shows all the constituencies that have independent candidates standing in them at the 2015 general election"
 msgstr ""
 
 #: candidates/templates/candidates/party.html:25
-msgid ""
-"The Speaker of the House of Commons stands as a \"The Speaker seeking re-"
-"election\" rather than a particular party at a general election; for more "
-"information, please see <a href=\"http://www.parliament.uk/about/faqs/house-"
-"of-commons-faqs/speakers-election/\">Parliament's website</a>."
+msgid "The Speaker of the House of Commons stands as a \"The Speaker seeking re-election\" rather than a particular party at a general election; for more information, please see <a href=\"http://www.parliament.uk/about/faqs/house-of-commons-faqs/speakers-election/\">Parliament's website</a>."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:33
 #, python-format
-msgid ""
-"%(party_name)s is on the Electoral Commission's register for %(register)s."
+msgid "%(party_name)s is on the Electoral Commission's register for %(register)s."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:35
 #, python-format
-msgid ""
-"You can find more data about the party's registration at the <a href="
-"\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
+msgid "You can find more data about the party's registration at the <a href=\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:51
 #, python-format
-msgid ""
-"<a href=\"%(person_url)s\">%(name)s</a> is standing in <a href=\"%(post_url)s"
-"\">%(post)s</a>"
+msgid "<a href=\"%(person_url)s\">%(name)s</a> is standing in <a href=\"%(post_url)s\">%(post)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/party.html:55
@@ -1604,16 +1355,12 @@ msgstr ""
 
 #: candidates/templates/candidates/party.html:63
 #, python-format
-msgid ""
-"There were also %(missing)s posts in %(country)s that %(party_name)s aren't "
-"standing a candidate for."
+msgid "There were also %(missing)s posts in %(country)s that %(party_name)s aren't standing a candidate for."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:68
 #, python-format
-msgid ""
-"There were also %(missing)s posts that %(party_name)s aren't standing a "
-"candidate for."
+msgid "There were also %(missing)s posts that %(party_name)s aren't standing a candidate for."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:75
@@ -1674,9 +1421,7 @@ msgid "Additional information:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:246
-msgid ""
-"<strong>You forgot to reference a source!</strong> Can you show us "
-"<em>where</em> you got this information?"
+msgid "<strong>You forgot to reference a source!</strong> Can you show us <em>where</em> you got this information?"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:248
@@ -1688,10 +1433,7 @@ msgid "Thanks for helping out!"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:265
-msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/"
-"d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
-"fields</a>."
+msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields</a>."
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:271
@@ -1700,9 +1442,7 @@ msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:273
 #, python-format
-msgid ""
-"There’s a separate page for <a href=\"%(url)s\">uploading a photo of "
-"%(name)s</a>."
+msgid "There’s a separate page for <a href=\"%(url)s\">uploading a photo of %(name)s</a>."
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:281
@@ -1808,9 +1548,7 @@ msgstr ""
 
 #: candidates/templates/candidates/person-view.html:95
 #, python-format
-msgid ""
-"We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by "
-"adding one</a>!"
+msgid "We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by adding one</a>!"
 msgstr ""
 
 #: candidates/templates/candidates/person-view.html:104
@@ -1895,8 +1633,7 @@ msgid "Our database is built by people like you."
 msgstr ""
 
 #: candidates/templates/candidates/person-view.html:215
-msgid ""
-"Please do add extra details about this candidate – it only takes a moment."
+msgid "Please do add extra details about this candidate – it only takes a moment."
 msgstr ""
 
 #: candidates/templates/candidates/person-view.html:218
@@ -1917,16 +1654,11 @@ msgstr ""
 
 #: candidates/templates/candidates/person-view.html:238
 #, python-format
-msgid ""
-"More details about getting <a href=\"%(api_url)s\">the data</a> and <a href="
-"\"%(about_url)s\">its license</a>."
+msgid "More details about getting <a href=\"%(api_url)s\">the data</a> and <a href=\"%(about_url)s\">its license</a>."
 msgstr ""
 
 #: candidates/templates/candidates/person-view.html:247
-msgid ""
-"As a staff user, you can invalidate any cached data for this user. This may "
-"<em>occasionally</em> be necessary if the page is showing stale information "
-"for more than 10 seconds."
+msgid "As a staff user, you can invalidate any cached data for this user. This may <em>occasionally</em> be necessary if the page is showing stale information for more than 10 seconds."
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:7
@@ -1944,9 +1676,7 @@ msgid "Sorry, %(site_name)s is temporarily unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:26
-msgid ""
-"This usually means that we’re having to do some brief maintenance, and the "
-"site will be back soon."
+msgid "This usually means that we’re having to do some brief maintenance, and the site will be back soon."
 msgstr ""
 
 #: candidates/templates/candidates/posts.html:9
@@ -1956,8 +1686,7 @@ msgstr ""
 
 #: candidates/templates/candidates/posts.html:14
 #: elections/st_paul_municipal_2015/templates/candidates/posts.html:14
-msgid ""
-"Follow one of the links below to see the known candidates for that post:"
+msgid "Follow one of the links below to see the known candidates for that post:"
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:6
@@ -1982,29 +1711,20 @@ msgid "This site is run by %(site_owner)s."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:28
-msgid ""
-"We make the following promises about your personal information as a user of "
-"the site:"
+msgid "We make the following promises about your personal information as a user of the site:"
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:34
-msgid ""
-"We will not sell or distribute your email address or other personal "
-"information."
+msgid "We will not sell or distribute your email address or other personal information."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:38
-msgid ""
-"We will gladly show you the personal data we store about you in order to run "
-"the website."
+msgid "We will gladly show you the personal data we store about you in order to run the website."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:44
 #, python-format
-msgid ""
-"We may use your email address to contact you about your use of the site if "
-"it's problematic (or particularly helpful!), or with occasional "
-"announcements about %(site_name)s and other %(site_owner)s projects."
+msgid "We may use your email address to contact you about your use of the site if it's problematic (or particularly helpful!), or with occasional announcements about %(site_name)s and other %(site_owner)s projects."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:51
@@ -2012,27 +1732,15 @@ msgid "Details"
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:53
-msgid ""
-"As well as your login details, we store your IP address along with any "
-"changes you make to the data on the site.  All this information is "
-"accessible to administrators of the site."
+msgid "As well as your login details, we store your IP address along with any changes you make to the data on the site.  All this information is accessible to administrators of the site."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:59
-msgid ""
-"Please note that this policy refers to the personal information arising from "
-"creating a login on the site, not the personal information about candidates "
-"for elections - the reason for the site to exist is to make information "
-"about those candidates available to members of the public and website "
-"developers so that they can find out more about those candidates, their "
-"promises and policy positions."
+msgid "Please note that this policy refers to the personal information arising from creating a login on the site, not the personal information about candidates for elections - the reason for the site to exist is to make information about those candidates available to members of the public and website developers so that they can find out more about those candidates, their promises and policy positions."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:69
-msgid ""
-"We also use Google Analytics to aggregate and track data about usage of the "
-"site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a "
-"browser plugin to opt out of having data collected by Google Analytics</a>."
+msgid "We also use Google Analytics to aggregate and track data about usage of the site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a browser plugin to opt out of having data collected by Google Analytics</a>."
 msgstr ""
 
 #: candidates/templates/candidates/recent-changes.html:6
@@ -2090,11 +1798,7 @@ msgstr ""
 
 #: candidates/templates/candidates/update-disallowed.html:16
 #, python-format
-msgid ""
-"As a precaution, this update hasn't been allowed, but details have been "
-"emailed to the team of %(site.name)s volunteers; they will apply the change "
-"after checking it. If you have any questions about this, please email <a "
-"href=\"%(email)s\">%(email)s</a>."
+msgid "As a precaution, this update hasn't been allowed, but details have been emailed to the team of %(site.name)s volunteers; they will apply the change after checking it. If you have any questions about this, please email <a href=\"%(email)s\">%(email)s</a>."
 msgstr ""
 
 #: candidates/templatetags/metadescription.py:23
@@ -2114,8 +1818,7 @@ msgstr ""
 
 #: candidates/templatetags/metadescription.py:29
 #, python-format
-msgid ""
-"%(name)s is standing as an independent candidate in %(post)s in %(election)s"
+msgid "%(name)s is standing as an independent candidate in %(post)s in %(election)s"
 msgstr ""
 
 #: candidates/templatetags/metadescription.py:31
@@ -2300,9 +2003,7 @@ msgstr ""
 #: elections/bf_elections_2015/templates/base.html:8
 #: elections/st_paul_municipal_2015/templates/base.html:8
 #, python-format
-msgid ""
-"Run by <img src=\"%(logo_url)s\" %%} alt=\"%(site_managers)s\" class=\"dc-"
-"logo\">"
+msgid "Run by <img src=\"%(logo_url)s\" %%} alt=\"%(site_managers)s\" class=\"dc-logo\">"
 msgstr ""
 
 #: elections/uk_general_election_2015/mapit.py:25
@@ -2326,75 +2027,39 @@ msgid "Unknown MapIt error for postcode \"{0}\""
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/base.html:24
-msgid ""
-"Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a href="
-"\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a href="
-"\"https://mysociety.org\">mySociety</a>."
+msgid "Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a href=\"https://mysociety.org\">mySociety</a>."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/base.html:31
 #, python-format
-msgid ""
-"Built by <a href=\"%(site_managers_url)s\"> <img src=\"%(logo_url)s\" %%} "
-"alt=\"%(site_managers)s\" class=\"dc-logo\"></a>"
+msgid "Built by <a href=\"%(site_managers_url)s\"> <img src=\"%(logo_url)s\" %%} alt=\"%(site_managers)s\" class=\"dc-logo\"></a>"
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:17
 #, python-format
-msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or "
-"bug reports. If you'd like to discuss this site or any other project "
-"relating to elections in the UK, we'd suggest that you post to the <a href="
-"\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy Club "
-"Google Group</a>."
+msgid "Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or bug reports. If you'd like to discuss this site or any other project relating to elections in the UK, we'd suggest that you post to the <a href=\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy Club Google Group</a>."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:34
-msgid ""
-"This site was originally developed by Mark Longair (mySociety), Sym Roe "
-"(Democracy Club) and Zarino Zappia (mySociety) and <a href=\"https://github."
-"com/mysociety/yournextrepresentative/graphs/contributors\">many other "
-"contributors</a>, to whom we owe a debt of gratitude."
+msgid "This site was originally developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety) and <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many other contributors</a>, to whom we owe a debt of gratitude."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:41
-msgid ""
-"The data on candidates from the last UK general election in 2010 is all "
-"taken from Edmund von der Burg's <a href=\"http://www.yournextmp.com"
-"\">YourNextMP.com</a>, with many thanks."
+msgid "The data on candidates from the last UK general election in 2010 is all taken from Edmund von der Burg's <a href=\"http://www.yournextmp.com\">YourNextMP.com</a>, with many thanks."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:58
-msgid ""
-"The party logos, which are taken from the Electoral Commission's website"
+msgid "The party logos, which are taken from the Electoral Commission's website"
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:73
 #, python-format
-msgid ""
-"For complicated reasons relating to database licensing, we have put the data "
-"as of the 4th of March 2015 into the public domain by declaring it to be <a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This "
-"data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-"
-"date/\">here</a> but please be warned that this snapshot will become "
-"inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date "
-"data</a> instead."
+msgid "For complicated reasons relating to database licensing, we have put the data as of the 4th of March 2015 into the public domain by declaring it to be <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-date/\">here</a> but please be warned that this snapshot will become inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date data</a> instead."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:63
 #, python-format
-msgid ""
-"When we originally set up %(site_name)s for the 2015 UK general election we "
-"didn't get legal advice about the best way to deal with copyright and "
-"licensing. It turns out that the way that the user agreement that was worded "
-"on the 'About' page had a few problems, and in particular restricted what we "
-"could do with the data such that we couldn't license the database to some "
-"partners who we thought would make good use of the data but who needed "
-"slightly different licensing. The simplest way to ensure that we can make "
-"the data as widely available as possible while preventing the hard work of "
-"contributors to %(site_name)s being co-opted by companies building closed "
-"candidate databases is to ask you to assign the copyright of your "
-"contributions to %(copyright_holder)s."
+msgid "When we originally set up %(site_name)s for the 2015 UK general election we didn't get legal advice about the best way to deal with copyright and licensing. It turns out that the way that the user agreement that was worded on the 'About' page had a few problems, and in particular restricted what we could do with the data such that we couldn't license the database to some partners who we thought would make good use of the data but who needed slightly different licensing. The simplest way to ensure that we can make the data as widely available as possible while preventing the hard work of contributors to %(site_name)s being co-opted by companies building closed candidate databases is to ask you to assign the copyright of your contributions to %(copyright_holder)s."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/finder.html:14
@@ -2408,9 +2073,7 @@ msgid "The popit_person_id must be all digits"
 msgstr ""
 
 #: moderation_queue/forms.py:39
-msgid ""
-"If you checked 'Other' then you must provide a justification for why we can "
-"use it."
+msgid "If you checked 'Other' then you must provide a justification for why we can use it."
 msgstr ""
 
 #: moderation_queue/models.py:20
@@ -2434,15 +2097,11 @@ msgid "This photograph is free of any copyright restrictions"
 msgstr ""
 
 #: moderation_queue/models.py:35
-msgid ""
-"I own copyright of this photo and I assign the copyright to Democracy Club "
-"Limited in return for it being displayed on this site"
+msgid "I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on this site"
 msgstr ""
 
 #: moderation_queue/models.py:39
-msgid ""
-"This is the candidate's public profile photo from social media (e.g. "
-"Twitter, Facebook) or their official campaign page"
+msgid "This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page"
 msgstr ""
 
 #: moderation_queue/models.py:43
@@ -2456,12 +2115,8 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:7
 #, python-format
-msgid ""
-"<strong>Warning:</strong> there is already %(queued_images)s photo of "
-"%(name)s in the queue, waiting to be moderated:"
-msgid_plural ""
-"<strong>Warning:</strong> there are already %(queued_images)s photos of "
-"%(name)s in the queue, waiting to be moderated:"
+msgid "<strong>Warning:</strong> there is already %(queued_images)s photo of %(name)s in the queue, waiting to be moderated:"
+msgid_plural "<strong>Warning:</strong> there are already %(queued_images)s photos of %(name)s in the queue, waiting to be moderated:"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2472,9 +2127,7 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:25
 #, python-format
-msgid ""
-"If you still want to upload another photo of %(name)s, first select an image "
-"from your computer:"
+msgid "If you still want to upload another photo of %(name)s, first select an image from your computer:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:29
@@ -2482,15 +2135,11 @@ msgid "First, select an image from your computer:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:38
-msgid ""
-"Now let us know about the copyright of this image by selecting one of these "
-"options or explaining why we can use it:"
+msgid "Now let us know about the copyright of this image by selecting one of these options or explaining why we can use it:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:47
-msgid ""
-"Here is my justification for why this photo may be reasonably used on the "
-"website, including the source URL:"
+msgid "Here is my justification for why this photo may be reasonably used on the website, including the source URL:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:54
@@ -2530,19 +2179,12 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:30
 #, python-format
-msgid ""
-"Please check that this is really <a href=\"%(url)s\">%(name)s</a> "
-"(%(party)s) before approving the upload. This <a href="
-"\"%(google_image_search_url)s\">Google Image search for candidate details</"
-"a> may be a good start."
+msgid "Please check that this is really <a href=\"%(url)s\">%(name)s</a> (%(party)s) before approving the upload. This <a href=\"%(google_image_search_url)s\">Google Image search for candidate details</a> may be a good start."
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:36
 #, python-format
-msgid ""
-"If you're trying to find the likely <em>source</em> of this image, you can "
-"also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image "
-"search</a> on the uploaded image."
+msgid "If you're trying to find the likely <em>source</em> of this image, you can also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image search</a> on the uploaded image."
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:41
@@ -2550,9 +2192,7 @@ msgid "Click and drag in the image to crop"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:43
-msgid ""
-"Please crop to just around the candidate's head, since they're displayed in "
-"thumbnail form on the site."
+msgid "Please crop to just around the candidate's head, since they're displayed in thumbnail form on the site."
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:68
@@ -2597,16 +2237,12 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:113
 #, python-format
-msgid ""
-"%(username)s said that this is the candidate's public profile photo from "
-"social media or their official campaign page"
+msgid "%(username)s said that this is the candidate's public profile photo from social media or their official campaign page"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:120
 #, python-format
-msgid ""
-"%(username)s's justification for use of this photo was: &#8220;"
-"%(justification)s&#8221;"
+msgid "%(username)s's justification for use of this photo was: &#8220;%(justification)s&#8221;"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:128
@@ -2626,9 +2262,7 @@ msgid "Why <em>you</em> think it's allowed:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:151
-msgid ""
-"Reason for rejection (<strong>Warning:</strong> this will be emailed to the "
-"user):"
+msgid "Reason for rejection (<strong>Warning:</strong> this will be emailed to the user):"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:158
@@ -2659,10 +2293,7 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-upload-success.html:15
 #, python-format
-msgid ""
-"Thank-you for uploading a photo - you will receive an email when it is "
-"approved to be added to the site, or an explanation for why it cannot be "
-"used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
+msgid "Thank-you for uploading a photo - you will receive an email when it is approved to be added to the site, or an explanation for why it cannot be used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
@@ -2676,9 +2307,7 @@ msgstr ""
 
 #: moderation_queue/views.py:290
 #, python-brace-format
-msgid ""
-"Approved a photo upload from {uploading_user} who provided the message: "
-"\"{message}\""
+msgid "Approved a photo upload from {uploading_user} who provided the message: \"{message}\""
 msgstr ""
 
 #: moderation_queue/views.py:316
@@ -2731,9 +2360,7 @@ msgstr ""
 
 #: moderation_queue/views.py:407
 #, python-brace-format
-msgid ""
-"Ignored a photo upload from {uploading_user} (This usually means it was a "
-"duplicate)"
+msgid "Ignored a photo upload from {uploading_user} (This usually means it was a duplicate)"
 msgstr ""
 
 #: moderation_queue/views.py:420
@@ -2789,8 +2416,7 @@ msgstr ""
 
 #: mysite/templates/account/signup.html:13
 #, python-format
-msgid ""
-"Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
+msgid "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr ""
 
 #: mysite/templates/generic_base.html:71
@@ -2828,9 +2454,7 @@ msgstr ""
 
 #: official_documents/templates/official_documents/_post.html:30
 #, python-format
-msgid ""
-"As you have permission to upload documents, you can <a href=\"%(url)s"
-"\">upload a %(type)s</a>."
+msgid "As you have permission to upload documents, you can <a href=\"%(url)s\">upload a %(type)s</a>."
 msgstr ""
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:16
@@ -2840,16 +2464,12 @@ msgstr ""
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:19
 #, python-format
-msgid ""
-"The source URL for this document was: <a href=\"%(source_url)s\">"
-"%(source_url)s</a>"
+msgid "The source URL for this document was: <a href=\"%(source_url)s\">%(source_url)s</a>"
 msgstr ""
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:32
 #, python-format
-msgid ""
-"You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to "
-"delete it)"
+msgid "You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to delete it)"
 msgstr ""
 
 #: official_documents/templates/official_documents/upload_document_form.html:5
@@ -2876,9 +2496,7 @@ msgstr ""
 
 #: results/feeds.py:28
 #, python-brace-format
-msgid ""
-"A {site_name} volunteer recorded at {datetime} that {name} ({party}) won the "
-"ballot in {cons}, quoting the source '{source}')."
+msgid "A {site_name} volunteer recorded at {datetime} that {name} ({party}) won the ballot in {cons}, quoting the source '{source}')."
 msgstr ""
 
 #: results/feeds.py:84
@@ -2899,17 +2517,12 @@ msgstr[1] ""
 
 #: tasks/templates/tasks/field.html:14
 #, python-format
-msgid ""
-"Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
+msgid "Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
 msgstr ""
 
 #: tasks/templates/tasks/field.html:21
 #, python-format
-msgid ""
-"Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make "
-"sure you read our <a href=\"https://docs.google.com/document/"
-"d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
-"fields.</a>"
+msgid "Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields.</a>"
 msgstr ""
 
 #: tasks/templates/tasks/field.html:35
@@ -2918,9 +2531,7 @@ msgstr ""
 
 #: tasks/templates/tasks/field.html:38
 #, python-format
-msgid ""
-"Hi @%(username)s could you add your %(field)s to your %(site_name)s page "
-"please? https://yournextmp.com/person/%(id)s/"
+msgid "Hi @%(username)s could you add your %(field)s to your %(site_name)s page please? https://yournextmp.com/person/%(id)s/"
 msgstr ""
 
 #: tasks/templates/tasks/field.html:41
@@ -2950,15 +2561,11 @@ msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:12
 #, python-format
-msgid ""
-"%(site_name)s is a volunteer-sourced database, and that means we constantly "
-"need help in making it better."
+msgid "%(site_name)s is a volunteer-sourced database, and that means we constantly need help in making it better."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:17
-msgid ""
-"There is a lot of useful information on candidates out there, so if you find "
-"any please do add it to our site."
+msgid "There is a lot of useful information on candidates out there, so if you find any please do add it to our site."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:22
@@ -2966,15 +2573,11 @@ msgid "Emails"
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:24
-msgid ""
-"At the moment we're trying to get as many email addresses on candidates as "
-"we can."
+msgid "At the moment we're trying to get as many email addresses on candidates as we can."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:29
-msgid ""
-"This will allow us to email them directly to ask them to add their own "
-"details."
+msgid "This will allow us to email them directly to ask them to add their own details."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:34
@@ -2983,47 +2586,27 @@ msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:37
 #, python-format
-msgid ""
-"First off you'll need to <a href=\"%(url)s\">log in</a> in order to start "
-"making edits."
+msgid "First off you'll need to <a href=\"%(url)s\">log in</a> in order to start making edits."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:43
 #, python-format
-msgid ""
-"We've added clear banners on the candidate and constituently pages "
-"indicating where we're missing email addresses, so you can start adding "
-"email addresses by <a href=\"%(url)s\">looking up your constituency on the "
-"home page</a>"
+msgid "We've added clear banners on the candidate and constituently pages indicating where we're missing email addresses, so you can start adding email addresses by <a href=\"%(url)s\">looking up your constituency on the home page</a>"
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:50
-msgid ""
-"Once you've found a candidate without an email address, you can go searching "
-"for it!"
+msgid "Once you've found a candidate without an email address, you can go searching for it!"
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:55
-msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/"
-"d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing "
-"fields</a>, and specifically the part about what sort of email addresses we "
-"accept."
+msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing fields</a>, and specifically the part about what sort of email addresses we accept."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:62
-msgid ""
-"In short, we only want email addresses could be considered public and "
-"related to the candidate's campaign. <code>@parliament.uk</code> email "
-"addresses will stop working once Parliament is disbanded, so try to find a "
-"different email address for them if you can. If not, we can always email "
-"everyone with a <code>@parliament.uk</code> address asking them for a better "
-"one."
+msgid "In short, we only want email addresses could be considered public and related to the candidate's campaign. <code>@parliament.uk</code> email addresses will stop working once Parliament is disbanded, so try to find a different email address for them if you can. If not, we can always email everyone with a <code>@parliament.uk</code> address asking them for a better one."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:72
 #, python-format
-msgid ""
-"Once your constituency has all the email addresses entered, you can look at "
-"our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
+msgid "Once your constituency has all the email addresses entered, you can look at our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
 msgstr ""

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1963,7 +1963,7 @@ msgstr ""
 #: candidates/templates/candidates/privacy.html:6
 #: candidates/templates/candidates/privacy.html:9
 #: elections/ar_elections_2015/templates/base.html:110
-#: mysite/templates/generic_base.html:125
+#: mysite/templates/generic_base.html:121
 msgid "Privacy policy"
 msgstr ""
 
@@ -2231,29 +2231,29 @@ msgid "Provinces"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:58
-#: mysite/templates/generic_base.html:82
+#: mysite/templates/generic_base.html:78
 #, python-format
 msgid "Signed in as <strong>%(username)s</strong>"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:60
-#: mysite/templates/generic_base.html:83
+#: mysite/templates/generic_base.html:79
 msgid "Sign out"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:63
-#: mysite/templates/generic_base.html:87
+#: mysite/templates/generic_base.html:83
 msgid "Sign in to edit"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:108
-#: mysite/templates/generic_base.html:122
+#: mysite/templates/generic_base.html:118
 msgid "Open data API"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:109
-#: mysite/templates/generic_base.html:74
-#: mysite/templates/generic_base.html:123
+#: mysite/templates/generic_base.html:70
+#: mysite/templates/generic_base.html:119
 msgid "About"
 msgstr ""
 
@@ -2793,20 +2793,15 @@ msgid ""
 "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr ""
 
-#: mysite/templates/generic_base.html:37
-#, python-format
-msgid "%(site_name)s"
-msgstr ""
-
-#: mysite/templates/generic_base.html:75
+#: mysite/templates/generic_base.html:71
 msgid "Posts"
 msgstr ""
 
-#: mysite/templates/generic_base.html:76
+#: mysite/templates/generic_base.html:72
 msgid "Numbers"
 msgstr ""
 
-#: mysite/templates/generic_base.html:124
+#: mysite/templates/generic_base.html:120
 msgid "Issue tracker"
 msgstr ""
 

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -462,17 +462,15 @@ msgstr "Fuente de información de que ganaron"
 msgid "{post_role} for {area_name}"
 msgstr ""
 
-#: candidates/middleware.py:43
-#, python-brace-format
-msgid ""
-"As a precaution, an update was blocked:\n"
-"\n"
-"  {0}\n"
-"\n"
-"If this update is appropriate, someone should apply it manually.\n"
-msgstr "Como precaución, esta actualización fue bloqueada:\n\n{0}\n\nSi esta actualización es apropiada, alguien debería aplicarla manualmente.\n"
+#: candidates/middleware.py:42
+msgid "As a precaution, an update was blocked:"
+msgstr "Como precaución, esta actualización fue bloqueada:"
 
-#: candidates/middleware.py:50
+#: candidates/middleware.py:43
+msgid "If this update is appropriate, someone should apply it manually."
+msgstr "Si esta actualización es apropiada, alguien debería aplicarla manualmente."
+
+#: candidates/middleware.py:51
 #, python-brace-format
 msgid "Disallowed {site_name} update for checking"
 msgstr ""
@@ -2671,36 +2669,7 @@ msgid ""
 "used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
 msgstr "Gracias por subir una foto - recibirás un email cuando esté aprobada para ser agregada al sitio, o una explicación de porqué no puede ser usada. <a href=\"%(url)s\">Volver a la página de %(name)s.</a>"
 
-#: moderation_queue/templates/moderation_queue/photo_approved_email.txt:1
-#, python-format
-msgid ""
-"Thank-you for submitting a photo to %(site_name)s; that's been\n"
-"uploaded now for the candidate page here:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_approved_email.txt:6
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
-#, python-format
-msgid ""
-"Many thanks,\n"
-"The %(site_name)s volunteers"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:1
-#, python-format
-msgid ""
-"Thank-you for uploading a photo of %(candidate_name)s\n"
-"to %(site_name)s, but unfortunately we can't use that image because:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:6
-msgid ""
-"You can just reply to this email if you want to discuss that\n"
-"further, or you can try uploading a photo with a different reason\n"
-"or justification for its use using this link:"
-msgstr "Podés responder a este email si querés seguir conversándolo, o podés intentar subir una foto con una razón o justificación diferente para su uso, en este enlace:"
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:16
 #, python-format
 msgid "For administrators' use: %(photo_review_url)s"
 msgstr "Para uso de los administradores: %(photo_review_url)s"
@@ -2709,49 +2678,67 @@ msgstr "Para uso de los administradores: %(photo_review_url)s"
 msgid "Approved from photo moderation queue"
 msgstr "Foto aprobada de la cola de moderación"
 
-#: moderation_queue/views.py:289
+#: moderation_queue/views.py:290
 #, python-brace-format
 msgid ""
 "Approved a photo upload from {uploading_user} who provided the message: "
 "\"{message}\""
 msgstr "Aprobada la foto subida de  {uploading_user} que ingresó el mensaje: \"{message}\""
 
-#: moderation_queue/views.py:315
+#: moderation_queue/views.py:316
 #, python-brace-format
 msgid "{site_name} image upload approved"
 msgstr ""
 
-#: moderation_queue/views.py:328
+#: moderation_queue/views.py:325
+#, python-brace-format
+msgid "Thank-you for submitting a photo to {site_name}; that's been uploaded now for the candidate page here:"
+msgstr ""
+
+#: moderation_queue/views.py:330 moderation_queue/views.py:385
+msgid "Many thanks from the {{ site_name }} volunteers"
+msgstr ""
+
+#: moderation_queue/views.py:337
 #, python-format
 msgid "You approved a photo upload for %s"
 msgstr "Aprobaste una foto subida para %s"
 
-#: moderation_queue/views.py:333
+#: moderation_queue/views.py:342
 #, python-brace-format
 msgid "Rejected a photo upload from {uploading_user}"
 msgstr "Rechazada una foto subida por {uploading_user}"
 
-#: moderation_queue/views.py:352
+#: moderation_queue/views.py:361
 #, python-brace-format
 msgid "{site_name} image moderation results"
 msgstr ""
 
-#: moderation_queue/views.py:369
+#: moderation_queue/views.py:371
+#, python-brace-format
+msgid "Thank-you for uploading a photo of {candidate_name} to {site_name}, but unfortunately we can't use that image because:"
+msgstr ""
+
+#: moderation_queue/views.py:379
+msgid "You can just reply to this email if you want to discuss that further, or you can try uploading a photo with a different reason or justification for its use using this link:"
+msgstr "Podés responder a este email si querés seguir conversándolo, o podés intentar subir una foto con una razón o justificación diferente para su uso, en este enlace:"
+
+#: moderation_queue/views.py:393
 #, python-format
 msgid "You rejected a photo upload for %s"
 msgstr "Rechazaste una imágen subida por %s"
 
-#: moderation_queue/views.py:376
+#: moderation_queue/views.py:400
 #, python-brace-format
 msgid "You left a photo upload for {0} in the queue"
 msgstr "Dejaste una foto subida por {0} en la cola"
 
-#: moderation_queue/views.py:383
+#: moderation_queue/views.py:407
 #, python-brace-format
 msgid "Ignored a photo upload from {uploading_user} (This usually means it was a duplicate)"
 msgstr "Ignorada una foto subida por {uploading_user} (Esto usualmente significa que era duplicada)"
 
-#: moderation_queue/views.py:396
+#: moderation_queue/views.py:420
 #, python-brace-format
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr "Indicaste que una foto subida por {0} debe ser ignorada"

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -75,13 +75,8 @@ msgstr "¿Cuales puestos tienen menos candidatos?"
 
 #: cached_counts/templates/reports.html:15
 #, python-format
-msgid ""
-"\n"
-"        You can see a list of all the posts in current elections\n"
-"        <a href=\"%(url)s\">ordered starting with those with the fewest\n"
-"        candidates</a>.\n"
-"     "
-msgstr "\nPuedes ver una lista de todos los cargos que se disputan en estas elecciones\n<a href=\"%(url)s\">empezando con aquellos con pocos \ncandidatos cargados</a>."
+msgid "You can see a list of all the posts in current elections <a href=\"%(url)s\">ordered starting with those with the fewest candidates</a>."
+msgstr "Puedes ver una lista de todos los cargos que se disputan en estas elecciones <a href=\"%(url)s\">empezando con aquellos con pocos candidatos cargados</a>."
 
 #: cached_counts/templates/reports.html:26
 msgid "Current Elections"
@@ -686,43 +681,27 @@ msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:4
 #, python-format
-msgid ""
-"\n"
-"    Thank-you for adding <a href=\"%(person_url)s\">%(person_name)s</a>!\n"
-"  "
+msgid "Thank-you for adding <a href=\"%(person_url)s\">%(person_name)s</a>!"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:8
 #, python-format
-msgid ""
-"\n"
-"    Thank-you for updating <a href=\"%(person_url)s\">%(person_name)s</a>!\n"
-"  "
+msgid "Thank-you for updating <a href=\"%(person_url)s\">%(person_name)s</a>!"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:17
 #, python-format
-msgid ""
-"\n"
-"      <a href=\"%(person_edit_url)s\">Edit %(person_name)s again</a>\n"
-"    "
+msgid "<a href=\"%(person_edit_url)s\">Edit %(person_name)s again</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:22
 #, python-format
-msgid ""
-"\n"
-"      Add a candidate for <a href=\"%(needing_attention_url)s\">one of the\n"
-"      posts with fewest candidates</a>\n"
-"    "
+msgid "Add a candidate for <a href=\"%(needing_attention_url)s\">one of the posts with fewest candidates</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:29
 #, python-format
-msgid ""
-"\n"
-"        <a href=\"%(person_create_url)s\">Add another candidate in the %(election_name)s</a>\n"
-"      "
+msgid "<a href=\"%(person_create_url)s\">Add another candidate in the %(election_name)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-credit.html:8
@@ -1188,21 +1167,11 @@ msgid "Areas: %(all_area_names)s"
 msgstr "Area(s): %(all_area_names)s"
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:7
-#: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:7
-#, python-format
-msgid ""
-"\n"
-"    %(site_name)s user agreement\n"
-"  "
-msgstr ""
-
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:14
+#: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:7
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:14
 #, python-format
-msgid ""
-"\n"
-"        %(site_name)s user agreement\n"
-"      "
+msgid "%(site_name)s user agreement"
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:22
@@ -1970,10 +1939,7 @@ msgstr "Como moderador, podés invalidar los datos en cache (actualizar) para es
 
 #: candidates/templates/candidates/popit_down.html:7
 #, python-format
-msgid ""
-"\n"
-"    %(site_name)s is Temporarily Unavailable\n"
-"  "
+msgid "%(site_name)s is Temporarily Unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:13
@@ -1982,10 +1948,7 @@ msgstr "Error"
 
 #: candidates/templates/candidates/popit_down.html:21
 #, python-format
-msgid ""
-"\n"
-"    Sorry, %(site_name)s is temporarily unavailable\n"
-"  "
+msgid "Sorry, %(site_name)s is temporarily unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:26
@@ -2785,9 +2748,7 @@ msgstr "Dejaste una foto subida por {0} en la cola"
 
 #: moderation_queue/views.py:383
 #, python-brace-format
-msgid ""
-"Ignored a photo upload from {uploading_user} (This usually means it was a "
-"duplicate)"
+msgid "Ignored a photo upload from {uploading_user} (This usually means it was a duplicate)"
 msgstr "Ignorada una foto subida por {uploading_user} (Esto usualmente significa que era duplicada)"
 
 #: moderation_queue/views.py:396
@@ -2795,10 +2756,8 @@ msgstr "Ignorada una foto subida por {uploading_user} (Esto usualmente significa
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr "Indicaste que una foto subida por {0} debe ser ignorada"
 
-#: mysite/settings.py:368
-msgid ""
-"Please don't quote third-party candidate sites —\n"
-"we prefer URLs of news stories or official candidate pages."
+#: mysite/settings.py:369
+msgid "Please don't quote third-party candidate sites — we prefer URLs of news stories or official candidate pages."
 msgstr "dirección URL de una noticia o de un sitio oficial del candidato."
 
 #: mysite/templates/account/login.html:6 mysite/templates/account/login.html:9
@@ -2808,11 +2767,8 @@ msgstr "Acceder"
 
 #: mysite/templates/account/login.html:15
 #, python-format
-msgid ""
-"Please sign in with one\n"
-"of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign up</a>\n"
-"for a %(site_name)s account and sign in below:"
-msgstr "Por favor acceda con una de sus cuentas existentes\nen servicios de terceras partes. O <a href=\"%(signup_url)s\">regístrese</a>\npara una cuenta nueva de %(site_name)s y acceda debajo:"
+msgid "Please sign in with one of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign up</a> for a %(site_name)s account and sign in below:"
+msgstr "Por favor acceda con una de sus cuentas existentes en servicios de terceras partes. O <a href=\"%(signup_url)s\">regístrese</a> para una cuenta nueva de %(site_name)s y acceda debajo:"
 
 #: mysite/templates/account/login.html:25
 msgid "or"
@@ -2820,9 +2776,7 @@ msgstr "o"
 
 #: mysite/templates/account/login.html:32
 #, python-format
-msgid ""
-"If you have not created an account yet, then please\n"
-"<a href=\"%(signup_url)s\">sign up</a> first."
+msgid "If you have not created an account yet, then please <a href=\"%(signup_url)s\">sign up</a> first."
 msgstr "Si no has creado tu cuenta aún, entonces por favor<a href=\"%(signup_url)s\">registrate</a> primero."
 
 #: mysite/templates/account/login.html:43
@@ -2856,11 +2810,8 @@ msgstr "¿Ya tenés una cuenta? Entonces por favor  <a href=\"%(login_url)s\">in
 
 #: mysite/templates/generic_base.html:37
 #, python-format
-msgid ""
-"\n"
-"           %(site_name)s\n"
-"        "
-msgstr ""
+msgid "%(site_name)s"
+msgstr "%(site_name)s"
 
 #: mysite/templates/generic_base.html:75
 msgid "Posts"

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -27,10 +27,7 @@ msgid "Permission denied"
 msgstr "No está autorizado para realizar esta acción."
 
 #: auth_helpers/templates/auth_helpers/group_permission_denied.html:14
-msgid ""
-"You must be in the member of a particular group in order to view that page. "
-"Please contact the administrators of the site if you feel that you should "
-"have access to this page."
+msgid "You must be in the member of a particular group in order to view that page. Please contact the administrators of the site if you feel that you should have access to this page."
 msgstr "Debe ser el administrador de un grupo particular para poder acceder a la página. Por favor contacte a los administradores del sitio si siente que debe tener acceso a esta página."
 
 #: cached_counts/templates/attention_needed.html:5
@@ -130,16 +127,12 @@ msgstr "Candidatos que también se presentaron en %(prior_election_name)s:"
 
 #: cached_counts/templates/reports.html:58
 #, python-format
-msgid ""
-"Candidates standing again from the %(prior_election_name)s for the same "
-"party:"
+msgid "Candidates standing again from the %(prior_election_name)s for the same party:"
 msgstr "Candidatos que también se presentaron en %(prior_election_name)s por el mismo partido:"
 
 #: cached_counts/templates/reports.html:62
 #, python-format
-msgid ""
-"Candidates standing again from the %(prior_election_name)s for a different "
-"party:"
+msgid "Candidates standing again from the %(prior_election_name)s for a different party:"
 msgstr "Candidatos que se habían presentado en %(prior_election_name)s por un partido diferente:"
 
 #: cached_counts/templates/reports.html:74
@@ -158,14 +151,12 @@ msgstr "supimos que se presentó por el partido '{party}' en las elecciones a {e
 
 #: candidates/diffs.py:38
 #, python-brace-format
-msgid ""
-"is known to be standing for the party with ID {party} in the {election}"
+msgid "is known to be standing for the party with ID {party} in the {election}"
 msgstr "Se sabe que se presenta por el partido con identificación {party} en las elecicones para {election}"
 
 #: candidates/diffs.py:40
 #, python-brace-format
-msgid ""
-"was known to be standing for the party with ID {party} in the {election}"
+msgid "was known to be standing for the party with ID {party} in the {election}"
 msgstr "supimos que se presentó por el partido con identificación {party} in las {election}"
 
 #: candidates/diffs.py:43 candidates/diffs.py:91
@@ -195,28 +186,22 @@ msgstr "Supimos que no se presentó en las elecciones a {election}"
 
 #: candidates/diffs.py:64
 #, python-brace-format
-msgid ""
-"is known to be standing for the post with ID {post_id} in the {election}"
+msgid "is known to be standing for the post with ID {post_id} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:66
 #, python-brace-format
-msgid ""
-"was known to be standing for the post with ID {post_id} in the {election}"
+msgid "was known to be standing for the post with ID {post_id} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:70
 #, python-brace-format
-msgid ""
-"is known to be standing in the constituency with MapIt URL {mapit_url} in "
-"the {election}"
+msgid "is known to be standing in the constituency with MapIt URL {mapit_url} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:72
 #, python-brace-format
-msgid ""
-"was known to be standing in the constituency with MapIt URL {mapit_url} in "
-"the {election}"
+msgid "was known to be standing in the constituency with MapIt URL {mapit_url} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:76 candidates/diffs.py:97
@@ -365,16 +350,12 @@ msgid "Program"
 msgstr ""
 
 #: candidates/forms.py:155
-msgid ""
-"The Twitter username must only consist of alphanumeric characters or "
-"underscore"
+msgid "The Twitter username must only consist of alphanumeric characters or underscore"
 msgstr "El usuario de twitter sólo debe contener caracteres alfanuméricos o guión abajo "
 
 #: candidates/forms.py:177
 #, python-brace-format
-msgid ""
-"If you mark the candidate as standing in the {election}, you must select a "
-"post"
+msgid "If you mark the candidate as standing in the {election}, you must select a post"
 msgstr "Si indicás que el candidato se presenta a {election}, debes seleccionar un cargo"
 
 #: candidates/forms.py:186
@@ -384,8 +365,7 @@ msgstr "Identificador de cargo (post ID {post_id}) desconocido"
 
 #: candidates/forms.py:192
 #, python-brace-format
-msgid ""
-"Could not find parties for the post with ID '{post_id}' in the {election}"
+msgid "Could not find parties for the post with ID '{post_id}' in the {election}"
 msgstr "No encontramos partidos para el cargo con post ID '{post_id}' en la elección de {election}"
 
 #: candidates/forms.py:200
@@ -442,9 +422,7 @@ msgstr "Fuente de información para este cambio ({0})"
 
 #: candidates/forms.py:425
 #, python-brace-format
-msgid ""
-"You can only edit data on {site_name} if you agree to this copyright "
-"assignment."
+msgid "You can only edit data on {site_name} if you agree to this copyright assignment."
 msgstr ""
 
 #: candidates/forms.py:449
@@ -501,9 +479,7 @@ msgid "Name change from '{0}' to '{1}' by user {2} disallowed"
 msgstr "Cambio de nombre de '{0}' a '{1}' por el usuario {2} rechazado."
 
 #: candidates/models/auth.py:84
-msgid ""
-"That update isn't allowed because candidates for a locked post would be "
-"changed"
+msgid "That update isn't allowed because candidates for a locked post would be changed"
 msgstr "La actualización no está permitida porque los candidatos para un puesto bloqueado pueden ser cambiados"
 
 #: candidates/models/db.py:29
@@ -558,10 +534,7 @@ msgid "(This list of candidates is currently <strong>unlocked</strong>.)"
 msgstr "(Esta lista de candidatos está <strong>abierta</strong>.)"
 
 #: candidates/templates/candidates/_candidates_for_post.html:74
-msgid ""
-"This list of candidates is now <strong>locked</strong>; you can still update"
-" contact details of candidates, but can't change the people standing in this"
-" constituency."
+msgid "This list of candidates is now <strong>locked</strong>; you can still update contact details of candidates, but can't change the people standing in this constituency."
 msgstr "Esta lista de candidatos está <strong>cerrada</strong>; aún se puede actualizar información de contacto de los candidatos, pero no se puede cambiar la gente que se presenta en este distrito."
 
 #: candidates/templates/candidates/_candidates_for_post.html:83
@@ -611,9 +584,7 @@ msgstr "¡Este candidato ganó!"
 
 #: candidates/templates/candidates/_candidates_for_post.html:150
 #, python-format
-msgid ""
-"<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s "
-"for the %(election_name)s yet."
+msgid "<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s for the %(election_name)s yet."
 msgstr "<strong>¡Epa!</strong> Aún no conocemos a ningún pre-candidato a %(post_label)s para las elecciones a %(election_name)s."
 
 #: candidates/templates/candidates/_candidates_for_post.html:154
@@ -649,8 +620,7 @@ msgid "Is a candidate from the 2010 election standing again?"
 msgstr "¿Un candidato de la elección anterior se presenta de nuevo?"
 
 #: candidates/templates/candidates/_candidates_for_post.html:200
-msgid ""
-"We don't know if these candidates from earlier elections are standing again"
+msgid "We don't know if these candidates from earlier elections are standing again"
 msgstr "No sabemos si estos candidatos de elecciones anteriores se presentan de nuevo"
 
 #: candidates/templates/candidates/_candidates_for_post.html:221
@@ -662,8 +632,7 @@ msgid "Not standing again"
 msgstr "No se presenta de nuevo"
 
 #: candidates/templates/candidates/_candidates_for_post.html:247
-msgid ""
-"These candidates from earlier elections are known not to be standing again"
+msgid "These candidates from earlier elections are known not to be standing again"
 msgstr "Estos candidatos de elecciones anteriores no se presentan de nuevo"
 
 #: candidates/templates/candidates/_candidates_for_post.html:267
@@ -672,9 +641,7 @@ msgstr "¡De verdad, se presentan!"
 
 #: candidates/templates/candidates/_edits_disallowed_message.html:2
 #, python-format
-msgid ""
-"Editing of data in %(site.name)s is now disabled, but if you have a "
-"correction, please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
+msgid "Editing of data in %(site.name)s is now disabled, but if you have a correction, please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:4
@@ -717,9 +684,7 @@ msgid "They commented: “%(user_comment)s”."
 msgstr "El usuario comentó: “%(user_comment)s”."
 
 #: candidates/templates/candidates/_photo-credit.html:18
-msgid ""
-"The volunteer moderator who reviewed this photo picked a different "
-"justification for its use on the site, which was:"
+msgid "The volunteer moderator who reviewed this photo picked a different justification for its use on the site, which was:"
 msgstr "El moderador voluntario que revisó esta foto dió una justificación diferente para usarla en este sitio, que fué:"
 
 #: candidates/templates/candidates/_photo-credit.html:27
@@ -733,22 +698,16 @@ msgid "Notes about this image: “%(notes)s”."
 msgstr "Notas sobre esta imágen: “%(notes)s”."
 
 #: candidates/templates/candidates/_photo-expand-reason.html:3
-msgid ""
-"the photo is free of copyright restrictions (i.e. has explictly been placed "
-"in the public domain)"
+msgid "the photo is free of copyright restrictions (i.e. has explictly been placed in the public domain)"
 msgstr "la foto está libre de restricciones de copyright (por ejemplo, fué puesta explícitamente en el dominio público, o está publicada con licencia Creative Commons)"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:8
 #, python-format
-msgid ""
-"they have assigned the copyright of the image to %(site_owner)s so that we "
-"may use it on the site"
+msgid "they have assigned the copyright of the image to %(site_owner)s so that we may use it on the site"
 msgstr ""
 
 #: candidates/templates/candidates/_photo-expand-reason.html:13
-msgid ""
-"this photo is the candidate's profile on social media, or is used to promote"
-" their candidacy on an official candidate or party website"
+msgid "this photo is the candidate's profile on social media, or is used to promote their candidacy on an official candidate or party website"
 msgstr "la foto es el perfil del candidato en medios sociales, o es usada para promover su candidatura en un sitio oficial del candidato o del partido"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:18
@@ -781,37 +740,22 @@ msgstr "Acerca de este sitio"
 
 #: candidates/templates/candidates/about.html:17
 #, python-format
-msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or"
-" bug reports."
+msgid "Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or bug reports."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:22
 #: elections/uk_general_election_2015/templates/candidates/about.html:26
-msgid ""
-"The source code for this site is <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/\">available on "
-"GitHub</a>, and you can find a <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/issues\">list of "
-"known bugs</a> there as well."
-msgstr "El código fuente de este sitio está <a href=\"https://github.com/mysociety/yournextrepresentative/\">disponible en GitHub</a>, y podés encontrar la <a href=\"https://github.com/mysociety/yournextrepresentative/issues\">lista de errores conocidos</a> ahí también.\nY este es nuestro <a href=\"https://github.com/YoQuieroSaber/yournextrepresentative/\">fork para Argentina</a>, en GitHub también."
+msgid "The source code for this site is <a href=\"https://github.com/mysociety/yournextrepresentative/\">available on GitHub</a>, and you can find a <a href=\"https://github.com/mysociety/yournextrepresentative/issues\">list of known bugs</a> there as well."
+msgstr "El código fuente de este sitio está <a href=\"https://github.com/mysociety/yournextrepresentative/\">disponible en GitHub</a>, y podés encontrar la <a href=\"https://github.com/mysociety/yournextrepresentative/issues\">lista de errores conocidos</a> ahí también. Y este es nuestro <a href=\"https://github.com/YoQuieroSaber/yournextrepresentative/\">fork para Argentina</a>, en GitHub también."
 
 #: candidates/templates/candidates/about.html:30
-msgid ""
-"This site was originally developed by Mark Longair (mySociety), Sym Roe "
-"(Democracy Club) and Zarino Zappia (mySociety), and <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many"
-" other contributors</a>, to whom we owe a debt of gratitude."
+msgid "This site was originally developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety), and <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many other contributors</a>, to whom we owe a debt of gratitude."
 msgstr ""
 
 #: candidates/templates/candidates/about.html:38
 #: elections/uk_general_election_2015/templates/candidates/about.html:49
 #, python-format
-msgid ""
-"You can use the data from this site, via the <a href=\"%(api_url)s\">API or "
-"CSV download</a>, under the terms of the Creative Commons license <a "
-"href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-"
-"ShareAlike (CC-BY-SA)</a> with the exception of:"
+msgid "You can use the data from this site, via the <a href=\"%(api_url)s\">API or CSV download</a>, under the terms of the Creative Commons license <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-ShareAlike (CC-BY-SA)</a> with the exception of:"
 msgstr "Podés usar los datos de este sitio, a través de la <a href=\"%(api_url)s\">API o descarga CSV</a>, bajo los términos de la licencia Creative Commons <a href=\"https://creativecommons.org/licenses/by-sa/4.0/deed.es\">Atribución-CompartirIgual 4.0 Internacional (CC BY-SA 4.0)</a> con la excepción de:"
 
 #: candidates/templates/candidates/about.html:47
@@ -820,20 +764,13 @@ msgstr ""
 
 #: candidates/templates/candidates/about.html:48
 #: elections/uk_general_election_2015/templates/candidates/about.html:59
-msgid ""
-"Candidate photos, which are typically either submitted by the candidates "
-"themselves, or from sources where it seems reasonable that we might use them"
-" on this site, such as the party's official page for that candidate, or "
-"their social media profile picture."
+msgid "Candidate photos, which are typically either submitted by the candidates themselves, or from sources where it seems reasonable that we might use them on this site, such as the party's official page for that candidate, or their social media profile picture."
 msgstr "Las fotos de los candidatos, que típicamente son enviadas por los propios candidaos, o de fuentes donde parece razonable que podaos usarlas, como la página oficial del candidato o su perfil en medios sociales."
 
 #: candidates/templates/candidates/about.html:56
 #: elections/uk_general_election_2015/templates/candidates/about.html:67
 #, python-format
-msgid ""
-"If the CC-BY-SA licence is problematic for you, but you feel that you have a"
-" worthwhile use of the data in mind, please <a "
-"href=\"mailto:%(email)s\">contact us</a> to discuss your situation further."
+msgid "If the CC-BY-SA licence is problematic for you, but you feel that you have a worthwhile use of the data in mind, please <a href=\"mailto:%(email)s\">contact us</a> to discuss your situation further."
 msgstr "Si la licencia CC-BY-SA le resulta problemática, por favor <a href=\"mailto:%(email)s\">contáctenos</a> para charlar sobre su situacion."
 
 #: candidates/templates/candidates/about.html:62
@@ -855,11 +792,7 @@ msgstr "Descargo de responsabilidades"
 #: candidates/templates/candidates/about.html:72
 #: elections/uk_general_election_2015/templates/candidates/about.html:95
 #, python-format
-msgid ""
-"The data on this website is crowd-sourced and may not be complete (or may "
-"contain inaccuracies). If you find an error, please either update the page "
-"yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the "
-"problem."
+msgid "The data on this website is crowd-sourced and may not be complete (or may contain inaccuracies). If you find an error, please either update the page yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the problem."
 msgstr "La información en este sitio es producto de una investigación colectiva (crowd-source) y puede no estar completa o contener inexactitudes. Si encuentra un error, por favor actualice la página usted mismo, o <a href=\"mailto:%(email)s\">envíenos un correo</a> para reportar el problema."
 
 #: candidates/templates/candidates/all-edits-disallowed.html:6
@@ -880,11 +813,7 @@ msgid "Using this data via the API"
 msgstr "Usando estos datos via la API"
 
 #: candidates/templates/candidates/api.html:16
-msgid ""
-"The data that's submitted to this site is available as a CSV/Excel download "
-"and programmatically via a RESTful web service called PopIt, which stores "
-"information about people and their positions in organizations. (You can <a "
-"href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
+msgid "The data that's submitted to this site is available as a CSV/Excel download and programmatically via a RESTful web service called PopIt, which stores information about people and their positions in organizations. (You can <a href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
 msgstr "Los datos enviados a este sitio están disponibles como un archivo CSV (formato Excel) para descargar y para su acceso automatizado metiante una API RESTful, de un webservice llamado PopIt, que almacena información sobre personas y sus posiciones en organizaciones. Podés  <a href=\"http://popit.poplus.org/\">saber más sobre PopIt en su sitio web</a>."
 
 #: candidates/templates/candidates/api.html:24
@@ -922,10 +851,7 @@ msgid "The base API URL for the data is:"
 msgstr "La URL base para la API es:"
 
 #: candidates/templates/candidates/api.html:72
-msgid ""
-"You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic "
-"documentation for the PopIt API</a> or just follow the simple examples that "
-"follow."
+msgid "You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic documentation for the PopIt API</a> or just follow the simple examples that follow."
 msgstr "Podés leer <a href=\"http://popit.poplus.org/docs/api/\">documentación más genérica para la API de PopIt</a> o seguir los simples ejemplos a continuación."
 
 #: candidates/templates/candidates/api.html:78
@@ -933,11 +859,7 @@ msgid "Find a Constituency ID"
 msgstr "Encontrar el ID de un distrito"
 
 #: candidates/templates/candidates/api.html:80
-msgid ""
-"In order to look up candidates for a constituency, you have to find the ID "
-"of that constituency. The IDs that we use for constituencies are the IDs for"
-" Westminster constituencies areas in another web service, <a "
-"href=\"http://mapit.mysociety.org\">MapIt</a>."
+msgid "In order to look up candidates for a constituency, you have to find the ID of that constituency. The IDs that we use for constituencies are the IDs for Westminster constituencies areas in another web service, <a href=\"http://mapit.mysociety.org\">MapIt</a>."
 msgstr "Con el fin de buscar candidatos para un distrito electoral, usted tiene que encontrar el ID de ese distrito. Los identificadores que utilizamos para los distritos electorales son los ID del distrito electoral de Westminster en otro servicio web, <a href=\"http://mapit.mysociety.org\"> MapIt </a>."
 
 #: candidates/templates/candidates/api.html:88
@@ -945,22 +867,15 @@ msgid "... from a postcode"
 msgstr "... de un código postal"
 
 #: candidates/templates/candidates/api.html:90
-msgid ""
-"Suppose you want to find the constituency for the postcode SW1A&nbsp;1AA, "
-"then you would make a GET request to the following URL:"
+msgid "Suppose you want to find the constituency for the postcode SW1A&nbsp;1AA, then you would make a GET request to the following URL:"
 msgstr "Suponga usted quiere encontrar el distrito electoral para el código postal SW1A&nbsp;1AA, después usted podría intentar una búsqueda para el siguiente URL:"
 
 #: candidates/templates/candidates/api.html:100
-msgid ""
-"This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON "
-"object</a>, wherein the constituency ID can be found at "
-"<tt>.shortcuts.WMC</tt>."
+msgid "This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON object</a>, wherein the constituency ID can be found at <tt>.shortcuts.WMC</tt>."
 msgstr "Esto <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">regresará a objeto JSON </a>, en donde la identificación del distrito electoral puede ser encontrada como <tt>.shortcuts.WMC</tt>."
 
 #: candidates/templates/candidates/api.html:106
-msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org"
-"/#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
+msgid "There's more documentation available on <a href=\"http://mapit.mysociety.org/#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
 msgstr "Hay más documentación disponible en <a href=\"http://mapit.mysociety.org/#api-by_postcode\">la búsqueda del código postal en la pagina principal de Maplt </a>."
 
 #: candidates/templates/candidates/api.html:112
@@ -968,24 +883,15 @@ msgid "... from a latitude / longitude or other coordinate"
 msgstr "... de una latitud / longitud u otra coordenada"
 
 #: candidates/templates/candidates/api.html:114
-msgid ""
-"You can look up constituencies in MapIt using a variety of coordinate "
-"systems. To give the most common example, you might have a WGS84 coordinate "
-"from a GPS or location API, in which can you should put the SRID 4326 in "
-"your lookup. For example, latitude 52.205083 and longitude 0.115194 could be"
-" looked up with:"
+msgid "You can look up constituencies in MapIt using a variety of coordinate systems. To give the most common example, you might have a WGS84 coordinate from a GPS or location API, in which can you should put the SRID 4326 in your lookup. For example, latitude 52.205083 and longitude 0.115194 could be looked up with:"
 msgstr "Usted puede buscar el distrito electoral en Maplt usando una varieda de sistemas de coordenadas. Para dar el ejemplo más común, usted puede tener una coordenada WGS84 de un GPS o una ubicación API, en donde podrá poner la SRID 4326 en su búsqueda. Por ejemplo, latitud 52.205083 y longitud 0.115194  puede ser buscada como: "
 
 #: candidates/templates/candidates/api.html:126
-msgid ""
-"(Note that the longitude comes before the latitude, which might not be what "
-"you expect.) The only key in that object is the constituency ID."
+msgid "(Note that the longitude comes before the latitude, which might not be what you expect.) The only key in that object is the constituency ID."
 msgstr "(Note que la longitud viene después de la latitud, que puede ser lo que usted espere.) La única clave in ese caso objeto es la identificación del distrito electoral."
 
 #: candidates/templates/candidates/api.html:132
-msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org"
-"/#api-by_point\">point lookups on the MapIt front-page</a>."
+msgid "There's more documentation available on <a href=\"http://mapit.mysociety.org/#api-by_point\">point lookups on the MapIt front-page</a>."
 msgstr "Hay más documentación disponible en <a href=\"http://mapit.mysociety.org/#api-by_point\">la búsqueda del código postal en la pagina principal de Maplt </a>."
 
 #: candidates/templates/candidates/api.html:138
@@ -993,18 +899,11 @@ msgid "... by selecting it from its name"
 msgstr "... seleccionando por su nombre"
 
 #: candidates/templates/candidates/api.html:140
-msgid ""
-"If you need to produce a list of all constituencies (e.g. for a select box) "
-"and allow the user to pick one, you can get a list of all Westminster "
-"constituencies in the UK from this request:"
+msgid "If you need to produce a list of all constituencies (e.g. for a select box) and allow the user to pick one, you can get a list of all Westminster constituencies in the UK from this request:"
 msgstr "si necesita producir una lista de todos los distritos electorales (por ejemplo para una caja de selección) y permitir a los usuarios elegir uno, puede tomar la lista del distrito electoral de Westminster en el UK para esta solicitud:"
 
 #: candidates/templates/candidates/api.html:150
-msgid ""
-"The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that"
-" request</a> has the constituency ID as its keys; the values are objects "
-"that include (among other things) a <tt>name</tt> element that gives you the"
-" official name of the constituency."
+msgid "The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that request</a> has the constituency ID as its keys; the values are objects that include (among other things) a <tt>name</tt> element that gives you the official name of the constituency."
 msgstr "El <a href=\"http://mapit.mysociety.org/areas/WMC\">dato resultante de esa búsqueda </a> tiene la identificación del distrito electoral como su clave; los valores son objetos que incluyen (entre otras cosas) un <tt>nombre</tt> elemento que te da el nombre oficial del distrito electoral"
 
 #: candidates/templates/candidates/api.html:158
@@ -1012,12 +911,7 @@ msgid "Find Candidates for a Constituency"
 msgstr "Encontrar candidatos para un distrito electoral"
 
 #: candidates/templates/candidates/api.html:160
-msgid ""
-"There are broadly two ways you can approach getting candidate data for a "
-"constituency; one is slightly simpler, and just gives you the basic "
-"candidate and party information, while the second gives you the full data in"
-" Popolo format, which is more complex but useful if you're using tools that "
-"generically process Popolo data."
+msgid "There are broadly two ways you can approach getting candidate data for a constituency; one is slightly simpler, and just gives you the basic candidate and party information, while the second gives you the full data in Popolo format, which is more complex but useful if you're using tools that generically process Popolo data."
 msgstr "Existen dos maneras usted puede aproximarse a los datos de un candidato para un distrito electoral: una es bastante simple, y solo te da los candidatos básicos y la información del partido, mientras el segundo te da los datos completos en formato Popolo, que es más complejo pero útil si usa herramientas que generalmente procesan datos Popolo."
 
 #: candidates/templates/candidates/api.html:169
@@ -1025,51 +919,28 @@ msgid "Simpler (Basic candidate information)"
 msgstr "Simple (Información básica del candidato)"
 
 #: candidates/templates/candidates/api.html:171
-msgid ""
-"You can get all the candidates for a constituency, both in 2010 and 2015 by "
-"a query like:"
+msgid "You can get all the candidates for a constituency, both in 2010 and 2015 by a query like:"
 msgstr "Puede mirar todos los candidatos en un distrio electoral, tanto en 2010 como en 2015, en una búsqueda tipo: "
 
 #: candidates/templates/candidates/api.html:180
 #, python-format
-msgid ""
-"For example, for Dulwich and West Norwood, <a "
-"href=\"%(popit_url)sposts/65808?embed=membership.person\">these would be the"
-" results</a>."
+msgid "For example, for Dulwich and West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person\">these would be the results</a>."
 msgstr "Por ejemplo, para Dulwich y West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person\">este puede ser el resultado</a>."
 
 #: candidates/templates/candidates/api.html:186
-msgid ""
-"If you iterate over the <tt>memberships</tt> in that result, each person "
-"will look something like:"
+msgid "If you iterate over the <tt>memberships</tt> in that result, each person will look something like:"
 msgstr "Si usted hace una iteración sobre la<tt>memebresía<tt> en ese resultado, cada persona verá algo como:"
 
 #: candidates/templates/candidates/api.html:214
-msgid ""
-"(I've removed some fields there to keep the example simpler.) The two fields"
-" of particular interest are probably <tt>standing_in</tt> and "
-"<tt>party_memberships</tt>."
+msgid "(I've removed some fields there to keep the example simpler.) The two fields of particular interest are probably <tt>standing_in</tt> and <tt>party_memberships</tt>."
 msgstr "(Removimos algunos campos para mantener el ejemplo simple). Los dos campos de particular interés son probablemente <tt>se presenta<tt> y <tt>membresía_partido<tt>"
 
 #: candidates/templates/candidates/api.html:222
-msgid ""
-"This object will only have keys '2010' or '2015'. If one of these keys is "
-"present then we have known information about the candidate for the UK "
-"general election in that year.  If the value is <tt>null</tt> then we know "
-"that they're <em>not</em> standing. If they are (or were) standing in the "
-"general election in that year then there will be a dictionary giving you "
-"details of the constituency they were standing in. So, in the example above "
-"we can see that Tessa Jowell stood in 2010 in Dulwich and West Norwood, but "
-"we know isn't standing in any consituency in 2015."
+msgid "This object will only have keys '2010' or '2015'. If one of these keys is present then we have known information about the candidate for the UK general election in that year.  If the value is <tt>null</tt> then we know that they're <em>not</em> standing. If they are (or were) standing in the general election in that year then there will be a dictionary giving you details of the constituency they were standing in. So, in the example above we can see that Tessa Jowell stood in 2010 in Dulwich and West Norwood, but we know isn't standing in any consituency in 2015."
 msgstr "Este objeto solo tienen claves '2010' o '2015'. Si una de esas claves se presenta entonces sabemos infomación acerca del candidato para las elecciones generales del UK en ese año. Si el valor es <tt>null<tt> entonces sabemos que ellos <em>not</em> se presentan. Si ellos están (o estuvieron) presentandose en las elecciones generales en ese año, entonces habrá un diccionario dandole detalles del distrito electoral en que ellos se presentaron. Entonces, en el ejemplo de arriba podemos ver que Tessa Jowell se situó en 2010 en Dulwich y West Norwood, pero sabemos no se está presentando en ningún distrito electoral en 2015"
 
 #: candidates/templates/candidates/api.html:236
-msgid ""
-"This object will similarly only have keys '2010' or '2015' and tells you "
-"what party the candidate is / was standing for in the general election of "
-"that year.  So in the example above, you can see that Tessa Jowell stood for"
-" the Labour Party in 2010, but has no entry for 2015 (because, as the "
-"<tt>standing_in</tt> tells us) she's not standing in 2015."
+msgid "This object will similarly only have keys '2010' or '2015' and tells you what party the candidate is / was standing for in the general election of that year.  So in the example above, you can see that Tessa Jowell stood for the Labour Party in 2010, but has no entry for 2015 (because, as the <tt>standing_in</tt> tells us) she's not standing in 2015."
 msgstr "Este objeto similar solo tiene llaves '2010' o '2015' y le dice qué partido se presentó o se está presentando para las elecciones generales de ese año. Entonces en el ejemplo de arriba, puede ver que Tessa Jowell se situó para el Partido LAboral en 2010, peso no tiene entradas para el 2015 (porque, como la <tt>standing_in</tt> nos dice) ella nos e presenta en 2015."
 
 #: candidates/templates/candidates/api.html:245
@@ -1077,38 +948,20 @@ msgid "More complex (Full Popolo information)"
 msgstr "Mas complejo (Información Popolo completa)"
 
 #: candidates/templates/candidates/api.html:247
-msgid ""
-"All the candidates we know about for a constituency can be returned by "
-"making a GET request to a URL of this form, where you should substitute in "
-"the constituency ID for CONSTITUENCY_ID:"
+msgid "All the candidates we know about for a constituency can be returned by making a GET request to a URL of this form, where you should substitute in the constituency ID for CONSTITUENCY_ID:"
 msgstr "Todos los candidatos que conocemos por un distrito electoral pueden ser devueltos haciendo una búsqueda GET a una URL de esta forma, donde usted pude sustituir en la identificación del distrito electoral por DISTRITO ELECTORAL_ID:"
 
 #: candidates/templates/candidates/api.html:258
 #, python-format
-msgid ""
-"For example, for Dulwich and West Norwood, <a "
-"href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">these"
-" would be the results</a>. To explain further, that's showing information "
-"about the <em>post</em> \"MP for Dulwich and West Norwood\". Under the "
-"<tt>memberships</tt> key of the <tt>result</tt> dictionary you can find all "
-"memberships of this post - those that have the <tt>role</tt> \"Candidate\" "
-"were candidates at one point."
+msgid "For example, for Dulwich and West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">these would be the results</a>. To explain further, that's showing information about the <em>post</em> \"MP for Dulwich and West Norwood\". Under the <tt>memberships</tt> key of the <tt>result</tt> dictionary you can find all memberships of this post - those that have the <tt>role</tt> \"Candidate\" were candidates at one point."
 msgstr "Por ejemplo, para Dulwich y West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">este puede ser el resultado</a>. PAra explicar detalladamente, se muestra informacion acerca del <em>post</em>\"MP for Dulwich y West Norwood\". Dentro de la clave del diccionario de <tt>membresía</tt> puede encontrar todas las membres´´ias para este puesto - aquellos que tiene el <tt>rol</tt>como\"Candidato\"o fueron candidatos en algún momento."
 
 #: candidates/templates/candidates/api.html:268
-msgid ""
-"You should then look at the start and end dates of that membership, which "
-"will tell you whether they're a candidate for the 2015 election or were a "
-"past candidate for the 2010 election:"
+msgid "You should then look at the start and end dates of that membership, which will tell you whether they're a candidate for the 2015 election or were a past candidate for the 2010 election:"
 msgstr "Después puede mirar al comienzo y fin de la membresía, lo que le dirá si es un candidato para la elección del 2015, o lo fue antes para la elección del 2010:"
 
 #: candidates/templates/candidates/api.html:281
-msgid ""
-"Under <tt>person_id</tt> attribute of each of those membership you can find "
-"information about that candidate, like their name, contact details and (in "
-"another nested <tt>memberships</tt> object) their memberships of political "
-"parties. The party memberships use the same date values as above to indicate"
-" whether it's their party membership at the 2010 or 2015 election."
+msgid "Under <tt>person_id</tt> attribute of each of those membership you can find information about that candidate, like their name, contact details and (in another nested <tt>memberships</tt> object) their memberships of political parties. The party memberships use the same date values as above to indicate whether it's their party membership at the 2010 or 2015 election."
 msgstr "Dentro del atributo <tt>person_id</tt> de cada uno de las membresías puede encontrar información acerca del candidato, como su nombre, detalles de contacto (in otro objeto anidado <tt>memberships</tt>), sus participaciones en partidos políticos. La membresía del partído político usa los mismos valores de datos como indica arriba tanto si es una membresía de las elecciones del 2010 o del 2015."
 
 #: candidates/templates/candidates/api.html:293
@@ -1116,19 +969,12 @@ msgid "Find a candidate by name"
 msgstr "Buscar un candidato por nombre"
 
 #: candidates/templates/candidates/api.html:295
-msgid ""
-"You can use the <tt>search/persons</tt> endpoint with a query paramter like "
-"<tt>q=name:\"John Doe\"</tt>."
+msgid "You can use the <tt>search/persons</tt> endpoint with a query paramter like <tt>q=name:\"John Doe\"</tt>."
 msgstr "Puede usar la <tt>search/persons</tt> endpoint con una búsqueda paramétrica como <tt>q=name:\"John Doe\"</tt>."
 
 #: candidates/templates/candidates/api.html:304
 #, python-format
-msgid ""
-"For example, you can find every David Jones in the database with <a "
-"href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this "
-"query</a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt>"
-" elements will give you details about which constituencies they are / were "
-"standing in, and for which parties."
+msgid "For example, you can find every David Jones in the database with <a href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this query</a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt> elements will give you details about which constituencies they are / were standing in, and for which parties."
 msgstr "Por ejemplo, usted puede encontrar a cada David Jones en la base de datos con  <a href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this query</a>. como se muestra arriba, el <tt>standing_in</tt> and <tt>party_memberships</tt>  elemento le dará detalles acerca de en cual distrito electoral ellos están o estuvieron presentándose, y para cual partido."
 
 #: candidates/templates/candidates/api.html:313
@@ -1137,19 +983,12 @@ msgstr "Conozca a los pre-candidatos de las PASO 2015"
 
 #: candidates/templates/candidates/api.html:315
 #, python-format
-msgid ""
-"You can also use the <tt>search/persons</tt> endpoint to find all the "
-"candidates that we think are standing in 2015, with <a "
-"href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id "
-"\">this query</a>:"
+msgid "You can also use the <tt>search/persons</tt> endpoint to find all the candidates that we think are standing in 2015, with <a href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id \">this query</a>:"
 msgstr "Usted puede usar el <tt>search/persons</tt> punto final para encontrar todos los candidatos que nosotros creemos se están presentando en 2015, con  <a href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id \">this query</a>:"
 
 #: candidates/templates/candidates/api.html:326
 #, python-format
-msgid ""
-"(This question was raised on the <a href=\"%(url)s\">Democracy Club Google "
-"Group</a>, which may be of interest if you're developing software that uses "
-"the %(site.name)s data.)"
+msgid "(This question was raised on the <a href=\"%(url)s\">Democracy Club Google Group</a>, which may be of interest if you're developing software that uses the %(site.name)s data.)"
 msgstr ""
 
 #: candidates/templates/candidates/areas-of-type.html:10
@@ -1175,22 +1014,13 @@ msgstr ""
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:22
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:22
 #, python-format
-msgid ""
-"Before you carry on to edit data in %(site_name)s, we need you to agree that"
-" your contributions to this site (with the exception of photo uploads) are "
-"owned by %(copyright_holder)s. In return, we agree to make the complete "
-"database available under an open licence such as <a "
-"href=\"http://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or "
-"remove copyright restrictions by releasing into the public domain (<a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
+msgid "Before you carry on to edit data in %(site_name)s, we need you to agree that your contributions to this site (with the exception of photo uploads) are owned by %(copyright_holder)s. In return, we agree to make the complete database available under an open licence such as <a href=\"http://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or remove copyright restrictions by releasing into the public domain (<a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:42
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:42
 #, python-format
-msgid ""
-"I assign the copyright of my contributions to %(site_name)s (apart from "
-"photo uploads) to %(copyright_holder)s."
+msgid "I assign the copyright of my contributions to %(site_name)s (apart from photo uploads) to %(copyright_holder)s."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:49
@@ -1201,10 +1031,7 @@ msgstr "Continuar"
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:53
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:53
 #, python-format
-msgid ""
-"Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a "
-"href=\"mailto:%(email)s\">email us</a> if you have any questions about this "
-"agreement."
+msgid "Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a href=\"mailto:%(email)s\">email us</a> if you have any questions about this agreement."
 msgstr "De lo contrario puede <a href=\"%(url)s\">cerrar sesión</a>. Por favor <a href=\"mailto:%(email)s\">escríbanos</a> si tiene preguntas sobre este acuerdo."
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:61
@@ -1214,12 +1041,7 @@ msgstr "¿Por qué le pedimos que acepte esto?"
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:63
 #, python-format
-msgid ""
-"This is the simplest way to ensure that we can make this data as widely "
-"available as possible while preventing the hard work of contributors to "
-"%(site_name)s being unfairly co-opted by companies building closed candidate"
-" databases. This also allows us the flexibility to release the data under "
-"different open licenses in the future."
+msgid "This is the simplest way to ensure that we can make this data as widely available as possible while preventing the hard work of contributors to %(site_name)s being unfairly co-opted by companies building closed candidate databases. This also allows us the flexibility to release the data under different open licenses in the future."
 msgstr ""
 
 #: candidates/templates/candidates/candidacy-create.html:6
@@ -1230,10 +1052,7 @@ msgstr "¿Cómo sabes que %(name)s se presenta?"
 
 #: candidates/templates/candidates/candidacy-create.html:14
 #, python-format
-msgid ""
-"Before updating our records we need to know the source for your information "
-"that %(name)s is standing for election to the post of %(post_label)s in the "
-"%(election_name)s."
+msgid "Before updating our records we need to know the source for your information that %(name)s is standing for election to the post of %(post_label)s in the %(election_name)s."
 msgstr "Antes de actualizar nuestro archivos necesitamos saber la fuente para su información que %(name)s se está presentando para la elección del puesto %(post_label)s en la %(election_name)s."
 
 #: candidates/templates/candidates/candidacy-delete.html:6
@@ -1244,10 +1063,7 @@ msgstr "Cómo sabés que %(name)s no se presenta?"
 
 #: candidates/templates/candidates/candidacy-delete.html:14
 #, python-format
-msgid ""
-"Before updating our records we need to know the source for your information "
-"that %(name)s <strong>isn’t</strong> standing for election to the post of "
-"%(post_label)s in the %(election_name)s."
+msgid "Before updating our records we need to know the source for your information that %(name)s <strong>isn’t</strong> standing for election to the post of %(post_label)s in the %(election_name)s."
 msgstr "Antes de actualizar nuestros archivos necesitamos saber la fuente de la información que%(name)s <strong>isn’t</strong> presentandose para  el puesto de la elección de %(post_label)s en la %(election_name)s."
 
 #: candidates/templates/candidates/constituencies-declared.html:6
@@ -1289,9 +1105,7 @@ msgid "All Constituencies for the 2015 General Election"
 msgstr "Todos los distritos para las PASO 2015"
 
 #: candidates/templates/candidates/constituencies.html:14
-msgid ""
-"Follow one of the links below to see the known candidates for that "
-"constituency:"
+msgid "Follow one of the links below to see the known candidates for that constituency:"
 msgstr "Sigue uno de los enlaces abajo para ver los candidatos de ese distrito:"
 
 #: candidates/templates/candidates/constituency.html:9
@@ -1325,8 +1139,7 @@ msgstr "@yournextmp"
 
 #: candidates/templates/candidates/constituency.html:35
 #, python-format
-msgid ""
-"Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
+msgid "Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr "Pre-candidatos a <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 
 #: candidates/templates/candidates/constituency.html:47
@@ -1337,10 +1150,7 @@ msgid "Invalidate Cache"
 msgstr "Invalidar Cache"
 
 #: candidates/templates/candidates/constituency.html:48
-msgid ""
-"As a staff user, you can invalidate any cached data for this constituency. "
-"This may <em>occasionally</em> be necessary if the page is showing stale "
-"information for more than 10 seconds."
+msgid "As a staff user, you can invalidate any cached data for this constituency. This may <em>occasionally</em> be necessary if the page is showing stale information for more than 10 seconds."
 msgstr "Como moderador, podés invalidar los datos en cache (actualizar) para este distrito. Esto puede ocasionalmente ser necesario si la página muestra información vieja por más de 10 segundos."
 
 #: candidates/templates/candidates/frontpage.html:14
@@ -1354,9 +1164,7 @@ msgid "Find candidates to be your next representative"
 msgstr "Encontrá candidatos"
 
 #: candidates/templates/candidates/frontpage.html:34
-msgid ""
-"Don’t pay for a candidate database sold by a data vendor — it’s a waste of "
-"money."
+msgid "Don’t pay for a candidate database sold by a data vendor — it’s a waste of money."
 msgstr "No le pagues a un proveedor de bases de datos -- es un desperdicio de dinero."
 
 #: candidates/templates/candidates/frontpage.html:44
@@ -1370,11 +1178,7 @@ msgstr "Esta base de datos de candidatos es producto de una investigación colec
 
 #: candidates/templates/candidates/frontpage.html:57
 #, python-format
-msgid ""
-"The database is transparently sourced and available as structured data, "
-"suitable for building other election websites. <a href=\"%(api_url)s\">Get "
-"the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new "
-"candidate details.</a>"
+msgid "The database is transparently sourced and available as structured data, suitable for building other election websites. <a href=\"%(api_url)s\">Get the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new candidate details.</a>"
 msgstr "Esta base de datos tiene fuentes transparentes y está disponible como datos estructurados, lo que permite hacer otras aplicaciones con esta información. <a href=\"%(api_url)s\">Obtené los datos ahora</a>, o <a href=\"%(tasks_url)s\">colaborá con más detalles de los candidatos.</a>"
 
 #: candidates/templates/candidates/frontpage.html:70
@@ -1383,102 +1187,67 @@ msgstr "Cambios recientes"
 
 #: candidates/templates/candidates/frontpage.html:77
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new "
-"candidate</a> <span class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new candidate</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> agregó <a href=\"%(person_url)s\">un nuevo candidato</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:83
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> is creating a new candidate <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> is creating a new candidate <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> está agregando un nuevo candidato, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:89
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> merged another candidate into <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> merged another candidate into <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> unificó otro candidato con <a href=\"%(person_url)s\">el candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:95
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> uploaded a photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> uploaded a photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> subió una foto de <a href=\"%(person_url)s\">el candidato #%(person_id)s</a> para ser moderada, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:101
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> approved an uploaded photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> approved an uploaded photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> aprobó una foto subida del <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:107
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> rejected an uploaded photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> rejected an uploaded photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> rechazó una foto subida de <a href=\"%(person_url)s\">el candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:113
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> reverted to an earlier version of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> reverted to an earlier version of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> volvió a una versión anterior del <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:119
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> confirmed candidacy for <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> confirmed candidacy for <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> confirmó la candidatura del <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:125
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> removed candidacy for <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> removed candidacy for <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> eliminó la candidatura del <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:131
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> locked a constituency <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> locked a constituency <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> cerró un distrito, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:135
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> unlocked a constituency <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> unlocked a constituency <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong>abrió un distrito, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:139
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> marked <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> as the winner <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> marked <a href=\"%(person_url)s\">candidate #%(person_id)s</a> as the winner <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> declaró ganador al <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:145
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> updated <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> updated <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr "El usuario <strong>%(username)s</strong> actualizó al <a href=\"%(person_url)s\">candidato #%(person_id)s</a>, <span class=\"when\">hace %(when)s</span>"
 
 #: candidates/templates/candidates/frontpage.html:154
@@ -1517,24 +1286,19 @@ msgstr "Número de ediciones"
 #: candidates/templates/candidates/ordered-party-list.html:9
 #: candidates/templates/candidates/ordered-party-list.html:32
 #, python-format
-msgid ""
-"Party list of %(party_name)s for %(post_label_shorter)s in the "
-"%(election_name)s"
+msgid "Party list of %(party_name)s for %(post_label_shorter)s in the %(election_name)s"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:16
 #: candidates/templates/candidates/ordered-party-list.html:22
 #: candidates/templates/candidates/ordered-party-list.html:27
 #, python-format
-msgid ""
-"Party list of %(party_name)s for %(post_label_shorter)s in the %(election)s"
+msgid "Party list of %(party_name)s for %(post_label_shorter)s in the %(election)s"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:35
 #, python-format
-msgid ""
-"Party list of %(party_name)s for <span id=\"constituency-"
-"name\">%(post_label_shorter)s</span>"
+msgid "Party list of %(party_name)s for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:45
@@ -1544,9 +1308,7 @@ msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:85
 #, python-format
-msgid ""
-"<strong>Oh no!</strong> We don’t know of any candidates from %(party.name)s "
-"for %(post_label)s for the %(election_name)s yet."
+msgid "<strong>Oh no!</strong> We don’t know of any candidates from %(party.name)s for %(post_label)s for the %(election_name)s yet."
 msgstr ""
 
 #: candidates/templates/candidates/party-list.html:6
@@ -1564,43 +1326,30 @@ msgstr "Todos los partidos con candidatos que se presentan en %(election_name)s"
 
 #: candidates/templates/candidates/party.html:8
 #, python-format
-msgid ""
-"%(party_name)s &#8212; Candidates by constituency for the UK 2015 General "
-"Election"
+msgid "%(party_name)s &#8212; Candidates by constituency for the UK 2015 General Election"
 msgstr "Candidatos del partido %(party_name)s a las PASO 2015"
 
 #: candidates/templates/candidates/party.html:20
-msgid ""
-"This shows all the constituencies that have independent candidates standing "
-"in them at the 2015 general election"
+msgid "This shows all the constituencies that have independent candidates standing in them at the 2015 general election"
 msgstr "Muestra todos los distritos que tienen candidatos independientes para las PASO 2015"
 
 #: candidates/templates/candidates/party.html:25
-msgid ""
-"The Speaker of the House of Commons stands as a \"The Speaker seeking re-"
-"election\" rather than a particular party at a general election; for more "
-"information, please see <a href=\"http://www.parliament.uk/about/faqs/house-"
-"of-commons-faqs/speakers-election/\">Parliament's website</a>."
+msgid "The Speaker of the House of Commons stands as a \"The Speaker seeking re-election\" rather than a particular party at a general election; for more information, please see <a href=\"http://www.parliament.uk/about/faqs/house-of-commons-faqs/speakers-election/\">Parliament's website</a>."
 msgstr "El Portavoz de la Cámara de los Comunes de presenta como un \"Portavoz buscando re elección\" más que un partido particular para la elección general; para más información por favor ver  <a href=\"http://www.parliament.uk/about/faqs/house-of-commons-faqs/speakers-election/\">Parliament's website</a>."
 
 #: candidates/templates/candidates/party.html:33
 #, python-format
-msgid ""
-"%(party_name)s is on the Electoral Commission's register for %(register)s."
+msgid "%(party_name)s is on the Electoral Commission's register for %(register)s."
 msgstr "%(party_name)s está en el registro de la Comisión Nacional Electoral para %(register)s."
 
 #: candidates/templates/candidates/party.html:35
 #, python-format
-msgid ""
-"You can find more data about the party's registration at the <a "
-"href=\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
+msgid "You can find more data about the party's registration at the <a href=\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
 msgstr "Podés encontrar más información sobre la registración del partido en la <a href=\"%(ec_url)s\">página de la Comisión Nacional Electoral para %(party_name)s</a>."
 
 #: candidates/templates/candidates/party.html:51
 #, python-format
-msgid ""
-"<a href=\"%(person_url)s\">%(name)s</a> is standing in <a "
-"href=\"%(post_url)s\">%(post)s</a>"
+msgid "<a href=\"%(person_url)s\">%(name)s</a> is standing in <a href=\"%(post_url)s\">%(post)s</a>"
 msgstr "<a href=\"%(person_url)s\">%(name)s</a> se presenta para <a href=\"%(post_url)s\">%(post)s</a>"
 
 #: candidates/templates/candidates/party.html:55
@@ -1610,16 +1359,12 @@ msgstr "Ningún candidato en <a href=\"%(post_url)s\">%(constituency_name)s</a>"
 
 #: candidates/templates/candidates/party.html:63
 #, python-format
-msgid ""
-"There were also %(missing)s posts in %(country)s that %(party_name)s aren't "
-"standing a candidate for."
+msgid "There were also %(missing)s posts in %(country)s that %(party_name)s aren't standing a candidate for."
 msgstr "También había %(missing)s  puestos en %(country)s que  %(party_name)s no se presentaba ningun candidato."
 
 #: candidates/templates/candidates/party.html:68
 #, python-format
-msgid ""
-"There were also %(missing)s posts that %(party_name)s aren't standing a "
-"candidate for."
+msgid "There were also %(missing)s posts that %(party_name)s aren't standing a candidate for."
 msgstr "También hay %(missing)s puestos que %(party_name)s no hay ningún candidato presentandose."
 
 #: candidates/templates/candidates/party.html:75
@@ -1680,9 +1425,7 @@ msgid "Additional information:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:246
-msgid ""
-"<strong>You forgot to reference a source!</strong> Can you show us "
-"<em>where</em> you got this information?"
+msgid "<strong>You forgot to reference a source!</strong> Can you show us <em>where</em> you got this information?"
 msgstr "<strong>¡Te olvidaste de citar una fuente!</strong>¿Nos podés contar <em>dónde</em> obtuviste esta información?"
 
 #: candidates/templates/candidates/person-edit.html:248
@@ -1694,10 +1437,7 @@ msgid "Thanks for helping out!"
 msgstr "¡Gracias por tu colaboración!"
 
 #: candidates/templates/candidates/person-edit.html:265
-msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
-"fields</a>."
+msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields</a>."
 msgstr "Por favor colaborá agregegando información faltante.  Asegurate e leer nuestra <a href=\"https://docs.google.com/document/d/11WsPkULuWzQNvy4anK-OWId819Tb0N-aZ7n7v6qYQr4/edit#\">guía para voluntarios.</a>"
 
 #: candidates/templates/candidates/person-edit.html:271
@@ -1706,9 +1446,7 @@ msgstr "¿Inentás subir una foto?"
 
 #: candidates/templates/candidates/person-edit.html:273
 #, python-format
-msgid ""
-"There’s a separate page for <a href=\"%(url)s\">uploading a photo of "
-"%(name)s</a>."
+msgid "There’s a separate page for <a href=\"%(url)s\">uploading a photo of %(name)s</a>."
 msgstr "Hay una página especial para <a href=\"%(url)s\">subir fotos de %(name)s</a>."
 
 #: candidates/templates/candidates/person-edit.html:281
@@ -1814,9 +1552,7 @@ msgstr "%(name)s no fué elegido"
 
 #: candidates/templates/candidates/person-view.html:95
 #, python-format
-msgid ""
-"We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by"
-" adding one</a>!"
+msgid "We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by adding one</a>!"
 msgstr "No tenemos la dirección de email de %(name)s, ¡<a href=\"%(url)s\">Ayudanos agregándola</a>!"
 
 #: candidates/templates/candidates/person-view.html:104
@@ -1901,8 +1637,7 @@ msgid "Our database is built by people like you."
 msgstr "Nuestra base de datos la construye gente como vos."
 
 #: candidates/templates/candidates/person-view.html:215
-msgid ""
-"Please do add extra details about this candidate – it only takes a moment."
+msgid "Please do add extra details about this candidate – it only takes a moment."
 msgstr "Por favor agregá detalles extra de este candidato - sólo toma un momento."
 
 #: candidates/templates/candidates/person-view.html:218
@@ -1923,16 +1658,11 @@ msgstr "API abierta en JSON:"
 
 #: candidates/templates/candidates/person-view.html:238
 #, python-format
-msgid ""
-"More details about getting <a href=\"%(api_url)s\">the data</a> and <a "
-"href=\"%(about_url)s\">its license</a>."
+msgid "More details about getting <a href=\"%(api_url)s\">the data</a> and <a href=\"%(about_url)s\">its license</a>."
 msgstr "Más detalles sobre obtener <a href=\"%(api_url)s\">los datos</a> y <a href=\"%(about_url)s\">su licencia</a>."
 
 #: candidates/templates/candidates/person-view.html:247
-msgid ""
-"As a staff user, you can invalidate any cached data for this user. This may "
-"<em>occasionally</em> be necessary if the page is showing stale information "
-"for more than 10 seconds."
+msgid "As a staff user, you can invalidate any cached data for this user. This may <em>occasionally</em> be necessary if the page is showing stale information for more than 10 seconds."
 msgstr "Como moderador, podés invalidar los datos en cache (actualizar) para este usuario. Esto puede ocasionalmente ser necesario si la página muestra información vieja por más de 10 segundos."
 
 #: candidates/templates/candidates/popit_down.html:7
@@ -1950,9 +1680,7 @@ msgid "Sorry, %(site_name)s is temporarily unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:26
-msgid ""
-"This usually means that we’re having to do some brief maintenance, and the "
-"site will be back soon."
+msgid "This usually means that we’re having to do some brief maintenance, and the site will be back soon."
 msgstr "Esto normalmente significa que estamos haciendo algo de mantenimiento, y el sitio va a estar online de nuevo muy pronto."
 
 #: candidates/templates/candidates/posts.html:9
@@ -1962,8 +1690,7 @@ msgstr "Todos los cargos en las elecciones actuales"
 
 #: candidates/templates/candidates/posts.html:14
 #: elections/st_paul_municipal_2015/templates/candidates/posts.html:14
-msgid ""
-"Follow one of the links below to see the known candidates for that post:"
+msgid "Follow one of the links below to see the known candidates for that post:"
 msgstr "Sigue uno de los enlaces abajo para ver los candidatos de ese cargo:"
 
 #: candidates/templates/candidates/privacy.html:6
@@ -1988,29 +1715,20 @@ msgid "This site is run by %(site_owner)s."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:28
-msgid ""
-"We make the following promises about your personal information as a user of "
-"the site:"
+msgid "We make the following promises about your personal information as a user of the site:"
 msgstr "Hacemos las siguientes promesas sobre tu información personal como usuario de este sitio:"
 
 #: candidates/templates/candidates/privacy.html:34
-msgid ""
-"We will not sell or distribute your email address or other personal "
-"information."
+msgid "We will not sell or distribute your email address or other personal information."
 msgstr "No venderemos ni distribuiremos tu dirección de correo electrónico u otra infrmación personal."
 
 #: candidates/templates/candidates/privacy.html:38
-msgid ""
-"We will gladly show you the personal data we store about you in order to run"
-" the website."
+msgid "We will gladly show you the personal data we store about you in order to run the website."
 msgstr "Te mostraremos sin problemas los datos que guardamos sobre vos para hacer funcionar el sitio."
 
 #: candidates/templates/candidates/privacy.html:44
 #, python-format
-msgid ""
-"We may use your email address to contact you about your use of the site if "
-"it's problematic (or particularly helpful!), or with occasional "
-"announcements about %(site_name)s and other %(site_owner)s projects."
+msgid "We may use your email address to contact you about your use of the site if it's problematic (or particularly helpful!), or with occasional announcements about %(site_name)s and other %(site_owner)s projects."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:51
@@ -2018,27 +1736,15 @@ msgid "Details"
 msgstr "Detalles"
 
 #: candidates/templates/candidates/privacy.html:53
-msgid ""
-"As well as your login details, we store your IP address along with any "
-"changes you make to the data on the site.  All this information is "
-"accessible to administrators of the site."
+msgid "As well as your login details, we store your IP address along with any changes you make to the data on the site.  All this information is accessible to administrators of the site."
 msgstr "Además de tu nombre de usuario, almacenamos tu dirección IP junto con cualquier cambio que hacés a los datos en el sitio. Esta información es accesible a los administradores del sitio."
 
 #: candidates/templates/candidates/privacy.html:59
-msgid ""
-"Please note that this policy refers to the personal information arising from"
-" creating a login on the site, not the personal information about candidates"
-" for elections - the reason for the site to exist is to make information "
-"about those candidates available to members of the public and website "
-"developers so that they can find out more about those candidates, their "
-"promises and policy positions."
+msgid "Please note that this policy refers to the personal information arising from creating a login on the site, not the personal information about candidates for elections - the reason for the site to exist is to make information about those candidates available to members of the public and website developers so that they can find out more about those candidates, their promises and policy positions."
 msgstr "Por favor notar que estos términos se refieren a información personal que surje de crear una cuenta en este sitio, no la información personal de candidatos a las elecciones - la razón para la que el sitio existe es hacer disponible información sobre los candidatos al público y otros desarrolladores de software para que puedan informarse mejor sobre esos candidatos, sus promesas y sus posiciones políticas."
 
 #: candidates/templates/candidates/privacy.html:69
-msgid ""
-"We also use Google Analytics to aggregate and track data about usage of the "
-"site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a "
-"browser plugin to opt out of having data collected by Google Analytics</a>."
+msgid "We also use Google Analytics to aggregate and track data about usage of the site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a browser plugin to opt out of having data collected by Google Analytics</a>."
 msgstr "También usamos Google Analytics para recolectar y registrar datos sobre el uso del sitio; podés usar <a href=\"https://tools.google.com/dlpage/gaoptout/\">una extensión de navegador para evitar que Google Analytics te registre</a>."
 
 #: candidates/templates/candidates/recent-changes.html:6
@@ -2096,11 +1802,7 @@ msgstr "Si,%(name)s  (%(party)s) ganó en %(constituency_name)s"
 
 #: candidates/templates/candidates/update-disallowed.html:16
 #, python-format
-msgid ""
-"As a precaution, this update hasn't been allowed, but details have been "
-"emailed to the team of %(site.name)s volunteers; they will apply the change "
-"after checking it. If you have any questions about this, please email <a "
-"href=\"%(email)s\">%(email)s</a>."
+msgid "As a precaution, this update hasn't been allowed, but details have been emailed to the team of %(site.name)s volunteers; they will apply the change after checking it. If you have any questions about this, please email <a href=\"%(email)s\">%(email)s</a>."
 msgstr ""
 
 #: candidates/templatetags/metadescription.py:23
@@ -2120,8 +1822,7 @@ msgstr "%(name)s se presentó por el partido %(party)s para %(post)s en %(electi
 
 #: candidates/templatetags/metadescription.py:29
 #, python-format
-msgid ""
-"%(name)s is standing as an independent candidate in %(post)s in %(election)s"
+msgid "%(name)s is standing as an independent candidate in %(post)s in %(election)s"
 msgstr "%(name)s se presenta como candidato indpendiente para %(post)s en %(election)s"
 
 #: candidates/templatetags/metadescription.py:31
@@ -2330,75 +2031,39 @@ msgid "Unknown MapIt error for postcode \"{0}\""
 msgstr "Disculpas, ocurrió un error desconocido de MapIt para el código postal \"{0}\""
 
 #: elections/uk_general_election_2015/templates/base.html:24
-msgid ""
-"Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a "
-"href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a "
-"href=\"https://mysociety.org\">mySociety</a>."
+msgid "Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a href=\"https://mysociety.org\">mySociety</a>."
 msgstr "Apoyado por Congreso Interactivo, Open Knowledge Argentina, Datos Concepción, We Me, Fundación Directorio Legislativo, HacksLabs, Taringa, y otras organizaciones y muchos voluntarios como vos."
 
 #: elections/uk_general_election_2015/templates/base.html:31
 #, python-format
-msgid ""
-"Built by <a href=\"%(site_managers_url)s\"> <img src=\"%(logo_url)s\" %%} "
-"alt=\"%(site_managers)s\" class=\"dc-logo\"></a>"
+msgid "Built by <a href=\"%(site_managers_url)s\"> <img src=\"%(logo_url)s\" %%} alt=\"%(site_managers)s\" class=\"dc-logo\"></a>"
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:17
 #, python-format
-msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or"
-" bug reports. If you'd like to discuss this site or any other project "
-"relating to elections in the UK, we'd suggest that you post to the <a "
-"href=\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy "
-"Club Google Group</a>."
-msgstr "Por favor envíe un correo a <a href=\"mailto:%(email)s\">%(email)s</a> con cualquier devolución o reporte de errores. \nPara debatir sobre este sitio u otros proyectos relacionados a las elecciones argentinas, puede participar en nuestra <a href=\"https://groups.google.com/forum/#!forum/yoquierosaber2015\">lista de correo</a."
+msgid "Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or bug reports. If you'd like to discuss this site or any other project relating to elections in the UK, we'd suggest that you post to the <a href=\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy Club Google Group</a>."
+msgstr "Por favor envíe un correo a <a href=\"mailto:%(email)s\">%(email)s</a> con cualquier devolución o reporte de errores. Para debatir sobre este sitio u otros proyectos relacionados a las elecciones argentinas, puede participar en nuestra <a href=\"https://groups.google.com/forum/#!forum/yoquierosaber2015\">lista de correo</a."
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:34
-msgid ""
-"This site was originally developed by Mark Longair (mySociety), Sym Roe "
-"(Democracy Club) and Zarino Zappia (mySociety) and <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many"
-" other contributors</a>, to whom we owe a debt of gratitude."
+msgid "This site was originally developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety) and <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many other contributors</a>, to whom we owe a debt of gratitude."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:41
-msgid ""
-"The data on candidates from the last UK general election in 2010 is all "
-"taken from Edmund von der Burg's <a "
-"href=\"http://www.yournextmp.com\">YourNextMP.com</a>, with many thanks."
+msgid "The data on candidates from the last UK general election in 2010 is all taken from Edmund von der Burg's <a href=\"http://www.yournextmp.com\">YourNextMP.com</a>, with many thanks."
 msgstr "Los datos de los candidatos de las últimas elecciones de 2011 fueron tomados de YoQuieroSaber 2011"
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:58
-msgid ""
-"The party logos, which are taken from the Electoral Commission's website"
+msgid "The party logos, which are taken from the Electoral Commission's website"
 msgstr "Los logos de los partidos."
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:73
 #, python-format
-msgid ""
-"For complicated reasons relating to database licensing, we have put the data"
-" as of the 4th of March 2015 into the public domain by declaring it to be <a"
-" href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This "
-"data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-"
-"date/\">here</a> but please be warned that this snapshot will become "
-"inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date "
-"data</a> instead."
+msgid "For complicated reasons relating to database licensing, we have put the data as of the 4th of March 2015 into the public domain by declaring it to be <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-date/\">here</a> but please be warned that this snapshot will become inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date data</a> instead."
 msgstr "Por razones complejas relacionadas a la licencia de la base de datos, hemos puesto los datos a partir del 4 de Marzo de 2015 al domino público declarando será  <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CCO</a>. Estos datos están disponibles <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-date/\"> aquí, pero por favor esté atento que esta imagen puede desactualizarse muy rápidamente - por favor use <a href=\"%(api_url)s\"> los datos actualizados."
 
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:63
 #, python-format
-msgid ""
-"When we originally set up %(site_name)s for the 2015 UK general election we "
-"didn't get legal advice about the best way to deal with copyright and "
-"licensing. It turns out that the way that the user agreement that was worded"
-" on the 'About' page had a few problems, and in particular restricted what "
-"we could do with the data such that we couldn't license the database to some"
-" partners who we thought would make good use of the data but who needed "
-"slightly different licensing. The simplest way to ensure that we can make "
-"the data as widely available as possible while preventing the hard work of "
-"contributors to %(site_name)s being co-opted by companies building closed "
-"candidate databases is to ask you to assign the copyright of your "
-"contributions to %(copyright_holder)s."
+msgid "When we originally set up %(site_name)s for the 2015 UK general election we didn't get legal advice about the best way to deal with copyright and licensing. It turns out that the way that the user agreement that was worded on the 'About' page had a few problems, and in particular restricted what we could do with the data such that we couldn't license the database to some partners who we thought would make good use of the data but who needed slightly different licensing. The simplest way to ensure that we can make the data as widely available as possible while preventing the hard work of contributors to %(site_name)s being co-opted by companies building closed candidate databases is to ask you to assign the copyright of your contributions to %(copyright_holder)s."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/finder.html:14
@@ -2412,9 +2077,7 @@ msgid "The popit_person_id must be all digits"
 msgstr "El popit_person_id debe ser enteramente numérico"
 
 #: moderation_queue/forms.py:39
-msgid ""
-"If you checked 'Other' then you must provide a justification for why we can "
-"use it."
+msgid "If you checked 'Other' then you must provide a justification for why we can use it."
 msgstr "Si seleccionaste 'otra' entones debes justificar por qué podemos usarla."
 
 #: moderation_queue/models.py:20
@@ -2438,15 +2101,11 @@ msgid "This photograph is free of any copyright restrictions"
 msgstr "Esta foto está libre de cualquier restricción de copyright"
 
 #: moderation_queue/models.py:35
-msgid ""
-"I own copyright of this photo and I assign the copyright to Democracy Club "
-"Limited in return for it being displayed on this site"
+msgid "I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on this site"
 msgstr ""
 
 #: moderation_queue/models.py:39
-msgid ""
-"This is the candidate's public profile photo from social media (e.g. "
-"Twitter, Facebook) or their official campaign page"
+msgid "This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page"
 msgstr "Esta es la foto del perfil del candidato en medios sociales (twitter, facebook, etc), o de su sitio oficial de campaña"
 
 #: moderation_queue/models.py:43
@@ -2460,12 +2119,8 @@ msgstr "Imágen subida por {user} del candidato {popit_person_id}"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:7
 #, python-format
-msgid ""
-"<strong>Warning:</strong> there is already %(queued_images)s photo of "
-"%(name)s in the queue, waiting to be moderated:"
-msgid_plural ""
-"<strong>Warning:</strong> there are already %(queued_images)s photos of "
-"%(name)s in the queue, waiting to be moderated:"
+msgid "<strong>Warning:</strong> there is already %(queued_images)s photo of %(name)s in the queue, waiting to be moderated:"
+msgid_plural "<strong>Warning:</strong> there are already %(queued_images)s photos of %(name)s in the queue, waiting to be moderated:"
 msgstr[0] "<strong>Advertencia:</strong> ya hay %(queued_images)s foto de %(name)s esperando ser aprobada:"
 msgstr[1] "<strong>Advertencia:</strong> ya hay %(queued_images)s fotos de %(name)s esperando ser aprobadas:"
 
@@ -2476,9 +2131,7 @@ msgstr "Foto subida por %(name)s a las %(created)s"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:25
 #, python-format
-msgid ""
-"If you still want to upload another photo of %(name)s, first select an image"
-" from your computer:"
+msgid "If you still want to upload another photo of %(name)s, first select an image from your computer:"
 msgstr "Si aún querés subir otra foto de %(name)s, primero seleccioná una foto de tu computadora:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:29
@@ -2486,15 +2139,11 @@ msgid "First, select an image from your computer:"
 msgstr "Primero, elegí una imágen de tu computadora:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:38
-msgid ""
-"Now let us know about the copyright of this image by selecting one of these "
-"options or explaining why we can use it:"
+msgid "Now let us know about the copyright of this image by selecting one of these options or explaining why we can use it:"
 msgstr "Ahora, contanos sobe el los derechos de copia (propiedad intelectual, copyright) de esta imágen seleccionando una de estas opciones, o explicando por qué podemos usarla"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:47
-msgid ""
-"Here is my justification for why this photo may be reasonably used on the "
-"website, including the source URL:"
+msgid "Here is my justification for why this photo may be reasonably used on the website, including the source URL:"
 msgstr "Esta es mi justificación de por qué esta foto puede ser rasonablemente utilizada en este sitio, incluyendo la dirección web (URL) de la fuente:"
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:54
@@ -2534,19 +2183,12 @@ msgstr "Revisar y recortar la foto"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:30
 #, python-format
-msgid ""
-"Please check that this is really <a href=\"%(url)s\">%(name)s</a> "
-"(%(party)s) before approving the upload. This <a "
-"href=\"%(google_image_search_url)s\">Google Image search for candidate "
-"details</a> may be a good start."
+msgid "Please check that this is really <a href=\"%(url)s\">%(name)s</a> (%(party)s) before approving the upload. This <a href=\"%(google_image_search_url)s\">Google Image search for candidate details</a> may be a good start."
 msgstr "Por favor verificá que este sea realmente <a href=\"%(url)s\">%(name)s</a> (%(party)s) antes de aprobar la subida. Esta búsqueda de <a href=\"%(google_image_search_url)s\">Google Images</a> puede ser un buen comienzo."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:36
 #, python-format
-msgid ""
-"If you're trying to find the likely <em>source</em> of this image, you can "
-"also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image "
-"search</a> on the uploaded image."
+msgid "If you're trying to find the likely <em>source</em> of this image, you can also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image search</a> on the uploaded image."
 msgstr "Si estás intentando encontrar la posible <em>fuente</em> de esta imágen, podés hacer una <a href=\"%(google_reverse_image_search_url)s\">búsqueda inversa de imágenes</a> con la imágen subida."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:41
@@ -2554,9 +2196,7 @@ msgid "Click and drag in the image to crop"
 msgstr "Cliqueá y arrastrá en la imágen para recortarla"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:43
-msgid ""
-"Please crop to just around the candidate's head, since they're displayed in "
-"thumbnail form on the site."
+msgid "Please crop to just around the candidate's head, since they're displayed in thumbnail form on the site."
 msgstr "Por favor recortá sólo la cabeza del candidato, porque se muestran en una imágen pequeña en el sitio."
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:68
@@ -2601,16 +2241,12 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:113
 #, python-format
-msgid ""
-"%(username)s said that this is the candidate's public profile photo from "
-"social media or their official campaign page"
+msgid "%(username)s said that this is the candidate's public profile photo from social media or their official campaign page"
 msgstr "%(username)s dijo que esta es la foto del perfil de medios sociales del candidato o de su sitio oficial de campaña"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:120
 #, python-format
-msgid ""
-"%(username)s's justification for use of this photo was: "
-"&#8220;%(justification)s&#8221;"
+msgid "%(username)s's justification for use of this photo was: &#8220;%(justification)s&#8221;"
 msgstr "%(username)s's dijo que su justificación para usar esta foto es: &#8220;%(justification)s&#8221;"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:128
@@ -2630,9 +2266,7 @@ msgid "Why <em>you</em> think it's allowed:"
 msgstr "Porqué <em>vos</em> creés que está permitido:"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:151
-msgid ""
-"Reason for rejection (<strong>Warning:</strong> this will be emailed to the "
-"user):"
+msgid "Reason for rejection (<strong>Warning:</strong> this will be emailed to the user):"
 msgstr "Razón para rechazar (<strong>Advertencia:</strong> se enviará por email al usuario):"
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:158
@@ -2663,10 +2297,7 @@ msgstr "La foto ahora espera aprobación."
 
 #: moderation_queue/templates/moderation_queue/photo-upload-success.html:15
 #, python-format
-msgid ""
-"Thank-you for uploading a photo - you will receive an email when it is "
-"approved to be added to the site, or an explanation for why it cannot be "
-"used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
+msgid "Thank-you for uploading a photo - you will receive an email when it is approved to be added to the site, or an explanation for why it cannot be used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
 msgstr "Gracias por subir una foto - recibirás un email cuando esté aprobada para ser agregada al sitio, o una explicación de porqué no puede ser usada. <a href=\"%(url)s\">Volver a la página de %(name)s.</a>"
 
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
@@ -2680,9 +2311,7 @@ msgstr "Foto aprobada de la cola de moderación"
 
 #: moderation_queue/views.py:290
 #, python-brace-format
-msgid ""
-"Approved a photo upload from {uploading_user} who provided the message: "
-"\"{message}\""
+msgid "Approved a photo upload from {uploading_user} who provided the message: \"{message}\""
 msgstr "Aprobada la foto subida de  {uploading_user} que ingresó el mensaje: \"{message}\""
 
 #: moderation_queue/views.py:316
@@ -2791,8 +2420,7 @@ msgstr "Registrarse"
 
 #: mysite/templates/account/signup.html:13
 #, python-format
-msgid ""
-"Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
+msgid "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr "¿Ya tenés una cuenta? Entonces por favor  <a href=\"%(login_url)s\">iniciá sesión</a>."
 
 #: mysite/templates/generic_base.html:71
@@ -2830,9 +2458,7 @@ msgstr "No tenemos ningún %(type)s para el cargo %(post_data.label)s."
 
 #: official_documents/templates/official_documents/_post.html:30
 #, python-format
-msgid ""
-"As you have permission to upload documents, you can <a "
-"href=\"%(url)s\">upload a %(type)s</a>."
+msgid "As you have permission to upload documents, you can <a href=\"%(url)s\">upload a %(type)s</a>."
 msgstr "Como tenés permiso para subir documentos, podés <a href=\"%(url)s\">subir un %(type)s</a>."
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:16
@@ -2842,16 +2468,12 @@ msgstr "%(type)s para <a href=\"%(url)s\">%(post_label)s</a>."
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:19
 #, python-format
-msgid ""
-"The source URL for this document was: <a "
-"href=\"%(source_url)s\">%(source_url)s</a>"
+msgid "The source URL for this document was: <a href=\"%(source_url)s\">%(source_url)s</a>"
 msgstr "La URL de la fuente para este documento era: <a href=\"%(source_url)s\">%(source_url)s</a>"
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:32
 #, python-format
-msgid ""
-"You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to "
-"delete it)"
+msgid "You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to delete it)"
 msgstr "Podés <a href=\"%(url)s\">editar esto en la sección de administración</a> (por ejemplo para borrarlo, etc)"
 
 #: official_documents/templates/official_documents/upload_document_form.html:5
@@ -2878,9 +2500,7 @@ msgstr "{name} ({party}) ganó en {cons}"
 
 #: results/feeds.py:28
 #, python-brace-format
-msgid ""
-"A {site_name} volunteer recorded at {datetime} that {name} ({party}) won the"
-" ballot in {cons}, quoting the source '{source}')."
+msgid "A {site_name} volunteer recorded at {datetime} that {name} ({party}) won the ballot in {cons}, quoting the source '{source}')."
 msgstr ""
 
 #: results/feeds.py:84
@@ -2901,17 +2521,12 @@ msgstr[1] "%(pretty_count)s candidatos a los que les falta el campo %(field)s</h
 
 #: tasks/templates/tasks/field.html:14
 #, python-format
-msgid ""
-"Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
+msgid "Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
 msgstr "De %(num_candidates_2015)s candidatos en total (%(percent_empty)s%% están vacíos)"
 
 #: tasks/templates/tasks/field.html:21
 #, python-format
-msgid ""
-"Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make"
-" sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
-"fields.</a>"
+msgid "Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields.</a>"
 msgstr "Por favor <a href=\"%(url)s\">colaborá</a> agregegando información faltante.  Asegurate e leer nuestra <a href=\"https://docs.google.com/document/d/11WsPkULuWzQNvy4anK-OWId819Tb0N-aZ7n7v6qYQr4/edit#\">guía para voluntarios.</a>"
 
 #: tasks/templates/tasks/field.html:35
@@ -2920,9 +2535,7 @@ msgstr "editar"
 
 #: tasks/templates/tasks/field.html:38
 #, python-format
-msgid ""
-"Hi @%(username)s could you add your %(field)s to your %(site_name)s page "
-"please? https://yournextmp.com/person/%(id)s/"
+msgid "Hi @%(username)s could you add your %(field)s to your %(site_name)s page please? https://yournextmp.com/person/%(id)s/"
 msgstr ""
 
 #: tasks/templates/tasks/field.html:41
@@ -2952,15 +2565,11 @@ msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:12
 #, python-format
-msgid ""
-"%(site_name)s is a volunteer-sourced database, and that means we constantly "
-"need help in making it better."
+msgid "%(site_name)s is a volunteer-sourced database, and that means we constantly need help in making it better."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:17
-msgid ""
-"There is a lot of useful information on candidates out there, so if you find"
-" any please do add it to our site."
+msgid "There is a lot of useful information on candidates out there, so if you find any please do add it to our site."
 msgstr "Hay mucha información útil sobre los candidatos dando vueltas, así que si encontrás algo, por favor agregalo a nuestro sitio, gracias."
 
 #: tasks/templates/tasks/tasks_home.html:22
@@ -2968,15 +2577,11 @@ msgid "Emails"
 msgstr "Correos electrónicos"
 
 #: tasks/templates/tasks/tasks_home.html:24
-msgid ""
-"At the moment we're trying to get as many email addresses on candidates as "
-"we can."
+msgid "At the moment we're trying to get as many email addresses on candidates as we can."
 msgstr "En este momento estamos intentando obtener todas las dirección de correo electrónico que podamos de los candidatos."
 
 #: tasks/templates/tasks/tasks_home.html:29
-msgid ""
-"This will allow us to email them directly to ask them to add their own "
-"details."
+msgid "This will allow us to email them directly to ask them to add their own details."
 msgstr "Esto nos permitirá escribirles directamente para pedirles que agreguen su información ellos mismos."
 
 #: tasks/templates/tasks/tasks_home.html:34
@@ -2985,49 +2590,29 @@ msgstr "Cómo colaborar"
 
 #: tasks/templates/tasks/tasks_home.html:37
 #, python-format
-msgid ""
-"First off you'll need to <a href=\"%(url)s\">log in</a> in order to start "
-"making edits."
+msgid "First off you'll need to <a href=\"%(url)s\">log in</a> in order to start making edits."
 msgstr "Primero vas a tener que <a href=\"%(url)s\">iniciar sesión</a> para comenzar a hacer ediciones."
 
 #: tasks/templates/tasks/tasks_home.html:43
 #, python-format
-msgid ""
-"We've added clear banners on the candidate and constituently pages "
-"indicating where we're missing email addresses, so you can start adding "
-"email addresses by <a href=\"%(url)s\">looking up your constituency on the "
-"home page</a>"
+msgid "We've added clear banners on the candidate and constituently pages indicating where we're missing email addresses, so you can start adding email addresses by <a href=\"%(url)s\">looking up your constituency on the home page</a>"
 msgstr "Agregamos destacados en las páginas de los candidatos y los distritos indicando dónde nos faltan direcciones de correo electrónico, así que podés ayudarnos a conseguirlas <a href=\"%(url)s\">buscando tu distrito en la página principal</a>"
 
 #: tasks/templates/tasks/tasks_home.html:50
-msgid ""
-"Once you've found a candidate without an email address, you can go searching"
-" for it!"
+msgid "Once you've found a candidate without an email address, you can go searching for it!"
 msgstr "Una vez que hayas encontrado un candidato sin dirección de email, podés comenzar a buscarla."
 
 #: tasks/templates/tasks/tasks_home.html:55
-msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing "
-"fields</a>, and specifically the part about what sort of email addresses we "
-"accept."
+msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing fields</a>, and specifically the part about what sort of email addresses we accept."
 msgstr "Por favor asegurate de leer nuestra <a href=\"https://docs.google.com/document/d/11WsPkULuWzQNvy4anK-OWId819Tb0N-aZ7n7v6qYQr4/edit#\">guía de voluntarios</a>, especificamente la parte sobre qué tipo de direcciones de correo aceptamos."
 
 #: tasks/templates/tasks/tasks_home.html:62
-msgid ""
-"In short, we only want email addresses could be considered public and "
-"related to the candidate's campaign. <code>@parliament.uk</code> email "
-"addresses will stop working once Parliament is disbanded, so try to find a "
-"different email address for them if you can. If not, we can always email "
-"everyone with a <code>@parliament.uk</code> address asking them for a better"
-" one."
+msgid "In short, we only want email addresses could be considered public and related to the candidate's campaign. <code>@parliament.uk</code> email addresses will stop working once Parliament is disbanded, so try to find a different email address for them if you can. If not, we can always email everyone with a <code>@parliament.uk</code> address asking them for a better one."
 msgstr "Preferimos direcciones de correo que puedan ser consideradas públicas y relacionadas a la campaña del candidato, porque las direcciones de correo de oficinas del estado podrían cambiar luego de las elecciones."
 
 #: tasks/templates/tasks/tasks_home.html:72
 #, python-format
-msgid ""
-"Once your constituency has all the email addresses entered, you can look at "
-"our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
+msgid "Once your constituency has all the email addresses entered, you can look at our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
 msgstr "Una vez que tu distrito tenga todas las direcciones de correo cargadas, podés mirar nuestra <a href=\"%(url)s\">lista de todos los candidatos sin dirección de email</a>!"
 
 #~ msgid "%(site_name)s"

--- a/locale/es_AR/LC_MESSAGES/django.po
+++ b/locale/es_AR/LC_MESSAGES/django.po
@@ -1969,7 +1969,7 @@ msgstr "Sigue uno de los enlaces abajo para ver los candidatos de ese cargo:"
 #: candidates/templates/candidates/privacy.html:6
 #: candidates/templates/candidates/privacy.html:9
 #: elections/ar_elections_2015/templates/base.html:110
-#: mysite/templates/generic_base.html:125
+#: mysite/templates/generic_base.html:121
 msgid "Privacy policy"
 msgstr "Política de privacidad"
 
@@ -2237,29 +2237,29 @@ msgid "Provinces"
 msgstr "Candidatos por provincia"
 
 #: elections/ar_elections_2015/templates/base.html:58
-#: mysite/templates/generic_base.html:82
+#: mysite/templates/generic_base.html:78
 #, python-format
 msgid "Signed in as <strong>%(username)s</strong>"
 msgstr "Sesión iniciada como <strong>%(username)s</strong>"
 
 #: elections/ar_elections_2015/templates/base.html:60
-#: mysite/templates/generic_base.html:83
+#: mysite/templates/generic_base.html:79
 msgid "Sign out"
 msgstr "Cerrar sesión"
 
 #: elections/ar_elections_2015/templates/base.html:63
-#: mysite/templates/generic_base.html:87
+#: mysite/templates/generic_base.html:83
 msgid "Sign in to edit"
 msgstr "Iniciá sesión para editar"
 
 #: elections/ar_elections_2015/templates/base.html:108
-#: mysite/templates/generic_base.html:122
+#: mysite/templates/generic_base.html:118
 msgid "Open data API"
 msgstr "API de datos abiertos"
 
 #: elections/ar_elections_2015/templates/base.html:109
-#: mysite/templates/generic_base.html:74
-#: mysite/templates/generic_base.html:123
+#: mysite/templates/generic_base.html:70
+#: mysite/templates/generic_base.html:119
 msgid "About"
 msgstr "Acerca de Yo Quiero Saber"
 
@@ -2795,20 +2795,15 @@ msgid ""
 "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr "¿Ya tenés una cuenta? Entonces por favor  <a href=\"%(login_url)s\">iniciá sesión</a>."
 
-#: mysite/templates/generic_base.html:37
-#, python-format
-msgid "%(site_name)s"
-msgstr "%(site_name)s"
-
-#: mysite/templates/generic_base.html:75
+#: mysite/templates/generic_base.html:71
 msgid "Posts"
 msgstr "Cargos"
 
-#: mysite/templates/generic_base.html:76
+#: mysite/templates/generic_base.html:72
 msgid "Numbers"
 msgstr "Estadísticas"
 
-#: mysite/templates/generic_base.html:124
+#: mysite/templates/generic_base.html:120
 msgid "Issue tracker"
 msgstr "Reportes de errores"
 
@@ -3034,3 +3029,6 @@ msgid ""
 "Once your constituency has all the email addresses entered, you can look at "
 "our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
 msgstr "Una vez que tu distrito tenga todas las direcciones de correo cargadas, podés mirar nuestra <a href=\"%(url)s\">lista de todos los candidatos sin dirección de email</a>!"
+
+#~ msgid "%(site_name)s"
+#~ msgstr "%(site_name)s"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -459,17 +459,15 @@ msgstr "Source d'information qu'ils ont gagné"
 msgid "{post_role} for {area_name}"
 msgstr "{post_role} pour {area_name}"
 
-#: candidates/middleware.py:43
-#, python-brace-format
-msgid ""
-"As a precaution, an update was blocked:\n"
-"\n"
-"  {0}\n"
-"\n"
-"If this update is appropriate, someone should apply it manually.\n"
-msgstr "Par précaution, une modification a été bloquée:\n\n  {0}\n\nSi cette mise à jour est appropriée, quelqu'un doit l'appliquer manuellement.\n"
+#: candidates/middleware.py:42
+msgid "As a precaution, an update was blocked:"
+msgstr "Par précaution, une modification a été bloquée:"
 
-#: candidates/middleware.py:50
+#: candidates/middleware.py:43
+msgid "If this update is appropriate, someone should apply it manually."
+msgstr "Si cette mise à jour est appropriée, quelqu'un doit l'appliquer manuellement."
+
+#: candidates/middleware.py:51
 #, python-brace-format
 msgid "Disallowed {site_name} update for checking"
 msgstr "Mise à jour de {site_name} refusé pour vérification"
@@ -2668,36 +2666,7 @@ msgid ""
 "used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
 msgstr ""
 
-#: moderation_queue/templates/moderation_queue/photo_approved_email.txt:1
-#, python-format
-msgid ""
-"Thank-you for submitting a photo to %(site_name)s; that's been\n"
-"uploaded now for the candidate page here:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_approved_email.txt:6
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
-#, python-format
-msgid ""
-"Many thanks,\n"
-"The %(site_name)s volunteers"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:1
-#, python-format
-msgid ""
-"Thank-you for uploading a photo of %(candidate_name)s\n"
-"to %(site_name)s, but unfortunately we can't use that image because:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:6
-msgid ""
-"You can just reply to this email if you want to discuss that\n"
-"further, or you can try uploading a photo with a different reason\n"
-"or justification for its use using this link:"
-msgstr ""
-
-#: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:16
 #, python-format
 msgid "For administrators' use: %(photo_review_url)s"
 msgstr ""
@@ -2706,51 +2675,69 @@ msgstr ""
 msgid "Approved from photo moderation queue"
 msgstr ""
 
-#: moderation_queue/views.py:289
+#: moderation_queue/views.py:290
 #, python-brace-format
 msgid ""
 "Approved a photo upload from {uploading_user} who provided the message: "
 "\"{message}\""
 msgstr ""
 
-#: moderation_queue/views.py:315
+#: moderation_queue/views.py:316
 #, python-brace-format
 msgid "{site_name} image upload approved"
 msgstr ""
 
-#: moderation_queue/views.py:328
+#: moderation_queue/views.py:325
+#, python-brace-format
+msgid "Thank-you for submitting a photo to {site_name}; that's been uploaded now for the candidate page here:"
+msgstr ""
+
+#: moderation_queue/views.py:330 moderation_queue/views.py:385
+msgid "Many thanks from the {{ site_name }} volunteers"
+msgstr ""
+
+#: moderation_queue/views.py:337
 #, python-format
 msgid "You approved a photo upload for %s"
 msgstr ""
 
-#: moderation_queue/views.py:333
+#: moderation_queue/views.py:342
 #, python-brace-format
 msgid "Rejected a photo upload from {uploading_user}"
 msgstr ""
 
-#: moderation_queue/views.py:352
+#: moderation_queue/views.py:361
 #, python-brace-format
 msgid "{site_name} image moderation results"
 msgstr ""
 
-#: moderation_queue/views.py:369
+#: moderation_queue/views.py:371
+#, python-brace-format
+msgid "Thank-you for uploading a photo of {candidate_name} to {site_name}, but unfortunately we can't use that image because:"
+msgstr ""
+
+#: moderation_queue/views.py:379
+msgid "You can just reply to this email if you want to discuss that further, or you can try uploading a photo with a different reason or justification for its use using this link:"
+msgstr ""
+
+#: moderation_queue/views.py:393
 #, python-format
 msgid "You rejected a photo upload for %s"
 msgstr ""
 
-#: moderation_queue/views.py:376
+#: moderation_queue/views.py:400
 #, python-brace-format
 msgid "You left a photo upload for {0} in the queue"
 msgstr ""
 
-#: moderation_queue/views.py:383
+#: moderation_queue/views.py:407
 #, python-brace-format
 msgid ""
 "Ignored a photo upload from {uploading_user} (This usually means it was a "
 "duplicate)"
 msgstr ""
 
-#: moderation_queue/views.py:396
+#: moderation_queue/views.py:420
 #, python-brace-format
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1966,7 +1966,7 @@ msgstr ""
 #: candidates/templates/candidates/privacy.html:6
 #: candidates/templates/candidates/privacy.html:9
 #: elections/ar_elections_2015/templates/base.html:110
-#: mysite/templates/generic_base.html:125
+#: mysite/templates/generic_base.html:121
 msgid "Privacy policy"
 msgstr ""
 
@@ -2234,29 +2234,29 @@ msgid "Provinces"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:58
-#: mysite/templates/generic_base.html:82
+#: mysite/templates/generic_base.html:78
 #, python-format
 msgid "Signed in as <strong>%(username)s</strong>"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:60
-#: mysite/templates/generic_base.html:83
+#: mysite/templates/generic_base.html:79
 msgid "Sign out"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:63
-#: mysite/templates/generic_base.html:87
+#: mysite/templates/generic_base.html:83
 msgid "Sign in to edit"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:108
-#: mysite/templates/generic_base.html:122
+#: mysite/templates/generic_base.html:118
 msgid "Open data API"
 msgstr ""
 
 #: elections/ar_elections_2015/templates/base.html:109
-#: mysite/templates/generic_base.html:74
-#: mysite/templates/generic_base.html:123
+#: mysite/templates/generic_base.html:70
+#: mysite/templates/generic_base.html:119
 msgid "About"
 msgstr ""
 
@@ -2794,20 +2794,15 @@ msgid ""
 "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr ""
 
-#: mysite/templates/generic_base.html:37
-#, python-format
-msgid "%(site_name)s"
-msgstr ""
-
-#: mysite/templates/generic_base.html:75
+#: mysite/templates/generic_base.html:71
 msgid "Posts"
 msgstr ""
 
-#: mysite/templates/generic_base.html:76
+#: mysite/templates/generic_base.html:72
 msgid "Numbers"
 msgstr ""
 
-#: mysite/templates/generic_base.html:124
+#: mysite/templates/generic_base.html:120
 msgid "Issue tracker"
 msgstr ""
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -72,13 +72,8 @@ msgstr "Quels postes ont le moins de candidats jusque là?"
 
 #: cached_counts/templates/reports.html:15
 #, python-format
-msgid ""
-"\n"
-"        You can see a list of all the posts in current elections\n"
-"        <a href=\"%(url)s\">ordered starting with those with the fewest\n"
-"        candidates</a>.\n"
-"     "
-msgstr "\n        Vous pouvez voir une liste de tous les postes pour l'élection actuelle\n        <a href=\"%(url)s\"> ordonnée, commençant par ceux ayant le moins de candidats</a>.\n     "
+msgid "You can see a list of all the posts in current elections <a href=\"%(url)s\">ordered starting with those with the fewest candidates</a>."
+msgstr "Vous pouvez voir une liste de tous les postes pour l'élection actuelle <a href=\"%(url)s\"> ordonnée, commençant par ceux ayant le moins de candidats</a>."
 
 #: cached_counts/templates/reports.html:26
 msgid "Current Elections"
@@ -683,44 +678,28 @@ msgstr "La modification des données sur  %(site.name)s est maintenant desactiv�
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:4
 #, python-format
-msgid ""
-"\n"
-"    Thank-you for adding <a href=\"%(person_url)s\">%(person_name)s</a>!\n"
-"  "
-msgstr "\nMerci pour l'ajout de <a href=\"%(person_url)s\">%(person_name)s</a>!\n  "
+msgid "Thank-you for adding <a href=\"%(person_url)s\">%(person_name)s</a>!"
+msgstr "Merci pour l'ajout de <a href=\"%(person_url)s\">%(person_name)s</a>!"
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:8
 #, python-format
-msgid ""
-"\n"
-"    Thank-you for updating <a href=\"%(person_url)s\">%(person_name)s</a>!\n"
-"  "
-msgstr "\nMerci pour la mise à jour de  <a href=\"%(person_url)s\">%(person_name)s</a>!\n  "
+msgid "Thank-you for updating <a href=\"%(person_url)s\">%(person_name)s</a>!"
+msgstr "Merci pour la mise à jour de  <a href=\"%(person_url)s\">%(person_name)s</a>!"
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:17
 #, python-format
-msgid ""
-"\n"
-"      <a href=\"%(person_edit_url)s\">Edit %(person_name)s again</a>\n"
-"    "
-msgstr "\n      <a href=\"%(person_edit_url)s\">Modifier %(person_name)s à nouveau</a>\n    "
+msgid "<a href=\"%(person_edit_url)s\">Edit %(person_name)s again</a>"
+msgstr "<a href=\"%(person_edit_url)s\">Modifier %(person_name)s à nouveau</a>"
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:22
 #, python-format
-msgid ""
-"\n"
-"      Add a candidate for <a href=\"%(needing_attention_url)s\">one of the\n"
-"      posts with fewest candidates</a>\n"
-"    "
-msgstr "\n     Ajouter un candidat pour <a href=\"%(needing_attention_url)s\">Un des postes avec le moins de candidats</a>\n    "
+msgid "Add a candidate for <a href=\"%(needing_attention_url)s\">one of the posts with fewest candidates</a>"
+msgstr "Ajouter un candidat pour <a href=\"%(needing_attention_url)s\">Un des postes avec le moins de candidats</a>"
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:29
 #, python-format
-msgid ""
-"\n"
-"        <a href=\"%(person_create_url)s\">Add another candidate in the %(election_name)s</a>\n"
-"      "
-msgstr "\n        <a href=\"%(person_create_url)s\">Ajouter un autre candidats aux %(election_name)s</a>\n      "
+msgid "<a href=\"%(person_create_url)s\">Add another candidate in the %(election_name)s</a>"
+msgstr "<a href=\"%(person_create_url)s\">Ajouter un autre candidats aux %(election_name)s</a>"
 
 #: candidates/templates/candidates/_photo-credit.html:8
 #, python-format
@@ -1185,21 +1164,11 @@ msgid "Areas: %(all_area_names)s"
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:7
-#: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:7
-#, python-format
-msgid ""
-"\n"
-"    %(site_name)s user agreement\n"
-"  "
-msgstr ""
-
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:14
+#: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:7
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:14
 #, python-format
-msgid ""
-"\n"
-"        %(site_name)s user agreement\n"
-"      "
+msgid "%(site_name)s user agreement"
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:22
@@ -1967,10 +1936,7 @@ msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:7
 #, python-format
-msgid ""
-"\n"
-"    %(site_name)s is Temporarily Unavailable\n"
-"  "
+msgid "%(site_name)s is Temporarily Unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:13
@@ -1979,10 +1945,7 @@ msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:21
 #, python-format
-msgid ""
-"\n"
-"    Sorry, %(site_name)s is temporarily unavailable\n"
-"  "
+msgid "Sorry, %(site_name)s is temporarily unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:26
@@ -2792,10 +2755,8 @@ msgstr ""
 msgid "You indicated a photo upload for {0} should be ignored"
 msgstr ""
 
-#: mysite/settings.py:368
-msgid ""
-"Please don't quote third-party candidate sites —\n"
-"we prefer URLs of news stories or official candidate pages."
+#: mysite/settings.py:369
+msgid "Please don't quote third-party candidate sites — we prefer URLs of news stories or official candidate pages."
 msgstr ""
 
 #: mysite/templates/account/login.html:6 mysite/templates/account/login.html:9
@@ -2805,10 +2766,7 @@ msgstr ""
 
 #: mysite/templates/account/login.html:15
 #, python-format
-msgid ""
-"Please sign in with one\n"
-"of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign up</a>\n"
-"for a %(site_name)s account and sign in below:"
+msgid "Please sign in with one of your existing third party accounts. Or, <a href=\"%(signup_url)s\">sign up</a> for a %(site_name)s account and sign in below:"
 msgstr ""
 
 #: mysite/templates/account/login.html:25
@@ -2817,9 +2775,7 @@ msgstr ""
 
 #: mysite/templates/account/login.html:32
 #, python-format
-msgid ""
-"If you have not created an account yet, then please\n"
-"<a href=\"%(signup_url)s\">sign up</a> first."
+msgid "If you have not created an account yet, then please <a href=\"%(signup_url)s\">sign up</a> first."
 msgstr ""
 
 #: mysite/templates/account/login.html:43
@@ -2853,10 +2809,7 @@ msgstr ""
 
 #: mysite/templates/generic_base.html:37
 #, python-format
-msgid ""
-"\n"
-"           %(site_name)s\n"
-"        "
+msgid "%(site_name)s"
 msgstr ""
 
 #: mysite/templates/generic_base.html:75

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -24,10 +24,7 @@ msgid "Permission denied"
 msgstr "Permission non accordée"
 
 #: auth_helpers/templates/auth_helpers/group_permission_denied.html:14
-msgid ""
-"You must be in the member of a particular group in order to view that page. "
-"Please contact the administrators of the site if you feel that you should "
-"have access to this page."
+msgid "You must be in the member of a particular group in order to view that page. Please contact the administrators of the site if you feel that you should have access to this page."
 msgstr "Vous devez être membre d'un groupe particulier pour voir cette page. S'il vous plaît, contactez l'administrateur du site si vous pensez devoir avoir à cette page."
 
 #: cached_counts/templates/attention_needed.html:5
@@ -127,16 +124,12 @@ msgstr "Candidats à %(prior_election_name)s briguant à nouveau :"
 
 #: cached_counts/templates/reports.html:58
 #, python-format
-msgid ""
-"Candidates standing again from the %(prior_election_name)s for the same "
-"party:"
+msgid "Candidates standing again from the %(prior_election_name)s for the same party:"
 msgstr "Candidats à %(prior_election_name)s briguant à nouveau pour le même parti:"
 
 #: cached_counts/templates/reports.html:62
 #, python-format
-msgid ""
-"Candidates standing again from the %(prior_election_name)s for a different "
-"party:"
+msgid "Candidates standing again from the %(prior_election_name)s for a different party:"
 msgstr "Candidats à %(prior_election_name)s briguant pour un parti différent :"
 
 #: cached_counts/templates/reports.html:74
@@ -155,14 +148,12 @@ msgstr "était connu pour être un candidat du parti '{party}' aux {election}"
 
 #: candidates/diffs.py:38
 #, python-brace-format
-msgid ""
-"is known to be standing for the party with ID {party} in the {election}"
+msgid "is known to be standing for the party with ID {party} in the {election}"
 msgstr "est connu pour être un candidat du parti avec l'ID {party} aux {election}"
 
 #: candidates/diffs.py:40
 #, python-brace-format
-msgid ""
-"was known to be standing for the party with ID {party} in the {election}"
+msgid "was known to be standing for the party with ID {party} in the {election}"
 msgstr "était connu pour être un candidat du parti avec l'ID {party} aux {election}"
 
 #: candidates/diffs.py:43 candidates/diffs.py:91
@@ -192,28 +183,22 @@ msgstr "était connu pour ne pas être candidat aux {election}"
 
 #: candidates/diffs.py:64
 #, python-brace-format
-msgid ""
-"is known to be standing for the post with ID {post_id} in the {election}"
+msgid "is known to be standing for the post with ID {post_id} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:66
 #, python-brace-format
-msgid ""
-"was known to be standing for the post with ID {post_id} in the {election}"
+msgid "was known to be standing for the post with ID {post_id} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:70
 #, python-brace-format
-msgid ""
-"is known to be standing in the constituency with MapIt URL {mapit_url} in "
-"the {election}"
+msgid "is known to be standing in the constituency with MapIt URL {mapit_url} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:72
 #, python-brace-format
-msgid ""
-"was known to be standing in the constituency with MapIt URL {mapit_url} in "
-"the {election}"
+msgid "was known to be standing in the constituency with MapIt URL {mapit_url} in the {election}"
 msgstr ""
 
 #: candidates/diffs.py:76 candidates/diffs.py:97
@@ -362,16 +347,12 @@ msgid "Program"
 msgstr "Programme"
 
 #: candidates/forms.py:155
-msgid ""
-"The Twitter username must only consist of alphanumeric characters or "
-"underscore"
+msgid "The Twitter username must only consist of alphanumeric characters or underscore"
 msgstr "Le nom d'utilisateur Twitter doit contenir seulement des caractères alphanumériques ou des underscore"
 
 #: candidates/forms.py:177
 #, python-brace-format
-msgid ""
-"If you mark the candidate as standing in the {election}, you must select a "
-"post"
+msgid "If you mark the candidate as standing in the {election}, you must select a post"
 msgstr "Si vous marquez le candidat comme participant aux  {election}, vous devez sélectionner un poste"
 
 #: candidates/forms.py:186
@@ -381,8 +362,7 @@ msgstr "Un ID de post inconnu  '{post_id}' a été spécifié"
 
 #: candidates/forms.py:192
 #, python-brace-format
-msgid ""
-"Could not find parties for the post with ID '{post_id}' in the {election}"
+msgid "Could not find parties for the post with ID '{post_id}' in the {election}"
 msgstr "Impossible de trouver des partis pour le poste avec l'ID  '{post_id}' aux {election}"
 
 #: candidates/forms.py:200
@@ -439,9 +419,7 @@ msgstr "Source d'information pour ce changement ({0})"
 
 #: candidates/forms.py:425
 #, python-brace-format
-msgid ""
-"You can only edit data on {site_name} if you agree to this copyright "
-"assignment."
+msgid "You can only edit data on {site_name} if you agree to this copyright assignment."
 msgstr "Vous pouvez seulement modifier les données sur {site_name} si vous êtes d'accord avec cette cession de droit d'auteur."
 
 #: candidates/forms.py:449
@@ -498,9 +476,7 @@ msgid "Name change from '{0}' to '{1}' by user {2} disallowed"
 msgstr "changement de nom de '{0}' à '{1}' par l'utilisateur {2} rejeté"
 
 #: candidates/models/auth.py:84
-msgid ""
-"That update isn't allowed because candidates for a locked post would be "
-"changed"
+msgid "That update isn't allowed because candidates for a locked post would be changed"
 msgstr "Cette mise à jour n'est pas autorisée parce que des candidats à un post verrouillé seraient changés"
 
 #: candidates/models/db.py:29
@@ -555,10 +531,7 @@ msgid "(This list of candidates is currently <strong>unlocked</strong>.)"
 msgstr "(Cette liste de cancidats est actuellement <strong>Deverouillée</strong>.)"
 
 #: candidates/templates/candidates/_candidates_for_post.html:74
-msgid ""
-"This list of candidates is now <strong>locked</strong>; you can still update"
-" contact details of candidates, but can't change the people standing in this"
-" constituency."
+msgid "This list of candidates is now <strong>locked</strong>; you can still update contact details of candidates, but can't change the people standing in this constituency."
 msgstr "Cette liste de candidats est maintenant <strong>verrouillée</strong>; vous pouvez encore mettre à jour les informations de contact des candidats, mais vous ne pouvez plus changer les personnes candidates pour cette circonscription électorale."
 
 #: candidates/templates/candidates/_candidates_for_post.html:83
@@ -608,9 +581,7 @@ msgstr "Ce candidat à gagné"
 
 #: candidates/templates/candidates/_candidates_for_post.html:150
 #, python-format
-msgid ""
-"<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s "
-"for the %(election_name)s yet."
+msgid "<strong>Oh no!</strong> We don’t know of any candidates in %(post_label)s for the %(election_name)s yet."
 msgstr "<strong>Oh non!</strong> Nous ne connaissons pas encore de candidats dans %(post_label)s pour %(election_name)s."
 
 #: candidates/templates/candidates/_candidates_for_post.html:154
@@ -646,8 +617,7 @@ msgid "Is a candidate from the 2010 election standing again?"
 msgstr "Est-ce qu'un candidate ds élection de 2010 brigue à nouveau?"
 
 #: candidates/templates/candidates/_candidates_for_post.html:200
-msgid ""
-"We don't know if these candidates from earlier elections are standing again"
+msgid "We don't know if these candidates from earlier elections are standing again"
 msgstr "Nous ne savons pas si ces candidats de l'élection passée briguent à nouveau"
 
 #: candidates/templates/candidates/_candidates_for_post.html:221
@@ -659,8 +629,7 @@ msgid "Not standing again"
 msgstr "Ne brigue pas a nouveau"
 
 #: candidates/templates/candidates/_candidates_for_post.html:247
-msgid ""
-"These candidates from earlier elections are known not to be standing again"
+msgid "These candidates from earlier elections are known not to be standing again"
 msgstr "Ces candidats de l'élection passée sont connus pour pas briguer à nouveau"
 
 #: candidates/templates/candidates/_candidates_for_post.html:267
@@ -669,9 +638,7 @@ msgstr "Il sont candidats!"
 
 #: candidates/templates/candidates/_edits_disallowed_message.html:2
 #, python-format
-msgid ""
-"Editing of data in %(site.name)s is now disabled, but if you have a "
-"correction, please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
+msgid "Editing of data in %(site.name)s is now disabled, but if you have a correction, please email it to <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr "La modification des données sur  %(site.name)s est maintenant desactivée, mais si vous avez une correction, s'il vous plait, envoyez un email à <a href=\"mailto:%(email)s\">%(email)s</a>"
 
 #: candidates/templates/candidates/_person_update_call_to_action.html:4
@@ -714,9 +681,7 @@ msgid "They commented: “%(user_comment)s”."
 msgstr "Ils ont commenté: “%(user_comment)s”."
 
 #: candidates/templates/candidates/_photo-credit.html:18
-msgid ""
-"The volunteer moderator who reviewed this photo picked a different "
-"justification for its use on the site, which was:"
+msgid "The volunteer moderator who reviewed this photo picked a different justification for its use on the site, which was:"
 msgstr "Le volontaire modérateur qui a revu cette photo a pris une justification differente pour son utilisation sur le site, qui était"
 
 #: candidates/templates/candidates/_photo-credit.html:27
@@ -730,22 +695,16 @@ msgid "Notes about this image: “%(notes)s”."
 msgstr "Notes sur l'image: “%(notes)s”."
 
 #: candidates/templates/candidates/_photo-expand-reason.html:3
-msgid ""
-"the photo is free of copyright restrictions (i.e. has explictly been placed "
-"in the public domain)"
+msgid "the photo is free of copyright restrictions (i.e. has explictly been placed in the public domain)"
 msgstr "La photo est libre de droit (i.e. a été explicitement placée dans le domaine public)"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:8
 #, python-format
-msgid ""
-"they have assigned the copyright of the image to %(site_owner)s so that we "
-"may use it on the site"
+msgid "they have assigned the copyright of the image to %(site_owner)s so that we may use it on the site"
 msgstr "Ils ont cédé le droit d'utilisateur de l'image à %(site_owner)s afin que nous puissions l'utiliser sur le site internet"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:13
-msgid ""
-"this photo is the candidate's profile on social media, or is used to promote"
-" their candidacy on an official candidate or party website"
+msgid "this photo is the candidate's profile on social media, or is used to promote their candidacy on an official candidate or party website"
 msgstr "Cette photo est le profil du candidat sur les réseaux sociaux, ou est utilisée pour faire la promotion de sa candidature sur le site officiel des candidats ou sur le site du parti"
 
 #: candidates/templates/candidates/_photo-expand-reason.html:18
@@ -778,37 +737,22 @@ msgstr "A propos de ce site"
 
 #: candidates/templates/candidates/about.html:17
 #, python-format
-msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or"
-" bug reports."
+msgid "Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or bug reports."
 msgstr "s'il vous plaît, envoyez un email <a href=\"mailto:%(email)s\">%(email)s</a> avec vos retours et rapports de bogues."
 
 #: candidates/templates/candidates/about.html:22
 #: elections/uk_general_election_2015/templates/candidates/about.html:26
-msgid ""
-"The source code for this site is <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/\">available on "
-"GitHub</a>, and you can find a <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/issues\">list of "
-"known bugs</a> there as well."
+msgid "The source code for this site is <a href=\"https://github.com/mysociety/yournextrepresentative/\">available on GitHub</a>, and you can find a <a href=\"https://github.com/mysociety/yournextrepresentative/issues\">list of known bugs</a> there as well."
 msgstr "Le code source de ce site est <a href=\"https://github.com/mysociety/yournextrepresentative/\">disponible sur GitHub</a>, et vous pouvez trouver la <a href=\"https://github.com/mysociety/yournextrepresentative/issues\">liste des bogues connus</a> aussi."
 
 #: candidates/templates/candidates/about.html:30
-msgid ""
-"This site was originally developed by Mark Longair (mySociety), Sym Roe "
-"(Democracy Club) and Zarino Zappia (mySociety), and <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many"
-" other contributors</a>, to whom we owe a debt of gratitude."
+msgid "This site was originally developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety), and <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many other contributors</a>, to whom we owe a debt of gratitude."
 msgstr "A l'origine, ce site a été développé par Mark Longair (mySociety), Sym Roe (Democracy Club) et Zarino Zappia (mySociety), et <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">beaucoup d'autres contributeurs</a>, à qui nous sommes redevable. "
 
 #: candidates/templates/candidates/about.html:38
 #: elections/uk_general_election_2015/templates/candidates/about.html:49
 #, python-format
-msgid ""
-"You can use the data from this site, via the <a href=\"%(api_url)s\">API or "
-"CSV download</a>, under the terms of the Creative Commons license <a "
-"href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-"
-"ShareAlike (CC-BY-SA)</a> with the exception of:"
+msgid "You can use the data from this site, via the <a href=\"%(api_url)s\">API or CSV download</a>, under the terms of the Creative Commons license <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-ShareAlike (CC-BY-SA)</a> with the exception of:"
 msgstr "Vous pouvez utilisez les données sur ce site, à travers <a href=\"%(api_url)s\">l'API ou le téléchargement de fichiers CSV</a>, sous les termes de la licence Creative Commons <a href=\"https://creativecommons.org/licenses/by-sa/4.0/\">Attribution-ShareAlike (CC-BY-SA)</a> à l'exception de:"
 
 #: candidates/templates/candidates/about.html:47
@@ -817,20 +761,13 @@ msgstr "Logos du parti"
 
 #: candidates/templates/candidates/about.html:48
 #: elections/uk_general_election_2015/templates/candidates/about.html:59
-msgid ""
-"Candidate photos, which are typically either submitted by the candidates "
-"themselves, or from sources where it seems reasonable that we might use them"
-" on this site, such as the party's official page for that candidate, or "
-"their social media profile picture."
+msgid "Candidate photos, which are typically either submitted by the candidates themselves, or from sources where it seems reasonable that we might use them on this site, such as the party's official page for that candidate, or their social media profile picture."
 msgstr "Les photos de candidats, qui sont généralement soit soumis par les candidats eux-mêmes, ou provenant de sources où il semble raisonnable que nous pourrions les utiliser sur ce site, comme la page officielle du parti pour ce candidat, ou sa photo de profil sur les médias sociaux."
 
 #: candidates/templates/candidates/about.html:56
 #: elections/uk_general_election_2015/templates/candidates/about.html:67
 #, python-format
-msgid ""
-"If the CC-BY-SA licence is problematic for you, but you feel that you have a"
-" worthwhile use of the data in mind, please <a "
-"href=\"mailto:%(email)s\">contact us</a> to discuss your situation further."
+msgid "If the CC-BY-SA licence is problematic for you, but you feel that you have a worthwhile use of the data in mind, please <a href=\"mailto:%(email)s\">contact us</a> to discuss your situation further."
 msgstr "Si la licence CC-BY-SA est problématique pour vous, mais que vous sentez que vous avez un usage utile des données à l'esprit, s'il vous plaît contactez-nous <a href=\"mailto:%(email)s\"> </a> pour discuter de votre situation."
 
 #: candidates/templates/candidates/about.html:62
@@ -852,11 +789,7 @@ msgstr "Avertissement"
 #: candidates/templates/candidates/about.html:72
 #: elections/uk_general_election_2015/templates/candidates/about.html:95
 #, python-format
-msgid ""
-"The data on this website is crowd-sourced and may not be complete (or may "
-"contain inaccuracies). If you find an error, please either update the page "
-"yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the "
-"problem."
+msgid "The data on this website is crowd-sourced and may not be complete (or may contain inaccuracies). If you find an error, please either update the page yourself, or <a href=\"mailto:%(email)s\">email us</a> to report the problem."
 msgstr "Les données sur ce site sont crowd-sourcées et peut ne pas être complète (ou peut contenir des inexactitudes). Si vous trouvez une erreur, s'il vous plaît, vous pouvez mettre à jour la page vous-même, ou nous envoyer un courriel <a href=\"mailto:%(email)s\"> </a> pour signaler le problème."
 
 #: candidates/templates/candidates/all-edits-disallowed.html:6
@@ -877,11 +810,7 @@ msgid "Using this data via the API"
 msgstr "Utilisation de ces données via l'API"
 
 #: candidates/templates/candidates/api.html:16
-msgid ""
-"The data that's submitted to this site is available as a CSV/Excel download "
-"and programmatically via a RESTful web service called PopIt, which stores "
-"information about people and their positions in organizations. (You can <a "
-"href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
+msgid "The data that's submitted to this site is available as a CSV/Excel download and programmatically via a RESTful web service called PopIt, which stores information about people and their positions in organizations. (You can <a href=\"http://popit.poplus.org/\">find out more about PopIt here</a>.)"
 msgstr "Les données qui est soumises sur ce site sont disponibles en téléchargement CSV / Excel et par programmation via un service Web RESTful appelé Popit, qui stocke des informations sur les gens et leurs positions au sein des organisations. (Vous pouvez <a href=\"http://popit.poplus.org/\"> en savoir plus sur Popit ici </a>.)"
 
 #: candidates/templates/candidates/api.html:24
@@ -919,10 +848,7 @@ msgid "The base API URL for the data is:"
 msgstr "L'URL de base de l'API pour les données est:"
 
 #: candidates/templates/candidates/api.html:72
-msgid ""
-"You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic "
-"documentation for the PopIt API</a> or just follow the simple examples that "
-"follow."
+msgid "You can read <a href=\"http://popit.poplus.org/docs/api/\">more generic documentation for the PopIt API</a> or just follow the simple examples that follow."
 msgstr "Vous pouvez lire <a href=\"http://popit.poplus.org/docs/api/\"> plus de documentation générique pour l'</a> API Popit ou tout simplement suivre les exemples simples qui suivent."
 
 #: candidates/templates/candidates/api.html:78
@@ -930,11 +856,7 @@ msgid "Find a Constituency ID"
 msgstr "Trouver l'ID d'une circonscription électorale "
 
 #: candidates/templates/candidates/api.html:80
-msgid ""
-"In order to look up candidates for a constituency, you have to find the ID "
-"of that constituency. The IDs that we use for constituencies are the IDs for"
-" Westminster constituencies areas in another web service, <a "
-"href=\"http://mapit.mysociety.org\">MapIt</a>."
+msgid "In order to look up candidates for a constituency, you have to find the ID of that constituency. The IDs that we use for constituencies are the IDs for Westminster constituencies areas in another web service, <a href=\"http://mapit.mysociety.org\">MapIt</a>."
 msgstr "Afin de rechercher des candidats pour une circonscription, vous devez trouver l'ID de cette circonscription. Les identifiants que nous utilisons peuvent être trouvés sur un autre service Web, <a href=\"http://mapit.mysociety.org\"> MapIt </a>."
 
 #: candidates/templates/candidates/api.html:88
@@ -942,22 +864,15 @@ msgid "... from a postcode"
 msgstr "... à partir d'un code postal"
 
 #: candidates/templates/candidates/api.html:90
-msgid ""
-"Suppose you want to find the constituency for the postcode SW1A&nbsp;1AA, "
-"then you would make a GET request to the following URL:"
+msgid "Suppose you want to find the constituency for the postcode SW1A&nbsp;1AA, then you would make a GET request to the following URL:"
 msgstr "Supposons que vous voulez trouver la circonscription pour le code postal SW1A & nbsp; 1AA, alors vous ferez une requête GET à l'URL suivante:"
 
 #: candidates/templates/candidates/api.html:100
-msgid ""
-"This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON "
-"object</a>, wherein the constituency ID can be found at "
-"<tt>.shortcuts.WMC</tt>."
+msgid "This <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">returns a JSON object</a>, wherein the constituency ID can be found at <tt>.shortcuts.WMC</tt>."
 msgstr "Cela <a href=\"http://mapit.mysociety.org/postcode/SW1A1AA\">retourne un objet JSON</a>, dans lequel l'ID de la circonscription peut être trouvée à <tt> .shortcuts.WMC </ tt>."
 
 #: candidates/templates/candidates/api.html:106
-msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org"
-"/#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
+msgid "There's more documentation available on <a href=\"http://mapit.mysociety.org/#api-by_postcode\">postcode lookups on the MapIt front-page</a>."
 msgstr "Il y a plus de documentation disponible sur <a href=\"http://mapit.mysociety.org/#api-by_postcode\">la recherche à partir du code postal sur la première page de  MapIt</a>."
 
 #: candidates/templates/candidates/api.html:112
@@ -965,24 +880,15 @@ msgid "... from a latitude / longitude or other coordinate"
 msgstr "... à partir d'une latitude / longitude ou autre coordonnées"
 
 #: candidates/templates/candidates/api.html:114
-msgid ""
-"You can look up constituencies in MapIt using a variety of coordinate "
-"systems. To give the most common example, you might have a WGS84 coordinate "
-"from a GPS or location API, in which can you should put the SRID 4326 in "
-"your lookup. For example, latitude 52.205083 and longitude 0.115194 could be"
-" looked up with:"
+msgid "You can look up constituencies in MapIt using a variety of coordinate systems. To give the most common example, you might have a WGS84 coordinate from a GPS or location API, in which can you should put the SRID 4326 in your lookup. For example, latitude 52.205083 and longitude 0.115194 could be looked up with:"
 msgstr "Vous pouvez rechercher des circonscriptions dans MapIt utilisant une variété de systèmes de coordonnées. Pour donner l'exemple le plus courant, vous pourriez avoir une coordonnées WGS84 à partir d'un GPS ou d'un emplacement API, dans lequel vous devez mettre le SRID 4326 dans votre recherche. Par exemple, la latitude et la longitude 52.205083 0.115194 pourraient être examinées avec:"
 
 #: candidates/templates/candidates/api.html:126
-msgid ""
-"(Note that the longitude comes before the latitude, which might not be what "
-"you expect.) The only key in that object is the constituency ID."
+msgid "(Note that the longitude comes before the latitude, which might not be what you expect.) The only key in that object is the constituency ID."
 msgstr "(Notez que la longitude vient avant la latitude, ce qui pourrait ne pas être ce que vous attendez.) La seule clé dans cet objet est l'ID de circonscription."
 
 #: candidates/templates/candidates/api.html:132
-msgid ""
-"There's more documentation available on <a href=\"http://mapit.mysociety.org"
-"/#api-by_point\">point lookups on the MapIt front-page</a>."
+msgid "There's more documentation available on <a href=\"http://mapit.mysociety.org/#api-by_point\">point lookups on the MapIt front-page</a>."
 msgstr "Il ya plus de documentation disponible sur <a href=\"http://mapit.mysociety.org/#api-by_point\"> recherches ponctuelles sur la première page MapIt </a>."
 
 #: candidates/templates/candidates/api.html:138
@@ -990,18 +896,11 @@ msgid "... by selecting it from its name"
 msgstr "... en le sélectionnant à partir de son nom"
 
 #: candidates/templates/candidates/api.html:140
-msgid ""
-"If you need to produce a list of all constituencies (e.g. for a select box) "
-"and allow the user to pick one, you can get a list of all Westminster "
-"constituencies in the UK from this request:"
+msgid "If you need to produce a list of all constituencies (e.g. for a select box) and allow the user to pick one, you can get a list of all Westminster constituencies in the UK from this request:"
 msgstr "Si vous avez besoin pour produire une liste de toutes les circonscriptions (par exemple pour une boîte de sélection) et de permettre à l'utilisateur d'en choisir un, vous pouvez obtenir une liste de toutes les circonscriptions à partir de cette demande:"
 
 #: candidates/templates/candidates/api.html:150
-msgid ""
-"The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that"
-" request</a> has the constituency ID as its keys; the values are objects "
-"that include (among other things) a <tt>name</tt> element that gives you the"
-" official name of the constituency."
+msgid "The <a href=\"http://mapit.mysociety.org/areas/WMC\">returned data from that request</a> has the constituency ID as its keys; the values are objects that include (among other things) a <tt>name</tt> element that gives you the official name of the constituency."
 msgstr "Les données <a href=\"http://mapit.mysociety.org/areas/WMC\"> retourné de cette requête </a> a l'ID de la circonscription comme clés; les valeurs sont des objets qui comprennent (entre autres choses) un <tt> nom </ tt> qui vous donne le nom officiel de la circonscription."
 
 #: candidates/templates/candidates/api.html:158
@@ -1009,12 +908,7 @@ msgid "Find Candidates for a Constituency"
 msgstr "Trouver des candidats pour une circonscription"
 
 #: candidates/templates/candidates/api.html:160
-msgid ""
-"There are broadly two ways you can approach getting candidate data for a "
-"constituency; one is slightly simpler, and just gives you the basic "
-"candidate and party information, while the second gives you the full data in"
-" Popolo format, which is more complex but useful if you're using tools that "
-"generically process Popolo data."
+msgid "There are broadly two ways you can approach getting candidate data for a constituency; one is slightly simpler, and just gives you the basic candidate and party information, while the second gives you the full data in Popolo format, which is more complex but useful if you're using tools that generically process Popolo data."
 msgstr "Il existe globalement deux approches de l'obtention de données de candidats pour une circonscription; Une est un peu plus simple, et vous donne juste des informations basiques sur le candidat et le parti, tandis que la seconde vous donne l'ensemble des données au format Popolo, qui est plus complexe mais utile si vous utilisez des outils qui traite des données Popolo de façon générique."
 
 #: candidates/templates/candidates/api.html:169
@@ -1022,51 +916,28 @@ msgid "Simpler (Basic candidate information)"
 msgstr "Simple (information de base sur les candidats)"
 
 #: candidates/templates/candidates/api.html:171
-msgid ""
-"You can get all the candidates for a constituency, both in 2010 and 2015 by "
-"a query like:"
+msgid "You can get all the candidates for a constituency, both in 2010 and 2015 by a query like:"
 msgstr "Vous pouvez avoir tous les candidats pour une circonscription, avec une requête de la sorte : "
 
 #: candidates/templates/candidates/api.html:180
 #, python-format
-msgid ""
-"For example, for Dulwich and West Norwood, <a "
-"href=\"%(popit_url)sposts/65808?embed=membership.person\">these would be the"
-" results</a>."
+msgid "For example, for Dulwich and West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person\">these would be the results</a>."
 msgstr "Par exemple, pour  Dulwich et West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person\">cela serait le résultats</a>."
 
 #: candidates/templates/candidates/api.html:186
-msgid ""
-"If you iterate over the <tt>memberships</tt> in that result, each person "
-"will look something like:"
+msgid "If you iterate over the <tt>memberships</tt> in that result, each person will look something like:"
 msgstr "Si vous itérez sur l'<tt>appartenance</tt> dans ce résultat, chaque personne va ressembler à quelque chose comme:"
 
 #: candidates/templates/candidates/api.html:214
-msgid ""
-"(I've removed some fields there to keep the example simpler.) The two fields"
-" of particular interest are probably <tt>standing_in</tt> and "
-"<tt>party_memberships</tt>."
+msgid "(I've removed some fields there to keep the example simpler.) The two fields of particular interest are probably <tt>standing_in</tt> and <tt>party_memberships</tt>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:222
-msgid ""
-"This object will only have keys '2010' or '2015'. If one of these keys is "
-"present then we have known information about the candidate for the UK "
-"general election in that year.  If the value is <tt>null</tt> then we know "
-"that they're <em>not</em> standing. If they are (or were) standing in the "
-"general election in that year then there will be a dictionary giving you "
-"details of the constituency they were standing in. So, in the example above "
-"we can see that Tessa Jowell stood in 2010 in Dulwich and West Norwood, but "
-"we know isn't standing in any consituency in 2015."
+msgid "This object will only have keys '2010' or '2015'. If one of these keys is present then we have known information about the candidate for the UK general election in that year.  If the value is <tt>null</tt> then we know that they're <em>not</em> standing. If they are (or were) standing in the general election in that year then there will be a dictionary giving you details of the constituency they were standing in. So, in the example above we can see that Tessa Jowell stood in 2010 in Dulwich and West Norwood, but we know isn't standing in any consituency in 2015."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:236
-msgid ""
-"This object will similarly only have keys '2010' or '2015' and tells you "
-"what party the candidate is / was standing for in the general election of "
-"that year.  So in the example above, you can see that Tessa Jowell stood for"
-" the Labour Party in 2010, but has no entry for 2015 (because, as the "
-"<tt>standing_in</tt> tells us) she's not standing in 2015."
+msgid "This object will similarly only have keys '2010' or '2015' and tells you what party the candidate is / was standing for in the general election of that year.  So in the example above, you can see that Tessa Jowell stood for the Labour Party in 2010, but has no entry for 2015 (because, as the <tt>standing_in</tt> tells us) she's not standing in 2015."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:245
@@ -1074,38 +945,20 @@ msgid "More complex (Full Popolo information)"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:247
-msgid ""
-"All the candidates we know about for a constituency can be returned by "
-"making a GET request to a URL of this form, where you should substitute in "
-"the constituency ID for CONSTITUENCY_ID:"
+msgid "All the candidates we know about for a constituency can be returned by making a GET request to a URL of this form, where you should substitute in the constituency ID for CONSTITUENCY_ID:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:258
 #, python-format
-msgid ""
-"For example, for Dulwich and West Norwood, <a "
-"href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">these"
-" would be the results</a>. To explain further, that's showing information "
-"about the <em>post</em> \"MP for Dulwich and West Norwood\". Under the "
-"<tt>memberships</tt> key of the <tt>result</tt> dictionary you can find all "
-"memberships of this post - those that have the <tt>role</tt> \"Candidate\" "
-"were candidates at one point."
+msgid "For example, for Dulwich and West Norwood, <a href=\"%(popit_url)sposts/65808?embed=membership.person.membership.organization\">these would be the results</a>. To explain further, that's showing information about the <em>post</em> \"MP for Dulwich and West Norwood\". Under the <tt>memberships</tt> key of the <tt>result</tt> dictionary you can find all memberships of this post - those that have the <tt>role</tt> \"Candidate\" were candidates at one point."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:268
-msgid ""
-"You should then look at the start and end dates of that membership, which "
-"will tell you whether they're a candidate for the 2015 election or were a "
-"past candidate for the 2010 election:"
+msgid "You should then look at the start and end dates of that membership, which will tell you whether they're a candidate for the 2015 election or were a past candidate for the 2010 election:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:281
-msgid ""
-"Under <tt>person_id</tt> attribute of each of those membership you can find "
-"information about that candidate, like their name, contact details and (in "
-"another nested <tt>memberships</tt> object) their memberships of political "
-"parties. The party memberships use the same date values as above to indicate"
-" whether it's their party membership at the 2010 or 2015 election."
+msgid "Under <tt>person_id</tt> attribute of each of those membership you can find information about that candidate, like their name, contact details and (in another nested <tt>memberships</tt> object) their memberships of political parties. The party memberships use the same date values as above to indicate whether it's their party membership at the 2010 or 2015 election."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:293
@@ -1113,19 +966,12 @@ msgid "Find a candidate by name"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:295
-msgid ""
-"You can use the <tt>search/persons</tt> endpoint with a query paramter like "
-"<tt>q=name:\"John Doe\"</tt>."
+msgid "You can use the <tt>search/persons</tt> endpoint with a query paramter like <tt>q=name:\"John Doe\"</tt>."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:304
 #, python-format
-msgid ""
-"For example, you can find every David Jones in the database with <a "
-"href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this "
-"query</a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt>"
-" elements will give you details about which constituencies they are / were "
-"standing in, and for which parties."
+msgid "For example, you can find every David Jones in the database with <a href=\"%(popit_url)ssearch/persons?q=name:%%22david%%20jones%%22\">this query</a>. As above, the <tt>standing_in</tt> and <tt>party_memberships</tt> elements will give you details about which constituencies they are / were standing in, and for which parties."
 msgstr ""
 
 #: candidates/templates/candidates/api.html:313
@@ -1134,19 +980,12 @@ msgstr ""
 
 #: candidates/templates/candidates/api.html:315
 #, python-format
-msgid ""
-"You can also use the <tt>search/persons</tt> endpoint to find all the "
-"candidates that we think are standing in 2015, with <a "
-"href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id "
-"\">this query</a>:"
+msgid "You can also use the <tt>search/persons</tt> endpoint to find all the candidates that we think are standing in 2015, with <a href=\"%(popit_url)ssearch/persons?q=_exists_:standing_in.2015.post_id \">this query</a>:"
 msgstr ""
 
 #: candidates/templates/candidates/api.html:326
 #, python-format
-msgid ""
-"(This question was raised on the <a href=\"%(url)s\">Democracy Club Google "
-"Group</a>, which may be of interest if you're developing software that uses "
-"the %(site.name)s data.)"
+msgid "(This question was raised on the <a href=\"%(url)s\">Democracy Club Google Group</a>, which may be of interest if you're developing software that uses the %(site.name)s data.)"
 msgstr ""
 
 #: candidates/templates/candidates/areas-of-type.html:10
@@ -1172,22 +1011,13 @@ msgstr ""
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:22
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:22
 #, python-format
-msgid ""
-"Before you carry on to edit data in %(site_name)s, we need you to agree that"
-" your contributions to this site (with the exception of photo uploads) are "
-"owned by %(copyright_holder)s. In return, we agree to make the complete "
-"database available under an open licence such as <a "
-"href=\"http://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or "
-"remove copyright restrictions by releasing into the public domain (<a "
-"href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
+msgid "Before you carry on to edit data in %(site_name)s, we need you to agree that your contributions to this site (with the exception of photo uploads) are owned by %(copyright_holder)s. In return, we agree to make the complete database available under an open licence such as <a href=\"http://creativecommons.org/licenses/by-sa/4.0/\">CC-BY-SA</a> or remove copyright restrictions by releasing into the public domain (<a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>)."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:42
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:42
 #, python-format
-msgid ""
-"I assign the copyright of my contributions to %(site_name)s (apart from "
-"photo uploads) to %(copyright_holder)s."
+msgid "I assign the copyright of my contributions to %(site_name)s (apart from photo uploads) to %(copyright_holder)s."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:49
@@ -1198,10 +1028,7 @@ msgstr ""
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:53
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:53
 #, python-format
-msgid ""
-"Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a "
-"href=\"mailto:%(email)s\">email us</a> if you have any questions about this "
-"agreement."
+msgid "Otherwise you can <a href=\"%(url)s\">log out</a>. Please do <a href=\"mailto:%(email)s\">email us</a> if you have any questions about this agreement."
 msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:61
@@ -1211,12 +1038,7 @@ msgstr ""
 
 #: candidates/templates/candidates/ask-for-copyright-assignment.html:63
 #, python-format
-msgid ""
-"This is the simplest way to ensure that we can make this data as widely "
-"available as possible while preventing the hard work of contributors to "
-"%(site_name)s being unfairly co-opted by companies building closed candidate"
-" databases. This also allows us the flexibility to release the data under "
-"different open licenses in the future."
+msgid "This is the simplest way to ensure that we can make this data as widely available as possible while preventing the hard work of contributors to %(site_name)s being unfairly co-opted by companies building closed candidate databases. This also allows us the flexibility to release the data under different open licenses in the future."
 msgstr ""
 
 #: candidates/templates/candidates/candidacy-create.html:6
@@ -1227,10 +1049,7 @@ msgstr ""
 
 #: candidates/templates/candidates/candidacy-create.html:14
 #, python-format
-msgid ""
-"Before updating our records we need to know the source for your information "
-"that %(name)s is standing for election to the post of %(post_label)s in the "
-"%(election_name)s."
+msgid "Before updating our records we need to know the source for your information that %(name)s is standing for election to the post of %(post_label)s in the %(election_name)s."
 msgstr ""
 
 #: candidates/templates/candidates/candidacy-delete.html:6
@@ -1241,10 +1060,7 @@ msgstr ""
 
 #: candidates/templates/candidates/candidacy-delete.html:14
 #, python-format
-msgid ""
-"Before updating our records we need to know the source for your information "
-"that %(name)s <strong>isn’t</strong> standing for election to the post of "
-"%(post_label)s in the %(election_name)s."
+msgid "Before updating our records we need to know the source for your information that %(name)s <strong>isn’t</strong> standing for election to the post of %(post_label)s in the %(election_name)s."
 msgstr ""
 
 #: candidates/templates/candidates/constituencies-declared.html:6
@@ -1286,9 +1102,7 @@ msgid "All Constituencies for the 2015 General Election"
 msgstr ""
 
 #: candidates/templates/candidates/constituencies.html:14
-msgid ""
-"Follow one of the links below to see the known candidates for that "
-"constituency:"
+msgid "Follow one of the links below to see the known candidates for that constituency:"
 msgstr ""
 
 #: candidates/templates/candidates/constituency.html:9
@@ -1322,8 +1136,7 @@ msgstr ""
 
 #: candidates/templates/candidates/constituency.html:35
 #, python-format
-msgid ""
-"Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
+msgid "Candidates for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr ""
 
 #: candidates/templates/candidates/constituency.html:47
@@ -1334,10 +1147,7 @@ msgid "Invalidate Cache"
 msgstr ""
 
 #: candidates/templates/candidates/constituency.html:48
-msgid ""
-"As a staff user, you can invalidate any cached data for this constituency. "
-"This may <em>occasionally</em> be necessary if the page is showing stale "
-"information for more than 10 seconds."
+msgid "As a staff user, you can invalidate any cached data for this constituency. This may <em>occasionally</em> be necessary if the page is showing stale information for more than 10 seconds."
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:14
@@ -1351,9 +1161,7 @@ msgid "Find candidates to be your next representative"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:34
-msgid ""
-"Don’t pay for a candidate database sold by a data vendor — it’s a waste of "
-"money."
+msgid "Don’t pay for a candidate database sold by a data vendor — it’s a waste of money."
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:44
@@ -1367,11 +1175,7 @@ msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:57
 #, python-format
-msgid ""
-"The database is transparently sourced and available as structured data, "
-"suitable for building other election websites. <a href=\"%(api_url)s\">Get "
-"the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new "
-"candidate details.</a>"
+msgid "The database is transparently sourced and available as structured data, suitable for building other election websites. <a href=\"%(api_url)s\">Get the data now</a>, or <a href=\"%(tasks_url)s\">help by contributing new candidate details.</a>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:70
@@ -1380,102 +1184,67 @@ msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:77
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new "
-"candidate</a> <span class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> created <a href=\"%(person_url)s\">a new candidate</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:83
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> is creating a new candidate <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> is creating a new candidate <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:89
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> merged another candidate into <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> merged another candidate into <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:95
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> uploaded a photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> uploaded a photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> for moderation <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:101
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> approved an uploaded photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> approved an uploaded photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:107
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> rejected an uploaded photo of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> rejected an uploaded photo of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:113
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> reverted to an earlier version of <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> reverted to an earlier version of <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:119
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> confirmed candidacy for <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> confirmed candidacy for <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:125
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> removed candidacy for <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> removed candidacy for <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:131
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> locked a constituency <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> locked a constituency <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:135
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> unlocked a constituency <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> unlocked a constituency <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:139
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> marked <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> as the winner <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> marked <a href=\"%(person_url)s\">candidate #%(person_id)s</a> as the winner <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:145
 #, python-format
-msgid ""
-"User <strong>%(username)s</strong> updated <a "
-"href=\"%(person_url)s\">candidate #%(person_id)s</a> <span "
-"class=\"when\">%(when)s ago</span>"
+msgid "User <strong>%(username)s</strong> updated <a href=\"%(person_url)s\">candidate #%(person_id)s</a> <span class=\"when\">%(when)s ago</span>"
 msgstr ""
 
 #: candidates/templates/candidates/frontpage.html:154
@@ -1514,24 +1283,19 @@ msgstr ""
 #: candidates/templates/candidates/ordered-party-list.html:9
 #: candidates/templates/candidates/ordered-party-list.html:32
 #, python-format
-msgid ""
-"Party list of %(party_name)s for %(post_label_shorter)s in the "
-"%(election_name)s"
+msgid "Party list of %(party_name)s for %(post_label_shorter)s in the %(election_name)s"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:16
 #: candidates/templates/candidates/ordered-party-list.html:22
 #: candidates/templates/candidates/ordered-party-list.html:27
 #, python-format
-msgid ""
-"Party list of %(party_name)s for %(post_label_shorter)s in the %(election)s"
+msgid "Party list of %(party_name)s for %(post_label_shorter)s in the %(election)s"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:35
 #, python-format
-msgid ""
-"Party list of %(party_name)s for <span id=\"constituency-"
-"name\">%(post_label_shorter)s</span>"
+msgid "Party list of %(party_name)s for <span id=\"constituency-name\">%(post_label_shorter)s</span>"
 msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:45
@@ -1541,9 +1305,7 @@ msgstr ""
 
 #: candidates/templates/candidates/ordered-party-list.html:85
 #, python-format
-msgid ""
-"<strong>Oh no!</strong> We don’t know of any candidates from %(party.name)s "
-"for %(post_label)s for the %(election_name)s yet."
+msgid "<strong>Oh no!</strong> We don’t know of any candidates from %(party.name)s for %(post_label)s for the %(election_name)s yet."
 msgstr ""
 
 #: candidates/templates/candidates/party-list.html:6
@@ -1561,43 +1323,30 @@ msgstr ""
 
 #: candidates/templates/candidates/party.html:8
 #, python-format
-msgid ""
-"%(party_name)s &#8212; Candidates by constituency for the UK 2015 General "
-"Election"
+msgid "%(party_name)s &#8212; Candidates by constituency for the UK 2015 General Election"
 msgstr ""
 
 #: candidates/templates/candidates/party.html:20
-msgid ""
-"This shows all the constituencies that have independent candidates standing "
-"in them at the 2015 general election"
+msgid "This shows all the constituencies that have independent candidates standing in them at the 2015 general election"
 msgstr ""
 
 #: candidates/templates/candidates/party.html:25
-msgid ""
-"The Speaker of the House of Commons stands as a \"The Speaker seeking re-"
-"election\" rather than a particular party at a general election; for more "
-"information, please see <a href=\"http://www.parliament.uk/about/faqs/house-"
-"of-commons-faqs/speakers-election/\">Parliament's website</a>."
+msgid "The Speaker of the House of Commons stands as a \"The Speaker seeking re-election\" rather than a particular party at a general election; for more information, please see <a href=\"http://www.parliament.uk/about/faqs/house-of-commons-faqs/speakers-election/\">Parliament's website</a>."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:33
 #, python-format
-msgid ""
-"%(party_name)s is on the Electoral Commission's register for %(register)s."
+msgid "%(party_name)s is on the Electoral Commission's register for %(register)s."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:35
 #, python-format
-msgid ""
-"You can find more data about the party's registration at the <a "
-"href=\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
+msgid "You can find more data about the party's registration at the <a href=\"%(ec_url)s\">Electoral Commission page for %(party_name)s</a>."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:51
 #, python-format
-msgid ""
-"<a href=\"%(person_url)s\">%(name)s</a> is standing in <a "
-"href=\"%(post_url)s\">%(post)s</a>"
+msgid "<a href=\"%(person_url)s\">%(name)s</a> is standing in <a href=\"%(post_url)s\">%(post)s</a>"
 msgstr ""
 
 #: candidates/templates/candidates/party.html:55
@@ -1607,16 +1356,12 @@ msgstr ""
 
 #: candidates/templates/candidates/party.html:63
 #, python-format
-msgid ""
-"There were also %(missing)s posts in %(country)s that %(party_name)s aren't "
-"standing a candidate for."
+msgid "There were also %(missing)s posts in %(country)s that %(party_name)s aren't standing a candidate for."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:68
 #, python-format
-msgid ""
-"There were also %(missing)s posts that %(party_name)s aren't standing a "
-"candidate for."
+msgid "There were also %(missing)s posts that %(party_name)s aren't standing a candidate for."
 msgstr ""
 
 #: candidates/templates/candidates/party.html:75
@@ -1677,9 +1422,7 @@ msgid "Additional information:"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:246
-msgid ""
-"<strong>You forgot to reference a source!</strong> Can you show us "
-"<em>where</em> you got this information?"
+msgid "<strong>You forgot to reference a source!</strong> Can you show us <em>where</em> you got this information?"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:248
@@ -1691,10 +1434,7 @@ msgid "Thanks for helping out!"
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:265
-msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
-"fields</a>."
+msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields</a>."
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:271
@@ -1703,9 +1443,7 @@ msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:273
 #, python-format
-msgid ""
-"There’s a separate page for <a href=\"%(url)s\">uploading a photo of "
-"%(name)s</a>."
+msgid "There’s a separate page for <a href=\"%(url)s\">uploading a photo of %(name)s</a>."
 msgstr ""
 
 #: candidates/templates/candidates/person-edit.html:281
@@ -1811,9 +1549,7 @@ msgstr ""
 
 #: candidates/templates/candidates/person-view.html:95
 #, python-format
-msgid ""
-"We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by"
-" adding one</a>!"
+msgid "We don’t have an email address for %(name)s, <a href=\"%(url)s\">help out by adding one</a>!"
 msgstr ""
 
 #: candidates/templates/candidates/person-view.html:104
@@ -1898,8 +1634,7 @@ msgid "Our database is built by people like you."
 msgstr ""
 
 #: candidates/templates/candidates/person-view.html:215
-msgid ""
-"Please do add extra details about this candidate – it only takes a moment."
+msgid "Please do add extra details about this candidate – it only takes a moment."
 msgstr ""
 
 #: candidates/templates/candidates/person-view.html:218
@@ -1920,16 +1655,11 @@ msgstr ""
 
 #: candidates/templates/candidates/person-view.html:238
 #, python-format
-msgid ""
-"More details about getting <a href=\"%(api_url)s\">the data</a> and <a "
-"href=\"%(about_url)s\">its license</a>."
+msgid "More details about getting <a href=\"%(api_url)s\">the data</a> and <a href=\"%(about_url)s\">its license</a>."
 msgstr ""
 
 #: candidates/templates/candidates/person-view.html:247
-msgid ""
-"As a staff user, you can invalidate any cached data for this user. This may "
-"<em>occasionally</em> be necessary if the page is showing stale information "
-"for more than 10 seconds."
+msgid "As a staff user, you can invalidate any cached data for this user. This may <em>occasionally</em> be necessary if the page is showing stale information for more than 10 seconds."
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:7
@@ -1947,9 +1677,7 @@ msgid "Sorry, %(site_name)s is temporarily unavailable"
 msgstr ""
 
 #: candidates/templates/candidates/popit_down.html:26
-msgid ""
-"This usually means that we’re having to do some brief maintenance, and the "
-"site will be back soon."
+msgid "This usually means that we’re having to do some brief maintenance, and the site will be back soon."
 msgstr ""
 
 #: candidates/templates/candidates/posts.html:9
@@ -1959,8 +1687,7 @@ msgstr ""
 
 #: candidates/templates/candidates/posts.html:14
 #: elections/st_paul_municipal_2015/templates/candidates/posts.html:14
-msgid ""
-"Follow one of the links below to see the known candidates for that post:"
+msgid "Follow one of the links below to see the known candidates for that post:"
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:6
@@ -1985,29 +1712,20 @@ msgid "This site is run by %(site_owner)s."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:28
-msgid ""
-"We make the following promises about your personal information as a user of "
-"the site:"
+msgid "We make the following promises about your personal information as a user of the site:"
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:34
-msgid ""
-"We will not sell or distribute your email address or other personal "
-"information."
+msgid "We will not sell or distribute your email address or other personal information."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:38
-msgid ""
-"We will gladly show you the personal data we store about you in order to run"
-" the website."
+msgid "We will gladly show you the personal data we store about you in order to run the website."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:44
 #, python-format
-msgid ""
-"We may use your email address to contact you about your use of the site if "
-"it's problematic (or particularly helpful!), or with occasional "
-"announcements about %(site_name)s and other %(site_owner)s projects."
+msgid "We may use your email address to contact you about your use of the site if it's problematic (or particularly helpful!), or with occasional announcements about %(site_name)s and other %(site_owner)s projects."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:51
@@ -2015,27 +1733,15 @@ msgid "Details"
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:53
-msgid ""
-"As well as your login details, we store your IP address along with any "
-"changes you make to the data on the site.  All this information is "
-"accessible to administrators of the site."
+msgid "As well as your login details, we store your IP address along with any changes you make to the data on the site.  All this information is accessible to administrators of the site."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:59
-msgid ""
-"Please note that this policy refers to the personal information arising from"
-" creating a login on the site, not the personal information about candidates"
-" for elections - the reason for the site to exist is to make information "
-"about those candidates available to members of the public and website "
-"developers so that they can find out more about those candidates, their "
-"promises and policy positions."
+msgid "Please note that this policy refers to the personal information arising from creating a login on the site, not the personal information about candidates for elections - the reason for the site to exist is to make information about those candidates available to members of the public and website developers so that they can find out more about those candidates, their promises and policy positions."
 msgstr ""
 
 #: candidates/templates/candidates/privacy.html:69
-msgid ""
-"We also use Google Analytics to aggregate and track data about usage of the "
-"site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a "
-"browser plugin to opt out of having data collected by Google Analytics</a>."
+msgid "We also use Google Analytics to aggregate and track data about usage of the site; you can use <a href=\"https://tools.google.com/dlpage/gaoptout/\">a browser plugin to opt out of having data collected by Google Analytics</a>."
 msgstr ""
 
 #: candidates/templates/candidates/recent-changes.html:6
@@ -2093,11 +1799,7 @@ msgstr ""
 
 #: candidates/templates/candidates/update-disallowed.html:16
 #, python-format
-msgid ""
-"As a precaution, this update hasn't been allowed, but details have been "
-"emailed to the team of %(site.name)s volunteers; they will apply the change "
-"after checking it. If you have any questions about this, please email <a "
-"href=\"%(email)s\">%(email)s</a>."
+msgid "As a precaution, this update hasn't been allowed, but details have been emailed to the team of %(site.name)s volunteers; they will apply the change after checking it. If you have any questions about this, please email <a href=\"%(email)s\">%(email)s</a>."
 msgstr ""
 
 #: candidates/templatetags/metadescription.py:23
@@ -2117,8 +1819,7 @@ msgstr ""
 
 #: candidates/templatetags/metadescription.py:29
 #, python-format
-msgid ""
-"%(name)s is standing as an independent candidate in %(post)s in %(election)s"
+msgid "%(name)s is standing as an independent candidate in %(post)s in %(election)s"
 msgstr ""
 
 #: candidates/templatetags/metadescription.py:31
@@ -2327,75 +2028,39 @@ msgid "Unknown MapIt error for postcode \"{0}\""
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/base.html:24
-msgid ""
-"Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a "
-"href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a "
-"href=\"https://mysociety.org\">mySociety</a>."
+msgid "Supported by <a href=\"https://fullfact.org\">Full Fact</a>, <a href=\"http://unlockdemocracy.org.uk\">Unlock Democracy</a>, and <a href=\"https://mysociety.org\">mySociety</a>."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/base.html:31
 #, python-format
-msgid ""
-"Built by <a href=\"%(site_managers_url)s\"> <img src=\"%(logo_url)s\" %%} "
-"alt=\"%(site_managers)s\" class=\"dc-logo\"></a>"
+msgid "Built by <a href=\"%(site_managers_url)s\"> <img src=\"%(logo_url)s\" %%} alt=\"%(site_managers)s\" class=\"dc-logo\"></a>"
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:17
 #, python-format
-msgid ""
-"Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or"
-" bug reports. If you'd like to discuss this site or any other project "
-"relating to elections in the UK, we'd suggest that you post to the <a "
-"href=\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy "
-"Club Google Group</a>."
+msgid "Please email <a href=\"mailto:%(email)s\">%(email)s</a> with any feedback or bug reports. If you'd like to discuss this site or any other project relating to elections in the UK, we'd suggest that you post to the <a href=\"https://groups.google.com/forum/#!forum/democracy-club\">Democracy Club Google Group</a>."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:34
-msgid ""
-"This site was originally developed by Mark Longair (mySociety), Sym Roe "
-"(Democracy Club) and Zarino Zappia (mySociety) and <a "
-"href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many"
-" other contributors</a>, to whom we owe a debt of gratitude."
+msgid "This site was originally developed by Mark Longair (mySociety), Sym Roe (Democracy Club) and Zarino Zappia (mySociety) and <a href=\"https://github.com/mysociety/yournextrepresentative/graphs/contributors\">many other contributors</a>, to whom we owe a debt of gratitude."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:41
-msgid ""
-"The data on candidates from the last UK general election in 2010 is all "
-"taken from Edmund von der Burg's <a "
-"href=\"http://www.yournextmp.com\">YourNextMP.com</a>, with many thanks."
+msgid "The data on candidates from the last UK general election in 2010 is all taken from Edmund von der Burg's <a href=\"http://www.yournextmp.com\">YourNextMP.com</a>, with many thanks."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:58
-msgid ""
-"The party logos, which are taken from the Electoral Commission's website"
+msgid "The party logos, which are taken from the Electoral Commission's website"
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/about.html:73
 #, python-format
-msgid ""
-"For complicated reasons relating to database licensing, we have put the data"
-" as of the 4th of March 2015 into the public domain by declaring it to be <a"
-" href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This "
-"data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-"
-"date/\">here</a> but please be warned that this snapshot will become "
-"inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date "
-"data</a> instead."
+msgid "For complicated reasons relating to database licensing, we have put the data as of the 4th of March 2015 into the public domain by declaring it to be <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0</a>. This data is available <a href=\"%(MEDIA_URL)scsv-archives/cc0-snapshot-out-of-date/\">here</a> but please be warned that this snapshot will become inaccurate very quickly - please use <a href=\"%(api_url)s\">the up-to-date data</a> instead."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/ask-for-copyright-assignment.html:63
 #, python-format
-msgid ""
-"When we originally set up %(site_name)s for the 2015 UK general election we "
-"didn't get legal advice about the best way to deal with copyright and "
-"licensing. It turns out that the way that the user agreement that was worded"
-" on the 'About' page had a few problems, and in particular restricted what "
-"we could do with the data such that we couldn't license the database to some"
-" partners who we thought would make good use of the data but who needed "
-"slightly different licensing. The simplest way to ensure that we can make "
-"the data as widely available as possible while preventing the hard work of "
-"contributors to %(site_name)s being co-opted by companies building closed "
-"candidate databases is to ask you to assign the copyright of your "
-"contributions to %(copyright_holder)s."
+msgid "When we originally set up %(site_name)s for the 2015 UK general election we didn't get legal advice about the best way to deal with copyright and licensing. It turns out that the way that the user agreement that was worded on the 'About' page had a few problems, and in particular restricted what we could do with the data such that we couldn't license the database to some partners who we thought would make good use of the data but who needed slightly different licensing. The simplest way to ensure that we can make the data as widely available as possible while preventing the hard work of contributors to %(site_name)s being co-opted by companies building closed candidate databases is to ask you to assign the copyright of your contributions to %(copyright_holder)s."
 msgstr ""
 
 #: elections/uk_general_election_2015/templates/candidates/finder.html:14
@@ -2409,9 +2074,7 @@ msgid "The popit_person_id must be all digits"
 msgstr ""
 
 #: moderation_queue/forms.py:39
-msgid ""
-"If you checked 'Other' then you must provide a justification for why we can "
-"use it."
+msgid "If you checked 'Other' then you must provide a justification for why we can use it."
 msgstr ""
 
 #: moderation_queue/models.py:20
@@ -2435,15 +2098,11 @@ msgid "This photograph is free of any copyright restrictions"
 msgstr ""
 
 #: moderation_queue/models.py:35
-msgid ""
-"I own copyright of this photo and I assign the copyright to Democracy Club "
-"Limited in return for it being displayed on this site"
+msgid "I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on this site"
 msgstr ""
 
 #: moderation_queue/models.py:39
-msgid ""
-"This is the candidate's public profile photo from social media (e.g. "
-"Twitter, Facebook) or their official campaign page"
+msgid "This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page"
 msgstr ""
 
 #: moderation_queue/models.py:43
@@ -2457,12 +2116,8 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:7
 #, python-format
-msgid ""
-"<strong>Warning:</strong> there is already %(queued_images)s photo of "
-"%(name)s in the queue, waiting to be moderated:"
-msgid_plural ""
-"<strong>Warning:</strong> there are already %(queued_images)s photos of "
-"%(name)s in the queue, waiting to be moderated:"
+msgid "<strong>Warning:</strong> there is already %(queued_images)s photo of %(name)s in the queue, waiting to be moderated:"
+msgid_plural "<strong>Warning:</strong> there are already %(queued_images)s photos of %(name)s in the queue, waiting to be moderated:"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -2473,9 +2128,7 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:25
 #, python-format
-msgid ""
-"If you still want to upload another photo of %(name)s, first select an image"
-" from your computer:"
+msgid "If you still want to upload another photo of %(name)s, first select an image from your computer:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:29
@@ -2483,15 +2136,11 @@ msgid "First, select an image from your computer:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:38
-msgid ""
-"Now let us know about the copyright of this image by selecting one of these "
-"options or explaining why we can use it:"
+msgid "Now let us know about the copyright of this image by selecting one of these options or explaining why we can use it:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:47
-msgid ""
-"Here is my justification for why this photo may be reasonably used on the "
-"website, including the source URL:"
+msgid "Here is my justification for why this photo may be reasonably used on the website, including the source URL:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/_photo-upload-form.html:54
@@ -2531,19 +2180,12 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:30
 #, python-format
-msgid ""
-"Please check that this is really <a href=\"%(url)s\">%(name)s</a> "
-"(%(party)s) before approving the upload. This <a "
-"href=\"%(google_image_search_url)s\">Google Image search for candidate "
-"details</a> may be a good start."
+msgid "Please check that this is really <a href=\"%(url)s\">%(name)s</a> (%(party)s) before approving the upload. This <a href=\"%(google_image_search_url)s\">Google Image search for candidate details</a> may be a good start."
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:36
 #, python-format
-msgid ""
-"If you're trying to find the likely <em>source</em> of this image, you can "
-"also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image "
-"search</a> on the uploaded image."
+msgid "If you're trying to find the likely <em>source</em> of this image, you can also do a <a href=\"%(google_reverse_image_search_url)s\">reverse image search</a> on the uploaded image."
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:41
@@ -2551,9 +2193,7 @@ msgid "Click and drag in the image to crop"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:43
-msgid ""
-"Please crop to just around the candidate's head, since they're displayed in "
-"thumbnail form on the site."
+msgid "Please crop to just around the candidate's head, since they're displayed in thumbnail form on the site."
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:68
@@ -2598,16 +2238,12 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:113
 #, python-format
-msgid ""
-"%(username)s said that this is the candidate's public profile photo from "
-"social media or their official campaign page"
+msgid "%(username)s said that this is the candidate's public profile photo from social media or their official campaign page"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:120
 #, python-format
-msgid ""
-"%(username)s's justification for use of this photo was: "
-"&#8220;%(justification)s&#8221;"
+msgid "%(username)s's justification for use of this photo was: &#8220;%(justification)s&#8221;"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:128
@@ -2627,9 +2263,7 @@ msgid "Why <em>you</em> think it's allowed:"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:151
-msgid ""
-"Reason for rejection (<strong>Warning:</strong> this will be emailed to the "
-"user):"
+msgid "Reason for rejection (<strong>Warning:</strong> this will be emailed to the user):"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-review.html:158
@@ -2660,10 +2294,7 @@ msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo-upload-success.html:15
 #, python-format
-msgid ""
-"Thank-you for uploading a photo - you will receive an email when it is "
-"approved to be added to the site, or an explanation for why it cannot be "
-"used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
+msgid "Thank-you for uploading a photo - you will receive an email when it is approved to be added to the site, or an explanation for why it cannot be used. <a href=\"%(url)s\">Return to %(name)s’s page.</a>"
 msgstr ""
 
 #: moderation_queue/templates/moderation_queue/photo_rejected_email.txt:12
@@ -2677,9 +2308,7 @@ msgstr ""
 
 #: moderation_queue/views.py:290
 #, python-brace-format
-msgid ""
-"Approved a photo upload from {uploading_user} who provided the message: "
-"\"{message}\""
+msgid "Approved a photo upload from {uploading_user} who provided the message: \"{message}\""
 msgstr ""
 
 #: moderation_queue/views.py:316
@@ -2732,9 +2361,7 @@ msgstr ""
 
 #: moderation_queue/views.py:407
 #, python-brace-format
-msgid ""
-"Ignored a photo upload from {uploading_user} (This usually means it was a "
-"duplicate)"
+msgid "Ignored a photo upload from {uploading_user} (This usually means it was a duplicate)"
 msgstr ""
 
 #: moderation_queue/views.py:420
@@ -2790,8 +2417,7 @@ msgstr ""
 
 #: mysite/templates/account/signup.html:13
 #, python-format
-msgid ""
-"Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
+msgid "Already have an account? Then please <a href=\"%(login_url)s\">sign in</a>."
 msgstr ""
 
 #: mysite/templates/generic_base.html:71
@@ -2829,9 +2455,7 @@ msgstr ""
 
 #: official_documents/templates/official_documents/_post.html:30
 #, python-format
-msgid ""
-"As you have permission to upload documents, you can <a "
-"href=\"%(url)s\">upload a %(type)s</a>."
+msgid "As you have permission to upload documents, you can <a href=\"%(url)s\">upload a %(type)s</a>."
 msgstr ""
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:16
@@ -2841,16 +2465,12 @@ msgstr ""
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:19
 #, python-format
-msgid ""
-"The source URL for this document was: <a "
-"href=\"%(source_url)s\">%(source_url)s</a>"
+msgid "The source URL for this document was: <a href=\"%(source_url)s\">%(source_url)s</a>"
 msgstr ""
 
 #: official_documents/templates/official_documents/officialdocument_detail.html:32
 #, python-format
-msgid ""
-"You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to "
-"delete it)"
+msgid "You can <a href=\"%(url)s\">edit this in the admin interface</a> (e.g. to delete it)"
 msgstr ""
 
 #: official_documents/templates/official_documents/upload_document_form.html:5
@@ -2877,9 +2497,7 @@ msgstr ""
 
 #: results/feeds.py:28
 #, python-brace-format
-msgid ""
-"A {site_name} volunteer recorded at {datetime} that {name} ({party}) won the"
-" ballot in {cons}, quoting the source '{source}')."
+msgid "A {site_name} volunteer recorded at {datetime} that {name} ({party}) won the ballot in {cons}, quoting the source '{source}')."
 msgstr ""
 
 #: results/feeds.py:84
@@ -2900,17 +2518,12 @@ msgstr[1] ""
 
 #: tasks/templates/tasks/field.html:14
 #, python-format
-msgid ""
-"Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
+msgid "Of %(num_candidates_2015)s candidates in total (%(percent_empty)s%% blank)"
 msgstr ""
 
 #: tasks/templates/tasks/field.html:21
 #, python-format
-msgid ""
-"Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make"
-" sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing "
-"fields.</a>"
+msgid "Please <a href=\"%(url)s\">help out</a> by adding missing information.  Make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields.</a>"
 msgstr ""
 
 #: tasks/templates/tasks/field.html:35
@@ -2919,9 +2532,7 @@ msgstr ""
 
 #: tasks/templates/tasks/field.html:38
 #, python-format
-msgid ""
-"Hi @%(username)s could you add your %(field)s to your %(site_name)s page "
-"please? https://yournextmp.com/person/%(id)s/"
+msgid "Hi @%(username)s could you add your %(field)s to your %(site_name)s page please? https://yournextmp.com/person/%(id)s/"
 msgstr ""
 
 #: tasks/templates/tasks/field.html:41
@@ -2951,15 +2562,11 @@ msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:12
 #, python-format
-msgid ""
-"%(site_name)s is a volunteer-sourced database, and that means we constantly "
-"need help in making it better."
+msgid "%(site_name)s is a volunteer-sourced database, and that means we constantly need help in making it better."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:17
-msgid ""
-"There is a lot of useful information on candidates out there, so if you find"
-" any please do add it to our site."
+msgid "There is a lot of useful information on candidates out there, so if you find any please do add it to our site."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:22
@@ -2967,15 +2574,11 @@ msgid "Emails"
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:24
-msgid ""
-"At the moment we're trying to get as many email addresses on candidates as "
-"we can."
+msgid "At the moment we're trying to get as many email addresses on candidates as we can."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:29
-msgid ""
-"This will allow us to email them directly to ask them to add their own "
-"details."
+msgid "This will allow us to email them directly to ask them to add their own details."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:34
@@ -2984,47 +2587,27 @@ msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:37
 #, python-format
-msgid ""
-"First off you'll need to <a href=\"%(url)s\">log in</a> in order to start "
-"making edits."
+msgid "First off you'll need to <a href=\"%(url)s\">log in</a> in order to start making edits."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:43
 #, python-format
-msgid ""
-"We've added clear banners on the candidate and constituently pages "
-"indicating where we're missing email addresses, so you can start adding "
-"email addresses by <a href=\"%(url)s\">looking up your constituency on the "
-"home page</a>"
+msgid "We've added clear banners on the candidate and constituently pages indicating where we're missing email addresses, so you can start adding email addresses by <a href=\"%(url)s\">looking up your constituency on the home page</a>"
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:50
-msgid ""
-"Once you've found a candidate without an email address, you can go searching"
-" for it!"
+msgid "Once you've found a candidate without an email address, you can go searching for it!"
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:55
-msgid ""
-"Please make sure you read our <a href=\"https://docs.google.com/document/d"
-"/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing "
-"fields</a>, and specifically the part about what sort of email addresses we "
-"accept."
+msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPX wXspA/edit\">guidance on sourcing fields</a>, and specifically the part about what sort of email addresses we accept."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:62
-msgid ""
-"In short, we only want email addresses could be considered public and "
-"related to the candidate's campaign. <code>@parliament.uk</code> email "
-"addresses will stop working once Parliament is disbanded, so try to find a "
-"different email address for them if you can. If not, we can always email "
-"everyone with a <code>@parliament.uk</code> address asking them for a better"
-" one."
+msgid "In short, we only want email addresses could be considered public and related to the candidate's campaign. <code>@parliament.uk</code> email addresses will stop working once Parliament is disbanded, so try to find a different email address for them if you can. If not, we can always email everyone with a <code>@parliament.uk</code> address asking them for a better one."
 msgstr ""
 
 #: tasks/templates/tasks/tasks_home.html:72
 #, python-format
-msgid ""
-"Once your constituency has all the email addresses entered, you can look at "
-"our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
+msgid "Once your constituency has all the email addresses entered, you can look at our <a href=\"%(url)s\">list of all candidates without emails listed</a>!"
 msgstr ""

--- a/moderation_queue/templates/moderation_queue/photo_approved_email.txt
+++ b/moderation_queue/templates/moderation_queue/photo_approved_email.txt
@@ -1,7 +1,5 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Thank-you for submitting a photo to {{ site_name }}; that's been
-uploaded now for the candidate page here:{% endblocktrans %}
+{% load i18n %}{% autoescape off %}{{ intro|wordwrap:64 }}
 
   {{ candidate_page_url }}
 
-{% blocktrans %}Many thanks,
-The {{ site_name }} volunteers{% endblocktrans %}{% endautoescape %}
+{{ signoff|wordwrap:64 }}{% endautoescape %}

--- a/moderation_queue/templates/moderation_queue/photo_rejected_email.txt
+++ b/moderation_queue/templates/moderation_queue/photo_rejected_email.txt
@@ -1,16 +1,12 @@
-{% load i18n %}{% autoescape off %}{% blocktrans %}Thank-you for uploading a photo of {{ candidate_name }}
-to {{ site_name }}, but unfortunately we can't use that image because:{% endblocktrans %}
+{% load i18n %}{% autoescape off %}{{ intro|wordwrap:64 }}
 
   {{ reason }}
 
-{% blocktrans %}You can just reply to this email if you want to discuss that
-further, or you can try uploading a photo with a different reason
-or justification for its use using this link:{% endblocktrans %}
+{{ possible_actions|wordwrap:64 }}
 
   {{ retry_upload_link }}
 
-{% blocktrans %}Many thanks,
-The {{ site_name }} volunteers{% endblocktrans %}
+{{ signoff|wordwrap:64 }}
 
 -- 
 {% blocktrans trimmed %}For administrators' use: {{ photo_review_url }}{% endblocktrans %}{% endautoescape %}

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -184,7 +184,7 @@ class PhotoReviewTests(WebTest):
 
             mock_send_mail.assert_called_once_with(
                 'YNR image upload approved',
-                u"Thank-you for submitting a photo to YNR; that's been\nuploaded now for the candidate page here:\n\n  http://localhost:80/person/2009/tessa-jowell\n\nMany thanks,\nThe YNR volunteers\n",
+                u"Thank-you for submitting a photo to YNR; that's been uploaded\nnow for the candidate page here:\n\n  http://localhost:80/person/2009/tessa-jowell\n\nMany thanks from the YNR volunteers\n",
                 'admins@example.com',
                 [u'john@example.com'],
                 fail_silently=False
@@ -271,7 +271,7 @@ class PhotoReviewTests(WebTest):
 
             mock_send_mail.assert_called_once_with(
                 'YNR image moderation results',
-                u"Thank-you for uploading a photo of Tessa Jowell\nto YNR, but unfortunately we can't use that image because:\n\n  There\'s no clear source or copyright statement\n\nYou can just reply to this email if you want to discuss that\nfurther, or you can try uploading a photo with a different reason\nor justification for its use using this link:\n\n  http://localhost:80/moderation/photo/upload/2009\n\nMany thanks,\nThe YNR volunteers\n\n-- \nFor administrators' use: http://localhost:80/moderation/photo/review/1\n",
+                u"Thank-you for uploading a photo of Tessa Jowell to YNR, but\nunfortunately we can't use that image because:\n\n  There\'s no clear source or copyright statement\n\nYou can just reply to this email if you want to discuss that\nfurther, or you can try uploading a photo with a different\nreason or justification for its use using this link:\n\n  http://localhost:80/moderation/photo/upload/2009\n\nMany thanks from the YNR volunteers\n\n-- \nFor administrators' use: http://localhost:80/moderation/photo/review/1\n",
                 'admins@example.com',
                 [u'john@example.com', 'support@example.com'],
                 fail_silently=False

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -262,6 +262,7 @@ class PhotoReview(GroupRequiredMixin, PopItApiMixin, TemplateView):
         photo_review_url = self.request.build_absolute_uri(
             self.queued_image.get_absolute_url()
         )
+        site_name = Site.objects.get_current().name
         def flash(level, message):
             messages.add_message(
                 self.request,
@@ -313,13 +314,21 @@ class PhotoReview(GroupRequiredMixin, PopItApiMixin, TemplateView):
             candidate_full_url = person.get_absolute_url(self.request)
             self.send_mail(
                 _('{site_name} image upload approved').format(
-                    site_name=Site.objects.get_current().name
+                    site_name=site_name
                 ),
                 render_to_string(
                     'moderation_queue/photo_approved_email.txt',
                     {
-                        'site_name': Site.objects.get_current().name,
-                        'candidate_page_url': candidate_full_url
+                        'site_name': site_name,
+                        'candidate_page_url': candidate_full_url,
+                        'intro': _(
+                            "Thank-you for submitting a photo to "
+                            "{site_name}; that's been uploaded now for "
+                            "the candidate page here:"
+                        ).format(site_name=site_name),
+                        'signoff': _(
+                            "Many thanks from the {site_name} volunteers"
+                        ).format(site_name=site_name),
                     }
                 ),
             )
@@ -355,11 +364,26 @@ class PhotoReview(GroupRequiredMixin, PopItApiMixin, TemplateView):
                 render_to_string(
                     'moderation_queue/photo_rejected_email.txt',
                     {
-                        'site_name': Site.objects.get_current().name,
                         'reason': form.cleaned_data['rejection_reason'],
-                        'candidate_name': candidate_name,
                         'retry_upload_link': retry_upload_link,
-                        'photo_review_url': photo_review_url
+                        'photo_review_url': photo_review_url,
+                        'intro': _(
+                            "Thank-you for uploading a photo of "
+                            "{candidate_name} to {site_name}, but "
+                            "unfortunately we can't use that image because:"
+                        ).format(
+                            candidate_name=candidate_name,
+                            site_name=site_name
+                        ),
+                        'possible_actions': _(
+                            'You can just reply to this email if you want to '
+                            'discuss that further, or you can try uploading a '
+                            'photo with a different reason or justification '
+                            'for its use using this link:'
+                        ),
+                        'signoff': _(
+                            "Many thanks from the {site_name} volunteers"
+                        ).format(site_name=site_name),
                     },
                 ),
                 email_support_too=True,

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -365,8 +365,10 @@ NOSE_ARGS = [
     '--ignore-files=faces',
 ]
 
-SOURCE_HINTS = _(u'''Please don't quote third-party candidate sites \u2014
-we prefer URLs of news stories or official candidate pages.''')
+SOURCE_HINTS = _(
+    u"Please don't quote third-party candidate sites \u2014 "
+    u"we prefer URLs of news stories or official candidate pages."
+)
 
 # By default, cache successful results from MapIt for a day
 MAPIT_CACHE_SECONDS = 86400

--- a/mysite/templates/account/login.html
+++ b/mysite/templates/account/login.html
@@ -12,7 +12,7 @@
 {% block content %}
 
 {% if socialaccount.providers  %}
-<p>{% blocktrans with site.name as site_name %}Please sign in with one
+<p>{% blocktrans trimmed with site.name as site_name %}Please sign in with one
 of your existing third party accounts. Or, <a href="{{ signup_url }}">sign up</a>
 for a {{site_name}} account and sign in below:{% endblocktrans %}</p>
 
@@ -29,7 +29,7 @@ for a {{site_name}} account and sign in below:{% endblocktrans %}</p>
 {% include "socialaccount/snippets/login_extra.html" %}
 
 {% else %}
-<p>{% blocktrans %}If you have not created an account yet, then please
+<p>{% blocktrans trimmed %}If you have not created an account yet, then please
 <a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
 {% endif %}
 

--- a/mysite/templates/generic_base.html
+++ b/mysite/templates/generic_base.html
@@ -34,7 +34,7 @@
 
     <title>
       {% block title %}
-        {% blocktrans with site_name=site.name %}
+        {% blocktrans trimmed with site_name=site.name %}
            {{ site_name }}
         {% endblocktrans %}
       {% endblock %}

--- a/mysite/templates/generic_base.html
+++ b/mysite/templates/generic_base.html
@@ -33,11 +33,7 @@
     {% endblock %}
 
     <title>
-      {% block title %}
-        {% blocktrans trimmed with site_name=site.name %}
-           {{ site_name }}
-        {% endblocktrans %}
-      {% endblock %}
+      {% block title %}{{ site.name }}{% endblock %}
     </title>
 
     {% block analytics %}


### PR DESCRIPTION
@evz pointed out that running `./manage.py makemessages` generates lots
lots of spurious changes because it was wrapping lines in the .po files; this
makes it really annoying for contributors to update translations when they
add a new string for localization. This pull request should fix that issue by
standardizing on not word-wrapping either the `msgid` or `msgstr`.