### PR TITLE
Import list of Costa Rica parties from CSV file

### DIFF
--- a/elections/cr/data/parties.csv
+++ b/elections/cr/data/parties.csv
@@ -1,0 +1,57 @@
+Accesibilidad Sin Exclusión (PASE),3-110-420985,"Escazú, Desamparados, Goicoechea, Santa Ana, Curridabat, Pérez Zeledón, Alajuela, Grecia, Palmares, Cartago, Paraíso, La Unión, Jiménez, Heredia, Liberia, Puntarenas, Esparza, Quepos, Pococí, Siquirres, Matina (21/81)"
+Acción Ciudadana (PAC),3-110-301964 ,"San José, Escazú, Puriscal, Tarrazú, Aserrí, Mora, Goicoechea, Santa Ana, Alajuelita, Vásquez de Coronado, Acosta, Moravia, Dota, Curridabat, Pérez Zeledón, León Cortés Castro, Alajuela, San Ramón, Grecia, San Mateo, Atenas, Naranjo, Palmares, Poás, Orotina, San Carlos, Valverde Vega, Upala, Los Chiles, Cartago, Paraíso, La Unión, Jiménez, Turrialba, Alvarado, Oreamuno, El Guarco, Heredia, Barva, Santo Domingo, Santa Bárbara, San Rafael, San Isidro, Flores, San Pablo, Sarapiquí, Liberia, Nicoya, Santa Cruz, Bagaces, Carrillo, Cañas, Abangares, Tilarán, Nandayure, La Cruz, Hojancha, Puntarenas, Esparza, Buenos Aires, Montes de Oro, Osa, Quepos, Golfito, Coto Brus, Parrita, Corredores, Garabito, Pococí, Siquirres, Talamanca, Matina, Guácimo (73/81)"
+Frente Amplio (FA),3-110-410964,"San José, Escazú, Desamparados, Puriscal, Tarrazú, Aserrí, Mora, Goicoechea, Alajuelita, Vásquez de Coronado, Moravia, Dota, Curridabat, Pérez Zeledón, Alajuela, San Ramón, Grecia, San Mateo, Atenas, Naranjo, Palmares, Poás, San Carlos, Upala, Los Chiles, Cartago, Paraíso, La Unión, Jiménez, Turrialba, Oreamuno, El Guarco, Heredia, Barva, Santa Bárbara, San Rafael, San Isidro, Flores, San Pablo, Sarapiquí, Liberia, Nicoya, Santa Cruz, Cañas, Abangares, Nandayure, Puntarenas, Esparza, Buenos Aires, Montes de Oro, Osa, Golfito, Corredores, Limón, Pococí, Siquirres, Talamanca, Matina, Guácimo (59/81)"
+Integración Nacional (PIN),3-110-212993,"San José, Tibás, Naranjo, Santa Cruz, Abangares, Puntarenas, Osa, Quepos (8/81)"
+Liberación Nacional (PLN),3-110-051854,"San José, Escazú, Desamparados, Puriscal, Tarrazú, Aserrí, Mora, Goicoechea, Santa Ana, Alajuelita, Vásquez de Coronado, Acosta, Tibás, Moravia, Montes de Oca, Turrubares, Dota, Curridabat, Pérez Zeledón, León Cortés Castro, Alajuela, San Ramón, Grecia, San Mateo, Atenas, Naranjo, Palmares, Poás, Orotina, San Carlos, Zarcero, Valverde Vega, Upala, Los Chiles, Guatuso, Cartago, Paraíso, La Unión, Jiménez, Turrialba, Alvarado, Oreamuno, El Guarco, Heredia, Barva, Santo Domingo, Santa Bárbara, San Rafael, San Isidro, Belén, Flores, San Pablo, Sarapiquí, Liberia, Nicoya, Santa Cruz, Bagaces, Carrillo, Cañas, Abangares, Tilarán, Nandayure, La Cruz, Hojancha, Puntarenas, Esparza, Buenos Aires, Montes de Oro, Osa, Quepos, Golfito, Coto Brus, Parrita, Corredores, Garabito, Limón, Pococí, Siquirres, Talamanca, Matina, Guácimo (81/81)"
+Movimiento Libertario (ML),3-110-200226,"San José, Escazú, Desamparados, Puriscal, Tarrazú, Aserrí, Mora, Goicoechea, Santa Ana, Alajuelita, Vásquez de Coronado, Tibás, Moravia, Montes de Oca, Turrubares, Dota, Curridabat, Pérez Zeledón, León Cortés Castro, Alajuela, San Ramón, Grecia, San Mateo, Atenas, Naranjo, Palmares, Zarcero, Upala, Los Chiles, Guatuso, Cartago, Paraíso, La Unión, Oreamuno, El Guarco, Heredia, Barva, Santo Domingo, Santa Bárbara, San Rafael, San Isidro, Belén, San Pablo, Sarapiquí, Liberia, Santa Cruz, Bagaces, Carrillo, Abangares, Tilarán, Puntarenas, Esparza, Buenos Aires, Montes de Oro, Osa, Quepos, Golfito, Coto Brus, Parrita, Corredores, Garabito, Limón, Pococí, Siquirres, Talamanca, Matina, Guácimo (67/81)"
+Nueva Generación (PNG),3-110-671418 ,"San José, Desamparados, Puriscal, Aserrí, Mora, Goicoechea, Santa Ana, Alajuelita, Tibás, Moravia, Montes de Oca, Turrubares, Dota, Curridabat, Pérez Zeledón, Alajuela, San Ramón, Palmares, Poás, Orotina, San Carlos, Valverde Vega, Guatuso, Cartago, Paraíso, La Unión, Turrialba, Alvarado, Heredia, Santo Domingo, Santa Bárbara, San Isidro, San Pablo, Sarapiquí, Liberia, Nicoya, Santa Cruz, Bagaces, Tilarán, Nandayure, Puntarenas, Buenos Aires, Quepos, Pococí, Siquirres (45/81)"
+Partido de los Trabajadores (PT), 3-110-071063,"San José, Curridabat, Alajuela, Naranjo, Los Chiles, Puntarenas, Limón, Pococí (8/81)"
+Renovación Costarricense (PRC), 3-110-190890,"Escazú, Desamparados, Santa Ana, Alajuelita, Tibás, Moravia, Curridabat, Alajuela, San Ramón, Grecia, Naranjo, Palmares, Poás, Orotina, San Carlos, Los Chiles, Paraíso, Heredia, Barva, Liberia,  Sarapiquí, Osa, Quepos, Golfito, Parrita, Corredores, Garabito, Limon, Pococí, Siquirres, Talamanca, Matina, Guácimo (33/81) "
+Republicano Social Cristiano (PRSC),,"San José, Escazú, Desamparados, Tarrazú, Goicoechea, Santa Ana, Alajuelita, Vásquez de Coronado, Tibás, Turrubares, Curridabat, Pérez Zeledón, Alajuela, San Ramón, Grecia, San Mateo, Atenas, Naranjo, Palmares, Poás, Orotina, San Carlos, Zarcero, Upala, Los Chiles, Guatuso, Cartago, Paraíso,  La Unión, Turrialba, Alvarado, Oreamuno, El Guarco, Heredia, Barva, Santo Domingo, Santa Bárbara, San Rafael, San Isidro, Belén, Flores, San Pablo, Sarapiquí, Liberia, Nicoya, Santa Cruz, Bagaces, Carrillo, Abangares, Tilarán, Nandayure, Hojancha, Puntarenas, Esparza, Buenos Aires, Quepos, Coto Brus, Parrita, Corredores, Garabito, Limon, Pococí, Siquirres, Talamanca, Matina, Guácimo (66/81)"
+Restauración Nacional (PREN),3-110-419368 ,"Desamparados, Goicoechea, Moravia, Montes de Oca, Curridabat, Pérez Zeledón, Alajuela, San Ramón, Poás, Orotina, Cartago, Alvarado, Heredia, Barva, Flores, San Pablo, Sarapiquí, Golfito (18/81)"
+Unidad Social Cristiana (PUSC), 3-110-098296,"San José, Escazú, Desamparados, Puriscal, Tarrazú, Aserrí, Mora, Goicoechea, Santa Ana, Alajuelita, Vásquez de Coronado, Acosta, Tibás, Moravia, Montes de Oca, Turrubares, Dota, Curridabat, Pérez Zeledón, Alajuela, San Ramón, Grecia, San Mateo, Atenas, Naranjo, Palmares, Poás, Orotina, San Carlos, Zarcero, Valverde Vega, Los Chiles, Guatuso, Cartago, Paraíso, La Unión, Jiménez, Turrialba, Oreamuno, El Guarco, Heredia, Barva, Santo Domingo, Santa Bárbara, San Rafael, San Isidro, Belén, Flores, San Pablo, Sarapiquí, Liberia, Nicoya, Santa Cruz, Bagaces, Carrillo, Cañas, Abangares, Tilarán, La Cruz, Hojancha, Puntarenas, Esparza, Buenos Aires, Montes de Oro, Osa, Quepos, Golfito, Coto Brus, Parrita, Corredores, Garabito, Limon, Pococí, Siquirres, Talamanca, Matina, Guácimo (78/81)"
+Alianza Demócrata Cristiana (Cartago),,"Cartago, Paraíso, La Unión, Jiménez, Turrialba, Alvarado, Oreamuno, El Guarco (8/81)"
+Recuperando Valores (Limón),,"Limon, Siquirres, Guácimo (3/81)"
+Verde (Cartago), 3-110-421552,"Cartago, Paraíso, La Unión (3/81)"
+Viva Puntarenas (Puntarenas),3-110-674493,"Puntarenas, Buenos Aires, Osa, Quepos, Golfito, Coto Brus (6/81)"
+Acción Cantonal Siquirres Independiente,3-110-359256,Siquirres (1/81)
+Acuerdo de Alianza de Quepos ,,Quepos (1/81)
+Alianza Cristiana Santaneña ,,Santa Ana (1/81)
+Alianza por Palmares ,,Palmares (1/81)
+Alianza por San José ,3-110-442583,San José (1/81)
+Alianza Sancarleña ,,San Carlos (1/81)
+Alianza Social por La Unión ,,La Unión (1/81)
+Auténtico Labrador de Coronado ,,Vasquez de Coronado (1/81)
+Auténtico Limonense ,,Limón (1/81)
+Auténtico Siquirreño,,Siquirres (1/81)
+Autónomo Oromontano,3-110-580805,Montes de Oro (1/81)
+Avance Montes de Oca ,3-110-668203,Montes de Oca (1/81)
+Barva Unida ,,Barva (1/81)
+Cívico de Tibás Fuenteovejuna ,3-110-606664,Tibás (1/81)
+Curridabat Siglo XXI ,3-110-426881,Curridabat (1/81)
+Del Sol ,3-110-603639,Santa Ana (1/81)
+Demócrata ,,Vasquez de Coronado (1/81)
+Desamparados Unido ,,Desamparados (1/81)
+Ecólogico Comunal Costarricense ,,Desamparados (1/81)
+Fuerza Democrática Desamparadeña ,,Desamparados (1/81)
+Fuerzas Unidas para el Cambio ,,San José (1/81)
+Garabito Ecológico ,,Garabito (1/81)
+Independiente Belemita,3-110-605963,Belén (1/81)
+Independiente Escazuceño,,Escazú (1/81)
+Justicia Generaleña ,,Pérez Zeledón (1/81)
+Liga Ramonense ,,San Ramón (1/81)
+Limón Independiente ,,Limón (1/81)
+Movimiento Avance Santo Domingo,3-110-604535,Santo Domingo (1/81)
+Nueva Mayoría Griega ,,Grecia (1/81)
+Parrita Independiente ,,Parrita (1/81)
+Progreso Comunal Desampareño ,,Desamparados (1/81)
+Pueblo Garabito ,,Garabito (1/81)
+Puriscaleños de Corazón ,,Puriscal (1/81)
+Renovación Cartago,,Cartago (1/81)
+Renovemos Alajuela,3-110-576965,Alajuela (1/81)
+Rescate Cantonal La Unión,,La Unión (1/81)
+Restauración Parriteña ,,Parrita (1/81)
+Solidaridad ,,San José (1/81)
+Todo por Flores,3-110-609027,Flores (1/81)
+Unión Guarqueño,,El Guarco (1/81)
+Yunta Progresista Escazuceña ,3-110-207588,Escazú (1/81)

