### PR TITLE
Upcoming elections api

### DIFF
--- a/candidates/election_specific.py
+++ b/candidates/election_specific.py
@@ -1,4 +1,12 @@
 from django.conf import settings
+from candidates.mapit import get_areas_from_coords
+
+
+def default_fetch_area_ids(**kwargs):
+    if kwargs['coords']:
+        areas = get_areas_from_coords(kwargs['coords'])
+
+    return areas
 
 # This is actually taken from Pombola's country-specific code package
 # in pombola/country/__init__.py. You should add to this list anything
@@ -9,6 +17,7 @@ imports_and_defaults = (
     ('EXTRA_CSV_ROW_FIELDS', []),
     ('shorten_post_label', lambda post_label: post_label),
     ('get_extra_csv_values', lambda person, election: {}),
+    ('fetch_area_ids', default_fetch_area_ids),
 )
 
 # Note that one could do this without the dynamic import and use of

--- a/candidates/mapit.py
+++ b/candidates/mapit.py
@@ -1,8 +1,111 @@
+# coding=utf-8
+
+import re
+import requests
+
+from django.utils.http import urlquote
+from django.core.cache import cache
+from django.utils.translation import ugettext as _
+
+from elections.models import AreaType
+
+
 class BaseMapItException(Exception):
     pass
+
 
 class BadPostcodeException(BaseMapItException):
     pass
 
+
+class BadCoordinatesException(BaseMapItException):
+    pass
+
+
 class UnknownMapitException(BaseMapItException):
     pass
+
+
+def fetch_area_ids(**kwargs):
+    if kwargs['postcode']:
+        areas = get_areas_from_postcode(kwargs['postcode'])
+
+    if kwargs['coords']:
+        areas = get_areas_from_coords(kwargs['coords'])
+
+    return areas
+
+
+def get_known_area_types(mapit_result):
+        known_area_types = set(AreaType.objects.values_list('name', flat=True))
+        return [
+            (a['type'], str(a['id']))
+            for a in mapit_result['areas'].values()
+            if a['type'] in known_area_types
+        ]
+
+
+def get_areas_from_postcode(original_postcode):
+    postcode = re.sub(r'(?ms)\s*', '', original_postcode.lower())
+    if re.search(r'[^a-z0-9]', postcode):
+        raise BadPostcodeException(
+            _(u'There were disallowed characters in "{0}"').format(
+                original_postcode
+            )
+        )
+    cached_result = cache.get(postcode)
+    if cached_result:
+        return cached_result
+    url = 'http://mapit.mysociety.org/postcode/' + urlquote(postcode)
+    r = requests.get(url)
+    if r.status_code == 200:
+        mapit_result = r.json()
+        areas = get_known_area_types(mapit_result)
+        cache.set(url, areas, 60 * 60 * 24)
+        return areas
+    elif r.status_code == 400:
+        mapit_result = r.json()
+        raise BadPostcodeException(mapit_result['error'])
+    elif r.status_code == 404:
+        raise BadPostcodeException(
+            _(u'The postcode “{0}” couldn’t be found').format(
+                original_postcode
+            )
+        )
+    else:
+        raise UnknownMapitException(
+            _(u'Unknown MapIt error for postcode "{0}"').format(
+                original_postcode
+            )
+        )
+
+
+def get_areas_from_coords(coords):
+    base_url = 'http://mapit.mysociety.org/'
+    url = base_url + 'point/4326/' + urlquote(coords)
+
+    cached_result = cache.get(url)
+    if cached_result:
+        return cached_result
+
+    r = requests.get(url)
+    if r.status_code == 200:
+        mapit_result = r.json()
+        areas = get_known_area_types(mapit_result)
+        cache.set(url, areas, 60 * 60 * 24)
+        return areas
+    elif r.status_code == 400:
+        mapit_result = r.json()
+        raise BadCoordinatesException(mapit_result['error'])
+    elif r.status_code == 404:
+        raise BadCoordinatesException(
+            u'The coordinates "{0}" could not be found'.format(
+                coords
+            )
+        )
+    else:
+        raise UnknownMapitException(
+            u'Unknown MapIt error for coordinates "{0}"'.format(
+                coords
+            )
+        )

