### PR TITLE
Fix a divide-by-zero error in /tasks/{whatever}

### DIFF
--- a/tasks/templates/tasks/field.html
+++ b/tasks/templates/tasks/field.html
@@ -11,8 +11,8 @@
 {{ pretty_count }} candidates missing {{ field }} field</h2>
 {% endblocktrans %}
 
-<h3>{% blocktrans trimmed with num_candidates_2015=candidates_2015|intcomma percent_empty=percent_empty|floatformat %}
-Of {{ num_candidates_2015 }} candidates in total ({{ percent_empty }}% blank)
+<h3>{% blocktrans trimmed with num_candidates=candidates_count|intcomma percent_empty=percent_empty|floatformat %}
+Of {{ num_candidates }} candidates in total ({{ percent_empty }}% blank)
 {% endblocktrans %}</h3>
 
 {% block advise %}

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -60,7 +60,7 @@ class TestFieldView(TestCase):
 
         response = self.client.get(url)
         self.assertEqual(response.context['field'], 'email')
-        self.assertEqual(response.context['candidates_2015'], 2)
+        self.assertEqual(response.context['candidates_count'], 2)
         self.assertEqual(response.context['results_count'], 1)
 
         self.assertContains(response, 'Tessa Jowell')

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -23,7 +23,7 @@ class IncompleteFieldView(TemplateView):
             .select_related('person', 'post', 'person__extra', 'post__extra', 'on_behalf_of') \
             .filter(
                 role='Candidate',
-                extra__election__slug='2015',
+                extra__election__current=True,
             )
 
         filtered_results = self.get_results(all_results)
@@ -59,10 +59,10 @@ class IncompleteFieldView(TemplateView):
         context['results'] = result_context
         context['results_count'] = filtered_results.count()
 
-        context['candidates_2015'] = all_results.count()
+        context['candidates_count'] = all_results.count()
         context['percent_empty'] = \
             (100 * context['results_count'] \
-            / float(context['candidates_2015']))
+            / float(context['candidates_count']))
 
         return context
 

--- a/tasks/views.py
+++ b/tasks/views.py
@@ -59,10 +59,13 @@ class IncompleteFieldView(TemplateView):
         context['results'] = result_context
         context['results_count'] = filtered_results.count()
 
-        context['candidates_count'] = all_results.count()
-        context['percent_empty'] = \
-            (100 * context['results_count'] \
-            / float(context['candidates_count']))
+        candidates_count = all_results.count()
+        if candidates_count == 0:
+            context['percent_empty'] = 0
+        else:
+            context['percent_empty'] = \
+                (100 * context['results_count'] / float(candidates_count))
+        context['candidates_count'] = candidates_count
 
         return context
 


### PR DESCRIPTION
If there were no candidates (e.g. when the site's first launched)
there would be a divide-by-zero on viewing, say /tasks/email

Thanks to Accesa for reporting this bug.
