### PR TITLE
Fix date parser errors with Spanish

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -163,7 +163,14 @@ class BasePersonForm(forms.Form):
         birth_date = self.cleaned_data['birth_date']
         if not birth_date:
             return ''
-        parsed_date = parse_approximate_date(birth_date)
+        try:
+            parsed_date = parse_approximate_date(birth_date)
+        except ValueError:
+            if settings.DD_MM_DATE_FORMAT_PREFERRED:
+                message = _("That date of birth could not be understood. Try using DD/MM/YYYY instead")
+            else:
+                message = _("That date of birth could not be understood. Try using MM/DD/YYYY instead")
+            raise ValidationError(message)
         return parsed_date
 
     def clean_twitter_username(self):

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -12,6 +12,7 @@ from django.core.files.storage import FileSystemStorage
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils.translation import ugettext as _
+from django.utils.translation import ugettext_lazy as _l
 
 from dateutil import parser
 from slugify import slugify
@@ -109,6 +110,25 @@ def update_person_from_form(person, person_extra, form):
             person_extra.not_standing.add(election_data)
 
 
+class localparserinfo(parser.parserinfo):
+    MONTHS = [
+        (u'Jan', _l(u'Jan'), u'January', _l(u'January')),
+        (u'Feb', _l(u'Feb'), u'February', _l(u'February')),
+        (u'Mar', _l(u'Mar'), u'March', _l(u'March')),
+        (u'Apr', _l(u'Apr'), u'April', _l(u'April')),
+        (u'May', _l(u'May'), u'May', _l(u'May')),
+        (u'Jun', _l(u'Jun'), u'June', _l(u'June')),
+        (u'Jul', _l(u'Jul'), u'July', _l(u'July')),
+        (u'Aug', _l(u'Aug'), u'August', _l(u'August')),
+        (u'Sep', _l(u'Sep'), u'Sept', u'September', _l(u'September')),
+        (u'Oct', _l(u'Oct'), u'October', _l(u'October')),
+        (u'Nov', _l(u'Nov'), u'November', _l(u'November')),
+        (u'Dec', _l(u'Dec'), u'December', _l(u'December'))
+    ]
+
+    PERTAIN = [u'of', _l(u'of')]
+
+
 def parse_approximate_date(s):
     """Take any reasonable date string, and return an ApproximateDate for it
 
@@ -136,7 +156,11 @@ def parse_approximate_date(s):
     if s == 'future':
         return ApproximateDate(future=True)
     if s:
-        dt = parser.parse(s, dayfirst=settings.DD_MM_DATE_FORMAT_PREFERRED)
+        dt = parser.parse(
+            s,
+            parserinfo=localparserinfo(),
+            dayfirst=settings.DD_MM_DATE_FORMAT_PREFERRED
+        )
         return ApproximateDate(dt.year, dt.month, dt.day)
     raise ValueError(u"Couldn't parse '{0}' as an ApproximateDate".format(s))
 

--- a/candidates/tests/test_date_parsing.py
+++ b/candidates/tests/test_date_parsing.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from django.utils.translation import override
+
 from django_date_extensions.fields import ApproximateDate
 
 from candidates.models import parse_approximate_date
@@ -49,3 +51,20 @@ class DateParsingTests(TestCase):
     def test_empty_string(self):
         with self.assertRaises(ValueError):
             parse_approximate_date('')
+
+    def test_expanded_natural_date_string(self):
+        parsed = parse_approximate_date('31st of December 1999')
+        self.assertEqual(type(parsed), ApproximateDate)
+        self.assertEqual(repr(parsed), '1999-12-31')
+
+    def test_nonsense_string(self):
+        with self.assertRaises(ValueError):
+            parse_approximate_date('this is not a date')
+
+    def test_spanish_date_string(self):
+        with self.assertRaises(ValueError):
+            parsed = parse_approximate_date('20 febrero 1954 ')
+        with override('es'):
+            parsed = parse_approximate_date('20 febrero 1954 ')
+            self.assertEqual(type(parsed), ApproximateDate)
+            self.assertEqual(repr(parsed), '1954-02-20')

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pyasn1==0.1.7
 pycparser==2.10
 pygeocoder==1.2.5
 pyOpenSSL==0.14
-python-dateutil==2.2
+python-dateutil==2.4.2
 python-magic==0.4.6
 python-memcached==1.54
 python-openid==2.2.5


### PR DESCRIPTION
This should fix handing dates in the translated language and also slightly more fullsome date descriptions like '20 de febrero de 1954'

It does this by adding a parserinfo class with translated month names that is then passed into dateutils.parse to change the set of strings it uses to match months. This uses ugettext_lazy as otherwise the translation is done at module load time which may be before language settings have been changed.