--- a/elections/cr/management/commands/cr_import_parties_from_csv.py
+++ b/elections/cr/management/commands/cr_import_parties_from_csv.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+
+import csv
+import re
+import requests
+
+from django.core.management.base import BaseCommand
+
+from django.utils.text import slugify
+
+from candidates.models import PartySet, OrganizationExtra
+from popolo import models as popolo_models
+from popolo.importers.popit import PopItImporter
+
+
+def fix_whitespace(s):
+    s = s.strip()
+    return re.sub(r'(?ms)\s+', ' ', s)
+
+
+"""
+Takes an argument of a CSV file which should have 3 columns:
+
+    1: Name of party
+    2: ID of party (optional)
+    3: Comma separated list of Cantons the party is standing in
+
+The ID is the "Cédula Jurídica" and is added as an Identifier and
+used as the slug, otherwise we fall back to the slugified name.
+
+It expects the CSV file to have NO header row.
+
+It will create, or update, a party for each row in the CSV and
+a party set for each Canton, adding the party to the party sets
+for the Cantons in which the party is standing.
+"""
+
+
+class Command(BaseCommand):
+    help = 'Create or update parties from a CSV file'
+
+    def add_arguments(self, parser):
+        parser.add_argument('CSV-FILENAME')
+
+    def add_id(self, party, party_id):
+        party.identifiers.update_or_create(
+            scheme='cedula-juridica',
+            defaults={'identifier': party_id}
+        )
+
+    def generate_party_sets(self):
+        mapit_url = 'http://international.mapit.mysociety.org/areas/CRCANTON'
+
+        cantons = requests.get(mapit_url).json()
+
+        for canton_id, canton_data in cantons.items():
+            name = canton_data['name']
+            self.get_party_set(name)
+
+    def update_party(self, party_data):
+        # strip any bracketed information from the end of the name
+        # as it's information about party initials or canton
+        name = re.search(
+            r'^([^(]*)\(?',
+            fix_whitespace(party_data[0])
+        ).group(1).decode('utf-8')
+        party_id = fix_whitespace(party_data[1])
+
+        # remove the (13/81) information text from the end of
+        # the canton list.
+        canton_list = re.search(
+            r'^([^(]*)\(?',
+            fix_whitespace(party_data[2])
+        ).group(1)
+        cantons = canton_list.split(',')
+
+        # if posible we should use the official id but failing that fall
+        # back to a slugified name
+        if party_id != '':
+            slug = party_id
+        else:
+            slug = slugify(name)
+
+        try:
+            # slug should be consistent and not have any
+            # encoding issues
+            org_extra = OrganizationExtra.objects.get(
+                slug=slug
+            )
+            org = org_extra.base
+            print u"found existing party {0}".format(name)
+        except OrganizationExtra.DoesNotExist:
+            org = popolo_models.Organization.objects.create(
+                name=name,
+                classification='party'
+            )
+
+            OrganizationExtra.objects.create(
+                base=org, slug=slug
+            )
+            print u"created new party {0}".format(name)
+
+        if party_id != '':
+            self.add_id(org, party_id)
+
+        for canton in cantons:
+            canton = canton.decode('utf-8')
+            party_set = self.get_party_set(canton)
+            if not org.party_sets.filter(slug=party_set.slug):
+                print "adding party set {0}".format(party_set.slug)
+                org.party_sets.add(party_set)
+
+    def get_party_set(self, canton_name):
+        canton = fix_whitespace(canton_name)
+        party_set_slug = "2016_canton_{0}".format(slugify(canton))
+        party_set_name = u"2016 parties in {0} Canton".format(canton)
+        try:
+            return PartySet.objects.get(slug=party_set_slug)
+        except PartySet.DoesNotExist:
+            self.stdout.write("Couldn't find the party set '{0}'".format(
+                party_set_slug
+            ))
+            return PartySet.objects.create(
+                slug=party_set_slug, name=party_set_name
+            )
+
+    def handle(self, **options):
+        self.importer = PopItImporter()
+
+        self.generate_party_sets()
+
+        with open(options['CSV-FILENAME']) as f:
+            csv_reader = csv.reader(f)
+            for party_data in csv_reader:
+                self.update_party(party_data)


### PR DESCRIPTION
Management command and accompanying CSV file for importing a list of parties and generating the related party sets for the 2016 Costa Rica municipal elections.

Takes an argument of a CSV file which should have 3 columns:

    1: Name of party
    2: ID of party (optional)
    3: Comma separated list of Cantons the party is standing in

The ID is the "Cédula Jurídica" and is added as an Identifier.

It expects the CSV file to have NO header row.

It will create, or update, a party for each row in the CSV and a party set for each Canton, adding the party to the party sets for the Cantons in which the party is standing.

This generates slugs by slugifying the party name as we don't have the above IDs for all parties.

If you run

```
/manage.py candidates_create_party_list_from_ep https://cdn.rawgit.com/everypolitician/everypolitician-data/9d6723d/data/Costa_Rica/Assembly/ep-popolo-v1.0.json
```

first then it should match up the imported parties with those pulled from EP.

Fixes #611 