### PR TITLE
Add generic support for additional fields

### DIFF
--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.forms import ModelForm
 
-from .models import LoggedAction, PartySet
+from .models import LoggedAction, PartySet, ExtraField, PersonExtraFieldValue
 # Register your models here.
 
 
@@ -40,5 +40,23 @@ class PartySetAdmin(admin.ModelAdmin):
     form = PartySetAdminForm
 
 
+class ExtraFieldAdminForm(ModelForm):
+    pass
+
+
+class ExtraFieldAdmin(admin.ModelAdmin):
+    form = ExtraFieldAdminForm
+
+
+class PersonExtraFieldValueAdminForm(ModelForm):
+    pass
+
+
+class PersonExtraFieldValueAdmin(admin.ModelAdmin):
+    form = PersonExtraFieldValueAdminForm
+
+
 admin.site.register(LoggedAction, LoggedActionAdmin)
 admin.site.register(PartySet, PartySetAdmin)
+admin.site.register(ExtraField, ExtraFieldAdmin)
+admin.site.register(PersonExtraFieldValue, PersonExtraFieldValueAdmin)

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -12,7 +12,7 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from candidates.models import PartySet, parse_approximate_date
+from candidates.models import PartySet, parse_approximate_date, ExtraField
 from popolo.models import Organization, Post
 
 class AddressForm(forms.Form):
@@ -58,6 +58,36 @@ class CandidacyDeleteForm(BaseCandidacyForm):
     )
 
 class BasePersonForm(forms.Form):
+
+    def __init__(self, *args, **kwargs):
+        super(BasePersonForm, self).__init__(*args, **kwargs)
+        # Add any extra fields to the person form:
+        for field in ExtraField.objects.all():
+            if field.type == 'line':
+                self.fields[field.key] = \
+                    forms.CharField(
+                        label=_(field.label),
+                        max_length=1024,
+                        required=False,
+                    )
+            elif field.type == 'longer-text':
+                self.fields[field.key] = \
+                    forms.CharField(
+                        label=_(field.label),
+                        required=False,
+                        widget=forms.Textarea,
+                    )
+            elif field.type == 'url':
+                self.fields[field.key] = \
+                    forms.URLField(
+                        label=_(field.label),
+                        max_length=256,
+                        required=False,
+                    )
+            else:
+                raise Exception(
+                    u"Unknown field type: {0}".format(field.type)
+                )
 
     STANDING_CHOICES = (
         ('not-sure', _(u"Don’t Know")),

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -159,20 +159,6 @@ class BasePersonForm(forms.Form):
         required=False,
     )
 
-    if 'cv' in settings.EXTRA_SIMPLE_FIELDS:
-        cv = forms.CharField(
-            required=False,
-            label=_(u"CV or Résumé"),
-            widget=forms.Textarea
-        )
-
-    if 'program' in settings.EXTRA_SIMPLE_FIELDS:
-        program = forms.CharField(
-            required=False,
-            label=_(u"Program"),
-            widget=forms.Textarea
-        )
-
     def clean_birth_date(self):
         birth_date = self.cleaned_data['birth_date']
         if not birth_date:

--- a/candidates/management/commands/candidates_import_from_live_site.py
+++ b/candidates/management/commands/candidates_import_from_live_site.py
@@ -326,10 +326,6 @@ class Command(BaseCommand):
                     'base': p,
                     'versions': json.dumps(person_data['versions'])
                 }
-                if person_data.get('cv'):
-                    kwargs['cv'] = person_data['cv']
-                if person_data.get('program'):
-                    kwargs['program'] = person_data['program']
                 pe = models.PersonExtra.objects.create(**kwargs)
         for m_data in self.get_api_results('memberships'):
             with show_data_on_error('m_data', m_data):

--- a/candidates/management/commands/candidates_import_from_live_site.py
+++ b/candidates/management/commands/candidates_import_from_live_site.py
@@ -86,7 +86,7 @@ class Command(BaseCommand):
                 pmodels.Identifier, pmodels.Link, pmodels.Area,
                 # Additional models:
                 models.PartySet, models.ImageExtra, models.LoggedAction,
-                models.PersonRedirect, emodels.Election,
+                models.PersonRedirect, emodels.Election, models.ExtraField
         ):
             if model_class.objects.exists():
                 non_empty_models.append(model_class)
