### PR TITLE
Make date-of-birth parsing more liberal

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -12,9 +12,8 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from candidates.models import PartySet
+from candidates.models import PartySet, parse_approximate_date
 from popolo.models import Organization, Post
-from django_date_extensions.fields import ApproximateDateFormField
 
 class AddressForm(forms.Form):
     address = forms.CharField(
@@ -90,8 +89,8 @@ class BasePersonForm(forms.Form):
         max_length=256,
         required=False,
     )
-    birth_date = ApproximateDateFormField(
-        label=_("Date of birth (as YYYY-MM-DD or YYYY)"),
+    birth_date = forms.CharField(
+        label=_("Date of birth (a four digit year or a full date)"),
         required=False,
     )
     wikipedia_url = forms.URLField(
@@ -143,6 +142,11 @@ class BasePersonForm(forms.Form):
             label=_(u"Program"),
             widget=forms.Textarea
         )
+
+    def clean_birth_date(self):
+        birth_date = self.cleaned_data['birth_date']
+        parsed_date = parse_approximate_date(birth_date)
+        return parsed_date
 
     def clean_twitter_username(self):
         # Remove any URL bits around it:

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -11,6 +11,7 @@ from popolo_extra import PostExtra
 from popolo_extra import MembershipExtra
 from popolo_extra import PartySet
 from popolo_extra import ImageExtra
+from popolo_extra import parse_approximate_date
 
 from field_mappings import CSV_ROW_FIELDS
 

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -13,6 +13,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.translation import ugettext as _
 
+from dateutil import parser
 from slugify import slugify
 from django_date_extensions.fields import ApproximateDate
 
@@ -104,7 +105,7 @@ def update_person_from_form(person, person_extra, form):
 
 
 def parse_approximate_date(s):
-    """Take a partial ISO 8601 date, and return an ApproximateDate for it
+    """Take any reasonable date string, and return an ApproximateDate for it
 
     >>> ad = parse_approximate_date('2014-02-17')
     >>> type(ad)
@@ -129,7 +130,9 @@ def parse_approximate_date(s):
             return ApproximateDate(*(int(g, 10) for g in m.groups()))
     if s == 'future':
         return ApproximateDate(future=True)
-    raise Exception, _("Couldn't parse '{0}' as an ApproximateDate").format(s)
+    dt = parser.parse(s, dayfirst=settings.DD_MM_DATE_FORMAT_PREFERRED)
+    return ApproximateDate(dt.year, dt.month, dt.day)
+    raise ValueError(u"Couldn't parse '{0}' as an ApproximateDate".format(s))
 
 
 class PersonExtra(HasImageMixin, models.Model):

--- a/candidates/tests/test_date_parsing.py
+++ b/candidates/tests/test_date_parsing.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from django_date_extensions.fields import ApproximateDate
+
+from candidates.models import parse_approximate_date
+
+# These tests supplement the doctests; they're not done as
+# doctests because we need to override settings to pick
+# either US or non-US day/month default ordering:
+
+class DateParsingTests(TestCase):
+
+    def test_only_year(self):
+        parsed = parse_approximate_date('1977')
+        self.assertEqual(type(parsed), ApproximateDate)
+        self.assertEqual(repr(parsed), '1977-00-00')
+
+    def test_iso_8601(self):
+        parsed = parse_approximate_date('1977-04-01')
+        self.assertEqual(type(parsed), ApproximateDate)
+        self.assertEqual(repr(parsed), '1977-04-01')
+
+    def test_nonsense(self):
+        with self.assertRaises(ValueError):
+            parse_approximate_date('12345678')
+
+    def test_dd_mm_yyyy_with_slashes(self):
+        parsed = parse_approximate_date('1/4/1977')
+        self.assertEqual(type(parsed), ApproximateDate)
+        self.assertEqual(repr(parsed), '1977-04-01')
+
+    @override_settings(DD_MM_DATE_FORMAT_PREFERRED=False)
+    def test_mm_dd_yyyy_with_slashes(self):
+        parsed = parse_approximate_date('4/1/1977')
+        self.assertEqual(type(parsed), ApproximateDate)
+        self.assertEqual(repr(parsed), '1977-04-01')
+
+    def test_dd_mm_yyyy_with_dashes(self):
+        parsed = parse_approximate_date('1-4-1977')
+        self.assertEqual(type(parsed), ApproximateDate)
+        self.assertEqual(repr(parsed), '1977-04-01')
+
+    def test_natural_date_string(self):
+        parsed = parse_approximate_date('31st December 1999')
+        self.assertEqual(type(parsed), ApproximateDate)
+        self.assertEqual(repr(parsed), '1999-12-31')

--- a/candidates/tests/test_update_view.py
+++ b/candidates/tests/test_update_view.py
@@ -108,3 +108,20 @@ class TestUpdatePersonView(TestUserMixin, WebTest):
             '/person/2009',
             split_location.path
         )
+
+    def test_update_dd_mm_yyyy_birth_date(self):
+        response = self.app.get(
+            '/person/2009/update',
+            user=self.user_who_can_lock,
+        )
+        form = response.forms['person-details']
+        form['birth_date'] = '1/4/1875'
+        form['source'] = "An update for testing purposes"
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 302)
+        split_location = urlsplit(response.location)
+        self.assertEqual('/person/2009', split_location.path)
+
+        person = Person.objects.get(id='2009')
+        self.assertEqual(person.birth_date, '1875-04-01')

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -91,3 +91,7 @@ EDITS_ALLOWED: true
 # This should be set to true unless you're using the old version of
 # Google Analytics.
 USE_UNIVERSAL_ANALYTICS: true
+
+# In all of the world apart from the United States, dd/mm is preferred
+# to mm/dd.  So if your site is for the USA, set this to false:
+DD_MM_DATE_FORMAT_PREFERRED: true

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -277,6 +277,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'USE_I18N': True,
         'USE_L10N': True,
         'USE_TZ': True,
+        'DD_MM_DATE_FORMAT_PREFERRED': conf.get('DD_MM_DATE_FORMAT_PREFERRED', True),
 
         # The media and static file settings:
         'MEDIA_ROOT': media_root,


### PR DESCRIPTION
The change introduced by this commits allows many more date formats
than previously, when just YYYY or YYYY-MM-DD was allowed.

There's also a new DD_MM_DATE_FORMAT_PREFERRED configuration option
to control whether to use the USA or rest-of-the-world date formatting
preference.

Fixes #165, hopefully fixes #444