### PR TITLE
Remove `key-value-list` class from core profile page list elements

### DIFF
--- a/candidates/static/candidates/_people.scss
+++ b/candidates/static/candidates/_people.scss
@@ -19,6 +19,8 @@
   border-bottom: 1px solid #ccc;
 }
 
+// You can apply this class to a <dl> element to stack the
+// <dt> children vertically, with the <dd>s to one side.
 .key-value-list {
   line-height: 1.4em;
 

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -109,7 +109,7 @@
     {% endif %}
   <h2>{% trans "Personal details:" %}</h2>
 
-  <dl class="key-value-list">
+  <dl>
     <dt>{% trans "Name" %}</dt>
     <dd>{{ person.extra.name_with_honorifics }}</dd>
     {% if person.other_names.exists %}
@@ -139,7 +139,7 @@
 
   <h2>{% trans "Links and social media:" %}</h2>
 
-  <dl class="key-value-list">
+  <dl>
     <dt>Twitter</dt>
     <dd>{% if person.extra.twitter_username %}<a rel="nofollow" href="https://twitter.com/{{ person.extra.twitter_username }}">@{{ person.extra.twitter_username }}</a>{% endif %}</dd>
     <dt>Facebook</dt>
@@ -164,7 +164,7 @@
 
   <h2>{% trans "Demographics:" %}</h2>
 
-  <dl class="key-value-list">
+  <dl>
     <dt>{% trans "Gender" %}</dt>
     <dd>{% if person.gender %}{{ person.gender|title }}{% else %}{% trans "Unknown" %}{% endif %}</dd>
     <dt>{% trans "Age" %}</dt>


### PR DESCRIPTION
The `key-value-list` class stacks a `<dl>` element’s contents vertically, limiting the width of the `<dt>` elements inside and truncating them with an ellipsis if they over-run.

This is mostly ok in English (but not always!) but is a real problem in other languages where important labels get truncated because they’re too long, and there’s no way to reveal the full text.

This commit removes the `key-value-list` class from the `<dl>` elements on the candidate profile page, so the `<dt>` and `<dd>` elements will just stack vertically, as normal.

The CSS rules are left intact, in case re-users want to add the class back into their custom templates.