--- a/candidates/tests/test_upcoming_elections_api.py
+++ b/candidates/tests/test_upcoming_elections_api.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+
+from mock import patch, Mock
+
+from datetime import date, timedelta
+
+from nose.plugins.attrib import attr
+from django_webtest import WebTest
+
+from candidates.tests.factories import (
+    AreaTypeFactory, ElectionFactory, PostExtraFactory,
+    ParliamentaryChamberFactory, ParliamentaryChamberExtraFactory,
+    PartySetFactory, AreaExtraFactory
+)
+from elections.models import Election
+from elections.uk_general_election_2015.tests.mapit_postcode_results \
+    import se240ag_result, sw1a1aa_result
+
+
+def fake_requests_for_mapit(url):
+    """Return reduced MapIt output for some known URLs"""
+    if url == 'http://mapit.mysociety.org/postcode/sw1a1aa':
+        status_code = 200
+        json_result = sw1a1aa_result
+    elif url == 'http://mapit.mysociety.org/postcode/se240ag':
+        status_code = 200
+        json_result = se240ag_result
+    elif url == 'http://mapit.mysociety.org/postcode/cb28rq':
+        status_code = 404
+        json_result = {
+            "code": 404,
+            "error": "No Postcode matches the given query."
+        }
+    elif url == 'http://mapit.mysociety.org/postcode/foobar':
+        status_code = 400
+        json_result = {
+            "code": 400,
+            "error": "Postcode 'FOOBAR' is not valid."
+        }
+    else:
+        raise Exception("URL that hasn't been mocked yet: " + url)
+    return Mock(**{
+        'json.return_value': json_result,
+        'status_code': status_code
+    })
+
+@attr(country='uk')
+@patch('elections.uk_general_election_2015.mapit.requests')
+class TestUpcomingElectionsAPI(WebTest):
+    def setUp(self):
+        election = Election.objects.get(slug='2015')
+        wmc_area_type = election.area_types.get(name='WMC')
+        gb_parties = PartySetFactory.create(slug='gb', name='Great Britain')
+        commons = ParliamentaryChamberFactory.create()
+        area_extra = AreaExtraFactory.create(
+            base__name="Dulwich and West Norwood",
+            type=wmc_area_type,
+        )
+        self.area = area_extra.base
+        PostExtraFactory.create(
+            elections=(election,),
+            base__organization=commons,
+            slug='65808',
+            base__label='Member of Parliament for Dulwich and West Norwood',
+            party_set=gb_parties,
+            base__area=area_extra.base,
+        )
+
+    def test_empty_results(self, mock_requests):
+        mock_requests.get.side_effect = fake_requests_for_mapit
+        response = self.app.get('/upcoming-elections/?postcode=SW1A+1AA')
+
+        output = response.json
+        self.assertEquals(output, [])
+
+    def test_results_for_past_elections(self, mock_requests):
+        mock_requests.get.side_effect = fake_requests_for_mapit
+        response = self.app.get('/upcoming-elections/?postcode=SE24+0AG')
+
+        output = response.json
+        self.assertEquals(output, [])
+
+    def test_results_for_upcoming_elections(self, mock_requests):
+        one_day = timedelta(days=1)
+        future_date = date.today() + one_day
+        london_assembly = ParliamentaryChamberExtraFactory.create(
+            slug='london-assembly', base__name='London Assembly'
+        )
+        lac_area_type = AreaTypeFactory.create(name='LAC')
+        gla_area_type = AreaTypeFactory.create(name='GLA')
+        area_extra_lac = AreaExtraFactory.create(
+            base__identifier='11822',
+            base__name="Dulwich and West Norwood",
+            type=lac_area_type,
+        )
+        area_extra_gla = AreaExtraFactory.create(
+            base__identifier='2247',
+            base__name='Greater London Authority',
+            type=gla_area_type,
+        )
+        election_lac = ElectionFactory.create(
+            slug='gb-gla-2016-05-05-c',
+            organization=london_assembly.base,
+            name='2016 London Assembly Election (Constituencies)',
+            election_date=future_date.isoformat(),
+            area_types=(lac_area_type,),
+        )
+        election_gla = ElectionFactory.create(
+            slug='gb-gla-2016-05-05-a',
+            organization=london_assembly.base,
+            name='2016 London Assembly Election (Additional)',
+            election_date=future_date.isoformat(),
+            area_types=(gla_area_type,),
+        )
+        PostExtraFactory.create(
+            elections=(election_lac,),
+            base__area=area_extra_lac.base,
+            base__organization=london_assembly.base,
+            slug='11822',
+            base__label='Assembly Member for Lambeth and Southwark',
+        )
+        PostExtraFactory.create(
+            elections=(election_gla,),
+            base__area=area_extra_gla.base,
+            base__organization=london_assembly.base,
+            slug='2247',
+            base__label='Assembly Member',
+        )
+
+        mock_requests.get.side_effect = fake_requests_for_mapit
+        response = self.app.get('/upcoming-elections/?postcode=SE24+0AG')
+
+        output = response.json
+        self.assertEquals(len(output), 2)
+
+        self.maxDiff = None
+        expected = [
+            {
+                u'organization': u'London Assembly',
+                u'election_date': unicode(future_date.isoformat()),
+                u'election_name': u'2016 London Assembly Election (Constituencies)',
+                u'post_name': u'Assembly Member for Lambeth and Southwark',
+                u'area': {
+                    u'identifier': u'11822',
+                    u'type': u'LAC',
+                    u'name': u'Dulwich and West Norwood'
+                }
+            },
+            {
+                u'organization': u'London Assembly',
+                u'election_date': unicode(future_date.isoformat()),
+                u'election_name': u'2016 London Assembly Election (Additional)',
+                u'post_name': u'Assembly Member',
+                u'area': {
+                    u'identifier': u'2247',
+                    u'type': u'GLA',
+                    u'name': u'Greater London Authority'
+                }
+            },
+        ]
+
+        self.assertEquals(expected, output)

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -197,6 +197,11 @@ patterns_to_format = [
         'pattern': r'^version.json',
         'view': views.VersionView.as_view(),
         'name': 'version'
+    },
+    {
+        'pattern': r'^upcoming-elections',
+        'view': views.UpcomingElectionsView.as_view(),
+        'name': 'upcoming-elections'
     }
 ]
 

