### PR TITLE
Fix bug where blank birth date was interpreted as today

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -145,6 +145,8 @@ class BasePersonForm(forms.Form):
 
     def clean_birth_date(self):
         birth_date = self.cleaned_data['birth_date']
+        if not birth_date:
+            return ''
         parsed_date = parse_approximate_date(birth_date)
         return parsed_date
 

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -130,8 +130,9 @@ def parse_approximate_date(s):
             return ApproximateDate(*(int(g, 10) for g in m.groups()))
     if s == 'future':
         return ApproximateDate(future=True)
-    dt = parser.parse(s, dayfirst=settings.DD_MM_DATE_FORMAT_PREFERRED)
-    return ApproximateDate(dt.year, dt.month, dt.day)
+    if s:
+        dt = parser.parse(s, dayfirst=settings.DD_MM_DATE_FORMAT_PREFERRED)
+        return ApproximateDate(dt.year, dt.month, dt.day)
     raise ValueError(u"Couldn't parse '{0}' as an ApproximateDate".format(s))
 
 

--- a/candidates/tests/test_date_parsing.py
+++ b/candidates/tests/test_date_parsing.py
@@ -45,3 +45,7 @@ class DateParsingTests(TestCase):
         parsed = parse_approximate_date('31st December 1999')
         self.assertEqual(type(parsed), ApproximateDate)
         self.assertEqual(repr(parsed), '1999-12-31')
+
+    def test_empty_string(self):
+        with self.assertRaises(ValueError):
+            parse_approximate_date('')

--- a/candidates/tests/test_new_person_view.py
+++ b/candidates/tests/test_new_person_view.py
@@ -82,6 +82,8 @@ class TestNewPersonView(TestUserMixin, WebTest):
 
         person = Person.objects.get(name='Elizabeth Bennet')
 
+        self.assertEqual(person.birth_date, '')
+
         self.assertEqual(submission_response.status_code, 302)
         self.assertEqual(
             submission_response.location,


### PR DESCRIPTION
The commit that added dateutil.parser for parsing otherwise
unrecognised dates (507055baf) unfortunately also handled the
empty string and interpreted it as today's date, so not filling
in the date of birth field would give someone today's date as
their birthday.  This commit fixes that and adds regression
tests.