### PR TITLE
Fix non-internationalizable ordinal suffix for day of the month

### DIFF
--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -175,7 +175,7 @@
             <small class="dob">({% blocktrans %}Year of birth: {{ dob }}{% endblocktrans %})</small>
         {% else %}
           <dd>{{ person.extra.age }}
-            <small class="dob">({% blocktrans with dob=person.extra.dob_as_date|date:"jS F Y" %}Date of birth: {{ dob }}{% endblocktrans %})</small>
+            <small class="dob">({% blocktrans with dob=person.extra.dob_as_date|date:settings.DATE_FORMAT %}Date of birth: {{ dob }}{% endblocktrans %})</small>
         {% endif %}
       {% else %}
         <dd>{% trans "Unknown" %}

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -23,6 +23,12 @@ ELECTION_APP: 'example'
 LANGUAGE_CODE: 'en-gb'
 TIME_ZONE: 'Europe/London'
 
+# This is the date format to use for formatting a candidate's date of
+# birth. It should be constructed using the format specifiers listed here:
+# https://docs.djangoproject.com/es/1.9/ref/templates/builtins/#date
+# If not specified the default is: 'j F Y'.
+DATE_FORMAT: 'j F Y'
+
 # The path to the gems directory:
 GEMS_DIRECTORY: ''
 

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -23,6 +23,7 @@ SETTINGS_TO_ADD = (
     'SITE_OWNER',
     'COPYRIGHT_HOLDER',
     'RUNNING_TESTS',
+    'DATE_FORMAT',
 )
 
 

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -251,6 +251,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'USE_I18N': True,
         'USE_L10N': True,
         'USE_TZ': True,
+        'DATE_FORMAT': conf.get('DATE_FORMAT', 'j F Y'),
 
         # The media and static file settings:
         'MEDIA_ROOT': media_root,


### PR DESCRIPTION
The 'S' format specifier for dates is:

  "English ordinal suffix for day of the month, 2 characters."

https://docs.djangoproject.com/es/1.9/ref/templates/builtins/#date

It doesn't make sense having the "th" suffix on a date in Spanish,
for example.

Fixes #631