@@ -155,6 +155,10 @@ class Command(BaseCommand):
             return PILLOW_FORMAT_EXTENSIONS[pillow_image.format]
 
     def mirror_from_api(self):
+        for extra_field in self.get_api_results('extra_fields'):
+            with show_data_on_error('extra_field', extra_field):
+                del extra_field['url']
+                models.ExtraField.objects.create(**extra_field)
         for area_type_data in self.get_api_results('area_types'):
             with show_data_on_error('area_type_data', area_type_data):
                 del area_type_data['url']
@@ -293,6 +297,9 @@ class Command(BaseCommand):
                     election = \
                         emodels.Election.objects.get(slug=election_data['id'])
                     pe.elections.add(election)
+        extra_fields = {
+            ef.key: ef for ef in models.ExtraField.objects.all()
+        }
         for person_data in self.get_api_results('persons'):
             with show_data_on_error('person_data', person_data):
                 kwargs = {
@@ -327,6 +334,13 @@ class Command(BaseCommand):
                     'versions': json.dumps(person_data['versions'])
                 }
                 pe = models.PersonExtra.objects.create(**kwargs)
+                # Look for any data in ExtraFields
+                for extra_field_data in person_data['extra_fields']:
+                    p.extra_field_values.create(
+                        field=extra_fields[extra_field_data['key']],
+                        value=extra_field_data['value'],
+                    )
+
         for m_data in self.get_api_results('memberships'):
             with show_data_on_error('m_data', m_data):
                 kwargs = {
@@ -407,7 +421,7 @@ class Command(BaseCommand):
         reset_sql_list = connection.ops.sequence_reset_sql(
             no_style(), [
                 emodels.AreaType, models.PartySet, pmodels.Area,
-                emodels.Election, Image
+                emodels.Election, Image, models.ExtraField
             ]
         )
         if reset_sql_list:

--- a/candidates/migrations/0015_add_configurable_extra_fields.py
+++ b/candidates/migrations/0015_add_configurable_extra_fields.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('popolo', '0002_update_models_from_upstream'),
+        ('candidates', '0014_make_extra_slugs_unique'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ExtraField',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('key', models.CharField(max_length=256)),
+                ('type', models.CharField(max_length=64, choices=[(b'line', b'A single line of text'), (b'longer-text', b'One or more paragraphs of text'), (b'url', b'A URL')])),
+                ('label', models.CharField(max_length=1024)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='PersonExtraFieldValue',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('value', models.TextField(blank=True)),
+                ('field', models.ForeignKey(to='candidates.ExtraField')),
+                ('person', models.ForeignKey(related_name='extra_field_values', to='popolo.Person')),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='personextrafieldvalue',
+            unique_together=set([('person', 'field')]),
+        ),
+    ]

--- a/candidates/migrations/0016_migrate_data_to_extra_fields.py
+++ b/candidates/migrations/0016_migrate_data_to_extra_fields.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+def from_person_extra_to_generic_fields(apps, schema_editor):
+    ExtraField = apps.get_model('candidates', 'ExtraField')
+    PersonExtraFieldValue = apps.get_model('candidates', 'PersonExtraFieldValue')
+    PersonExtra = apps.get_model('candidates', 'PersonExtra')
+    if settings.ELECTION_APP == 'cr':
+        p_field = ExtraField.objects.create(
+            key='profession',
+            type='line',
+            label=u'Profession',
+        )
+    elif settings.ELECTION_APP == 'bf_elections_2015':
+        c_field = ExtraField.objects.create(
+            key='cv',
+            type='longer-text',
+            label=u'CV or Résumé',
+        )
+        p_field = ExtraField.objects.create(
+            key='program',
+            type='longer-text',
+            label=u'Program',
+        )
+        for pe in PersonExtra.objects.all():
+            person = pe.base
+            PersonExtraFieldValue.objects.create(
+                person=person,
+                field=c_field,
+                value=pe.cv
+            )
+            PersonExtraFieldValue.objects.create(
+                person=person,
+                field=p_field,
+                value=pe.program
+            )
+
+def from_generic_fields_to_person_extra(apps, schema_editor):
+    ExtraField = apps.get_model('candidates', 'ExtraField')
+    PersonExtraFieldValue = apps.get_model('candidates', 'PersonExtraFieldValue')
+    if settings.ELECTION_APP == 'bf_elections_2015':
+        for pefv in PersonExtraFieldValue.objects.select_related('field'):
+            pe = pefv.person.extra
+            if pefv.field.key == 'cv':
+                pe.cv = pefv.value
+                pe.save()
+            elif pefv.field.key == 'program':
+                pe.program = pefv.value
+                pe.save()
+            else:
+                print "Ignoring field with unknown key:", pefv.field.key
+    PersonExtraFieldValue.objects.all().delete()
+    ExtraField.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0015_add_configurable_extra_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            from_person_extra_to_generic_fields,
+            from_generic_fields_to_person_extra
+        )
+    ]

