### PR TITLE
Make sure allauth's .po files are compiled on deploy

### DIFF
--- a/bin/pre-deploy
+++ b/bin/pre-deploy
@@ -44,6 +44,15 @@ done
 # make sure that there is no old code (the .py files may have been git deleted)
 find . -name '*.pyc' -delete
 
+# Compile the allauth messages files - see
+# https://github.com/pennersr/django-allauth/issues/1032
+if [ -d "$VIRTUALENV_DIR" ]
+then
+    find "$VIRTUALENV_DIR/lib/python2.7/site-packages/allauth/locale/" \
+        -name django.po \
+        -execdir msgfmt django.po -o django.mo \;
+fi
+
 # get the database up to speed
 ./manage.py migrate --noinput
 

--- a/conf/packages
+++ b/conf/packages
@@ -9,3 +9,4 @@ libxslt-dev
 libffi-dev
 libssl-dev
 memcached
+gettext


### PR DESCRIPTION
Because of this bug:

  https://github.com/pennersr/django-allauth/issues/1032

... we need to manually compile the allauth .po files into
.mo files.