--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -17,7 +17,7 @@ from elections.models import AreaType, Election
 from popolo.models import Area, Membership, Person, Post
 from rest_framework import viewsets
 
-from candidates.mapit import fetch_area_ids
+from ..election_specific import fetch_area_ids
 
 
 class UpcomingElectionsView(View):
@@ -28,6 +28,7 @@ class UpcomingElectionsView(View):
         postcode = request.GET.get('postcode', None)
         coords = request.GET.get('coords', None)
 
+        # TODO: postcode may not make sense everywhere
         errors = None
         if not postcode and not coords:
             errors = {

--- a/elections/uk_general_election_2015/lib.py
+++ b/elections/uk_general_election_2015/lib.py
@@ -3,6 +3,9 @@ import re
 from popolo.models import Identifier
 
 from candidates.models import MembershipExtra
+from candidates.mapit import get_areas_from_coords
+
+from .mapit import get_areas_from_postcode
 
 
 def shorten_post_label(post_label):
@@ -54,3 +57,13 @@ def get_extra_csv_values(person, election):
         'theyworkforyou_url': theyworkforyou_url,
         'party_ec_id': party_ec_id
     }
+
+
+def fetch_area_ids(**kwargs):
+    if kwargs['postcode']:
+        areas = get_areas_from_postcode(kwargs['postcode'])
+
+    if kwargs['coords']:
+        areas = get_areas_from_coords(kwargs['coords'])
+
+    return areas


### PR DESCRIPTION
Add an API to list some basic information for the upcoming elections at a postcode or co-ordinate.

The API lists all the positions for which there will be an election in the future, along with details of the area the post is for and the election it is part of. It uses the election_date property of the election to determine which elections to display.

If an election does not have an election_date then it won't be displayed.

Fixes #581