--- a/candidates/migrations/0017_remove_cv_and_program_fields.py
+++ b/candidates/migrations/0017_remove_cv_and_program_fields.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0016_migrate_data_to_extra_fields'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='personextra',
+            name='cv',
+        ),
+        migrations.RemoveField(
+            model_name='personextra',
+            name='program',
+        ),
+    ]

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -15,6 +15,9 @@ from popolo_extra import parse_approximate_date
 
 from field_mappings import CSV_ROW_FIELDS
 
+from fields import ExtraField
+from fields import PersonExtraFieldValue
+
 from db import LoggedAction
 from db import PersonRedirect
 from db import UserTermsAgreement

--- a/candidates/models/fields.py
+++ b/candidates/models/fields.py
@@ -1,0 +1,36 @@
+from django.db import models
+
+from popolo.models import Person
+
+
+class ExtraField(models.Model):
+
+    LINE = 'line'
+    LONGER_TEXT = 'longer-text'
+    URL = 'url'
+
+    FIELD_TYPES = (
+        (LINE, 'A single line of text'),
+        (LONGER_TEXT, 'One or more paragraphs of text'),
+        (URL, 'A URL')
+    )
+
+    key = models.CharField(max_length=256)
+    type = models.CharField(
+        max_length=64,
+        choices=FIELD_TYPES,
+    )
+    label = models.CharField(max_length=1024)
+
+    def __unicode__(self):
+        return self.key
+
+
+class PersonExtraFieldValue(models.Model):
+
+    class Meta:
+        unique_together = (('person', 'field'))
+
+    person = models.ForeignKey(Person, related_name='extra_field_values')
+    field = models.ForeignKey(ExtraField)
+    value = models.TextField(blank=True)

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -49,8 +49,6 @@ def update_person_from_form(person, person_extra, form):
         form_data['birth_date'] = ''
     for field_name in form_simple_fields.keys():
         setattr(person, field_name, form_data[field_name])
-    for field_name in settings.EXTRA_SIMPLE_FIELDS.keys():
-        setattr(person_extra, field_name, form_data[field_name])
     for field_name, location in form_complex_fields_locations.items():
         person_extra.update_complex_field(location, form_data[field_name])
     for extra_field in ExtraField.objects.all():
@@ -145,12 +143,6 @@ def parse_approximate_date(s):
 
 class PersonExtra(HasImageMixin, models.Model):
     base = models.OneToOneField(Person, related_name='extra')
-
-    # These two fields are added just for Burkina Faso - we should
-    # have a better way of adding arbitrary fields which are only
-    # needed for one site.
-    cv = models.TextField(blank=True)
-    program = models.TextField(blank=True)
 
     # This field stores JSON data with previous version information
     # (as it did in PopIt).
@@ -326,12 +318,9 @@ class PersonExtra(HasImageMixin, models.Model):
 
     def get_initial_form_data(self):
         initial_data = {}
-        fields_on_base = form_simple_fields.keys()
-        fields_on_extra = settings.EXTRA_SIMPLE_FIELDS.keys()
-        fields_on_extra += form_complex_fields_locations.keys()
-        for field_name in fields_on_base:
+        for field_name in form_simple_fields.keys():
             initial_data[field_name] = getattr(self.base, field_name)
-        for field_name in fields_on_extra:
+        for field_name in form_complex_fields_locations.keys():
             initial_data[field_name] = getattr(self, field_name)
         for extra_field_value in PersonExtraFieldValue.objects.filter(
                 person=self.base

--- a/candidates/serializers.py
+++ b/candidates/serializers.py
@@ -289,6 +289,15 @@ class JSONSerializerField(serializers.Field):
         return json.loads(value)
 
 
+class PersonExtraFieldSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = candidates_models.PersonExtraFieldValue
+        fields = ('key', 'value', 'type')
+
+    key = serializers.ReadOnlyField(source='field.key')
+    type = serializers.ReadOnlyField(source='field.type')
+
+
 class PersonSerializer(MinimalPersonSerializer):
     class Meta:
         model = popolo_models.Person
@@ -310,6 +319,7 @@ class PersonSerializer(MinimalPersonSerializer):
             'links',
             'memberships',
             'images',
+            'extra_fields',
         )
 
     contact_details = ContactDetailSerializer(many=True, read_only=True)
@@ -322,6 +332,8 @@ class PersonSerializer(MinimalPersonSerializer):
 
     memberships = MembershipSerializer(many=True, read_only=True)
 
+    extra_fields = PersonExtraFieldSerializer(
+        many=True, read_only=True, source='extra_field_values')
 
 class PostExtraSerializer(MinimalPostExtraSerializer):
     class Meta:

--- a/candidates/serializers.py
+++ b/candidates/serializers.py
@@ -372,3 +372,9 @@ class LoggedActionSerializer(serializers.HyperlinkedModelSerializer):
         source='popit_person_new_version')
     user = serializers.ReadOnlyField(source='user.username')
     person = MinimalPersonSerializer(read_only=True)
+
+
+class ExtraFieldSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = candidates_models.ExtraField
+        fields = ('id', 'url',  'key', 'type', 'label')

--- a/candidates/templates/candidates/person-edit.html
+++ b/candidates/templates/candidates/person-edit.html
@@ -229,26 +229,20 @@
         {{ form.birth_date.errors }}
       </div>
 
-      <h2>{% trans "Additional information:" %}</h2>
+      {% if extra_fields %}
 
-      {% if form.cv %}
-        <div class="form-item {% if form.cv.errors %}form-item--errors{% endif %}">
-          <p>
-            {{ form.cv.label_tag }}
-            {{ form.cv }}
-          </p>
-          {{ form.cv.errors }}
-        </div>
-      {% endif %}
+        <h2>{% trans "Additional information:" %}</h2>
 
-      {% if form.program %}
-        <div class="form-item {% if form.program.errors %}form-item--errors{% endif %}">
-          <p>
-            {{ form.program.label_tag }}
-            {{ form.program }}
-          </p>
-          {{ form.program.errors }}
-        </div>
+        {% for extra_field_key, extra_field in extra_fields.items %}
+          <div class="form-item {% if extra_field.form_field.errors %}form-item--errors{% endif %}">
+            <p>
+              {{ extra_field.form_field.label_tag }}
+              {{ extra_field.form_field }}
+            </p>
+            {{ extra_field.form_field.errors }}
+          </div>
+        {% endfor %}
+
       {% endif %}
 
       <div class="source-confirmation {% if form.source.errors %}source-confirmation--errors{% endif %}">

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -195,22 +195,21 @@
     {% endwith %}
   </dl>
 
-  {% if person.extra.cv or person.extra.program %}
+  {% if extra_fields %}
     <h2>{% trans "Additional information:" %}</h2>
     <dl>
-      {% if person.extra.cv %}
-        <dt>{% trans "CV or Résumé" %}</dt>
-        <dd>{{ person.extra.cv|linebreaks }}
+      {% for extra_field_key, extra_field in extra_fields.items %}
+        <dt>{{ extra_field.label }}</dt>
+        <dd>
+          {% if extra_field.type == 'url' %}
+            <a href="{{ extra_field.value }}" rel="nofollow">{{ extra_field.value }}</a>
+          {% else %}
+            {{ extra_field.value }}
+          {% endif %}
         </dd>
-      {% endif %}
-      {% if person.extra.program %}
-        <dt>{% trans "Program" %}</dt>
-        <dd>{{ person.extra.program|linebreaks }}
-        </dd>
-      {% endif %}
+      {% endfor %}
     </dl>
   {% endif %}
-
 
   {% if person.extra.primary_image %}
   <h2>{% trans "Photo Credit:" %}</h2>

--- a/candidates/tests/test_extra_fields.py
+++ b/candidates/tests/test_extra_fields.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+
+import re
+from urlparse import urlsplit
+
+from django_webtest import WebTest
+from popolo.models import Person
+
+from candidates.models import ExtraField, PersonExtraFieldValue, PersonExtra
+
+from .factories import (
+    AreaTypeFactory, PartySetFactory, ElectionFactory,
+    ParliamentaryChamberFactory
+)
+
+from .auth import TestUserMixin
+
+
+def get_next_dd(start):
+    return [t for t in start.next_siblings if t.name == 'dd'][0]
+
+
+class ExtraFieldTests(TestUserMixin, WebTest):
+
+    def setUp(self):
+        # Standard setup (should be factored out):
+        wmc_area_type = AreaTypeFactory.create()
+        # commons = ParliamentaryChamberFactory.create()
+        # gb_parties = PartySetFactory.create(slug='gb', name='Great Britain')
+        ElectionFactory.create(
+            slug='2015',
+            name='2015 General Election',
+            area_types=(wmc_area_type,)
+        )
+        # And now the extra fields:
+        p_field = ExtraField.objects.create(
+            key='profession',
+            label='Profession',
+            type=ExtraField.LINE,
+        )
+        c_field = ExtraField.objects.create(
+            key='cv',
+            label=u'Curriculum Vitae or Resumé',
+            type=ExtraField.LINE,
+        )
+        # Create one person with these fields already present:
+        self.person = Person.objects.create(
+            name="John the Well-Described"
+        )
+        PersonExtra.objects.create(base=self.person, versions='[]')
+        # Now create values for those fields:
+        PersonExtraFieldValue.objects.create(
+            field=c_field,
+            person=self.person,
+            value=u'http://cv.example.org/john'
+        )
+        PersonExtraFieldValue.objects.create(
+            field=p_field,
+            person=self.person,
+            value=u'Tree Surgeon'
+        )
+
+    def test_create_form_has_fields(self):
+        response = self.app.get(
+            '/election/2015/person/create/',
+            user=self.user
+        )
+        self.assertEqual(response.status_code, 200)
+        # Look for the extra fields' labels:
+        p_label = response.html.find('label', {'for': 'id_profession'})
+        c_label = response.html.find('label', {'for': 'id_cv'})
+        self.assertIsNotNone(p_label)
+        self.assertIsNotNone(c_label)
+        p_input = response.html.find('input', {'id': 'id_profession'})
+        c_input = response.html.find('input', {'id': 'id_cv'})
+        self.assertIsNotNone(p_input)
+        self.assertIsNotNone(c_input)
+
+    def test_update_form_is_prefilled(self):
+        response = self.app.get(
+            '/person/{person_id}/update'.format(person_id=self.person.id),
+            user=self.user,
+        )
+        # Look for the extra fields' labels:
+        p_label = response.html.find('label', {'for': 'id_profession'})
+        c_label = response.html.find('label', {'for': 'id_cv'})
+        self.assertIsNotNone(p_label)
+        self.assertIsNotNone(c_label)
+        p_input = response.html.find('input', {'id': 'id_profession'})
+        c_input = response.html.find('input', {'id': 'id_cv'})
+        self.assertIsNotNone(p_input)
+        self.assertIsNotNone(c_input)
+        self.assertEqual(p_input.get('value'), 'Tree Surgeon')
+        self.assertEqual(c_input.get('value'), 'http://cv.example.org/john')
+
+    def test_fields_are_saved_when_editing(self):
+        response = self.app.get(
+            '/person/{person_id}/update'.format(person_id=self.person.id),
+            user=self.user,
+        )
+        form = response.forms['person-details']
+        form['cv'] = 'http://homepage.example.org/john-the-described'
+        form['profession'] = 'Soda Jerk'
+        form['source'] = 'Testing setting additional fields'
+        submission_response = form.submit()
+
+        self.assertEqual(submission_response.status_code, 302)
+        split_location = urlsplit(submission_response.location)
+        self.assertEqual(
+            '/person/{person_id}'.format(person_id=self.person.id),
+            split_location.path
+        )
+
+        person = Person.objects.get(id=self.person.id)
+        self.assertEqual(
+            PersonExtraFieldValue.objects.get(
+                person=person, field__key='cv'
+            ).value,
+            'http://homepage.example.org/john-the-described'
+        )
+        self.assertEqual(
+            PersonExtraFieldValue.objects.get(
+                person=person, field__key='profession'
+            ).value,
+            'Soda Jerk'
+        )
+
+    def test_fields_are_saved_when_creating(self):
+        response = self.app.get(
+            '/election/2015/person/create/',
+            user=self.user
+        )
+        form = response.forms['person-details']
+        form['name'] = 'Naomi Newperson'
+        form['cv'] = 'http://example.org/another-cv'
+        form['profession'] = 'Longshoreman'
+        form['standing_2015'] = 'not-standing'
+        form['source'] = 'Test creating someone with additional fields'
+        submission_response = form.submit()
+
+        self.assertEqual(submission_response.status_code, 302)
+        split_location = urlsplit(submission_response.location)
+        m = re.search(r'^/person/(.*)', split_location.path)
+        self.assertTrue(m)
+
+        person = Person.objects.get(id=m.group(1))
+        self.assertEqual(
+            PersonExtraFieldValue.objects.get(
+                person=person, field__key='cv'
+            ).value,
+            'http://example.org/another-cv'
+        )
+        self.assertEqual(
+            PersonExtraFieldValue.objects.get(
+                person=person, field__key='profession'
+            ).value,
+            'Longshoreman'
+        )
+
+    def test_view_additional_fields(self):
+        response = self.app.get(
+            '/person/{person_id}'.format(person_id=self.person.id)
+        )
+
+        cv_dt = response.html.find('dt', text=u'Curriculum Vitae or Resumé')
+        cv_dd = get_next_dd(cv_dt)
+        self.assertEqual(cv_dd.text.strip(), 'http://cv.example.org/john')
+
+        profession_dt = response.html.find('dt', text=u'Profession')
+        profession_dd = get_next_dd(profession_dt)
+        self.assertEqual(profession_dd.text.strip(), 'Tree Surgeon')

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -20,6 +20,7 @@ api_router.register(r'party_sets', views.PartySetViewSet)
 api_router.register(r'images', views.ImageViewSet)
 api_router.register(r'memberships', views.MembershipViewSet)
 api_router.register(r'logged_actions', views.LoggedActionViewSet)
+api_router.register(r'extra_fields', views.ExtraFieldViewSet)
 
 urlpatterns = \
     patterns('',

--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -223,3 +223,8 @@ class MembershipViewSet(viewsets.ModelViewSet):
 class LoggedActionViewSet(viewsets.ModelViewSet):
     queryset = extra_models.LoggedAction.objects.order_by('id')
     serializer_class = serializers.LoggedActionSerializer
+
+
+class ExtraFieldViewSet(viewsets.ModelViewSet):
+    queryset = extra_models.ExtraField.objects.order_by('id')
+    serializer_class = serializers.ExtraFieldSerializer

--- a/elections/bf_elections_2015/settings.py
+++ b/elections/bf_elections_2015/settings.py
@@ -11,10 +11,5 @@ AREAS_TO_ALWAYS_RETURN = [
     }
 ]
 
-EXTRA_SIMPLE_FIELDS = {
-    'cv': '',
-    'program': ''
-}
-
 SITE_OWNER = 'Burkina Open Data Initiative (BODI)'
 COPYRIGHT_HOLDER = 'Burkina Open Data Initiative (BODI)'

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -430,7 +430,6 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
     for optional_election_app_setting, default in (
             ('SITE_OWNER_URL', ''),
             ('AREAS_TO_ALWAYS_RETURN', []),
-            ('EXTRA_SIMPLE_FIELDS', {}),
             ('IMAGE_PROXY_URL', ''),
     ):
         try:


### PR DESCRIPTION
We added hard-coded special cases for the 'CV' and 'Program' fields
to add them for Burkina Faso.  This was pretty ugly and not nice to
maintain as we add different additional (non-Popolo) fields for other
countries. For example, Costa Rica want a "Profession" field.

This pull request allows you to add additional fields in the admin
interface which anyone can then edit in the usual way on the site.

Still to do:

- [x] Add a data migration so that if ELECTION_APP is
      bf_elections_2015 then the `cv` and `program` fields
      are added to the database.
- [x] Remove the references to the hard-coded `cv` and
      `program` from the codebase.
- [x] Add a data migration so that if ELECTION_APP is cr
      then the `profession` field is added.
- [x] Update the mirror from live site command to deal with
      additional fields
   