### PR TITLE
Customize visible fields

### DIFF
--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -5,7 +5,7 @@ from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.forms import ModelForm
 
-from .models import LoggedAction, PartySet, ExtraField, PersonExtraFieldValue
+from .models import LoggedAction, PartySet, ExtraField, PersonExtraFieldValue, SimplePopoloField
 # Register your models here.
 
 
@@ -58,7 +58,12 @@ class PersonExtraFieldValueAdmin(admin.ModelAdmin):
     form = PersonExtraFieldValueAdminForm
 
 
+class SimplePopoloFieldAdmin(admin.ModelAdmin):
+    list_display = ['name', 'label']
+
+
 admin.site.register(LoggedAction, LoggedActionAdmin)
 admin.site.register(PartySet, PartySetAdmin)
 admin.site.register(ExtraField, ExtraFieldAdmin)
 admin.site.register(PersonExtraFieldValue, PersonExtraFieldValueAdmin)
+admin.site.register(SimplePopoloField, SimplePopoloFieldAdmin)

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -14,7 +14,7 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-from candidates.models import PartySet, parse_approximate_date, ExtraField
+from candidates.models import PartySet, parse_approximate_date, ExtraField, SimplePopoloField
 from popolo.models import Organization, Post
 
 class AddressForm(forms.Form):
@@ -106,40 +106,25 @@ class BasePersonForm(forms.Form):
                     "Unknown field type: {0}".format(field.type)
                 )
 
+        for field in SimplePopoloField.objects.all():
+            opts = {
+                'label': _(field.label),
+                'required': field.required
+            }
+
+            if field.info_type_key == 'url':
+                self.fields[field.name] = forms.URLField(**opts)
+            elif field.info_type_key == 'email':
+                self.fields[field.name] = forms.EmailField(**opts)
+            else:
+                self.fields[field.name] = forms.CharField(**opts)
+
     STANDING_CHOICES = (
         ('not-sure', _("Don’t Know")),
         ('standing', _("Yes")),
         ('not-standing', _("No")),
     )
 
-    honorific_prefix = forms.CharField(
-        label=_("Title / pre-nominal honorific (e.g. Dr, Sir, etc.)"),
-        max_length=256,
-        required=False,
-    )
-    name = forms.CharField(
-        label=_("Full name"),
-        max_length=1024,
-    )
-    honorific_suffix = forms.CharField(
-        label=_("Post-nominal letters (e.g. CBE, DSO, etc.)"),
-        max_length=256,
-        required=False,
-    )
-    email = forms.EmailField(
-        label=_("Email"),
-        max_length=256,
-        required=False,
-    )
-    gender = forms.CharField(
-        label=_("Gender (e.g. “male”, “female”)"),
-        max_length=256,
-        required=False,
-    )
-    birth_date = forms.CharField(
-        label=_("Date of birth (a four digit year or a full date)"),
-        required=False,
-    )
     wikipedia_url = forms.URLField(
         label=_("Wikipedia URL"),
         max_length=256,

--- a/candidates/management/commands/candidates_import_from_live_site.py
+++ b/candidates/management/commands/candidates_import_from_live_site.py
@@ -88,7 +88,8 @@ class Command(BaseCommand):
                 pmodels.Identifier, pmodels.Link, pmodels.Area,
                 # Additional models:
                 models.PartySet, models.ImageExtra, models.LoggedAction,
-                models.PersonRedirect, emodels.Election, models.ExtraField
+                models.PersonRedirect, emodels.Election, models.ExtraField,
+                models.SimplePopoloField
         ):
             if model_class.objects.exists():
                 non_empty_models.append(model_class)
@@ -161,6 +162,10 @@ class Command(BaseCommand):
             with show_data_on_error('extra_field', extra_field):
                 del extra_field['url']
                 models.ExtraField.objects.create(**extra_field)
+        for simple_field in self.get_api_results('simple_fields'):
+            with show_data_on_error('simple_field', simple_field):
+                del simple_field['url']
+                models.SimplePopoloField.objects.create(**simple_field)
         for area_type_data in self.get_api_results('area_types'):
             with show_data_on_error('area_type_data', area_type_data):
                 del area_type_data['url']
@@ -425,7 +430,8 @@ class Command(BaseCommand):
         reset_sql_list = connection.ops.sequence_reset_sql(
             no_style(), [
                 emodels.AreaType, models.PartySet, pmodels.Area,
-                emodels.Election, Image, models.ExtraField
+                emodels.Election, Image, models.ExtraField,
+                models.SimplePopoloField
             ]
         )
         if reset_sql_list:

--- a/candidates/migrations/0021_simplepopolofield.py
+++ b/candidates/migrations/0021_simplepopolofield.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0020_cr_add_reelection_field'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SimplePopoloField',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=256, choices=[(b'name', 'Name'), (b'family_name', 'Family Name'), (b'given_name', 'Given Name'), (b'additional_name', 'Additional Name'), (b'honorific_prefix', 'Honorific Prefix'), (b'honorific_suffix', 'Honorific Suffix'), (b'patronymic_name', 'Patronymic Name'), (b'sort_name', 'Sort Name'), (b'email', 'Email'), (b'gender', 'Gender'), (b'birth_date', 'Birth Date'), (b'death_date', 'Death Date'), (b'summary', 'Summary'), (b'biography', 'Biography'), (b'national_identity', 'National Identity')])),
+                ('label', models.CharField(max_length=256)),
+                ('required', models.BooleanField(default=False)),
+                ('info_type_key', models.CharField(max_length=256, choices=[(b'text', 'Text Field'), (b'email', 'Email Field')])),
+                ('order', models.IntegerField(blank=True)),
+            ],
+        ),
+    ]

--- a/candidates/migrations/0022_create_standard_simple_fields.py
+++ b/candidates/migrations/0022_create_standard_simple_fields.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def create_simple_fields(apps, schema_editor):
+    SimpleField = apps.get_model('candidates', 'SimplePopoloField')
+    db_alias = schema_editor.connection.alias
+
+    SimpleField.objects.using(db_alias).bulk_create([
+        SimpleField(
+            name='honorific_prefix',
+            label='Title / pre-nominal honorific (e.g. Dr, Sir, etc.)',
+            required=False,
+            info_type_key='text',
+            order=1,
+        ),
+        SimpleField(
+            name='name',
+            label='Full name',
+            required=True,
+            info_type_key='text',
+            order=2,
+        ),
+        SimpleField(
+            name='honorific_suffix',
+            label='Post-nominal letters (e.g. CBE, DSO, etc.)',
+            required=False,
+            info_type_key='text',
+            order=3,
+        ),
+        SimpleField(
+            name='email',
+            label='Email',
+            required=False,
+            info_type_key='email',
+            order=4,
+        ),
+        SimpleField(
+            name='gender',
+            label=u"Gender (e.g. “male”, “female”), Sir, etc.)",
+            required=False,
+            info_type_key='text',
+            order=5,
+        ),
+        SimpleField(
+            name='birth_date',
+            label='Date of birth (a four digit year or a full date)',
+            required=False,
+            info_type_key='text',
+            order=6,
+        ),
+    ])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0021_simplepopolofield'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_simple_fields),
+    ]

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -17,6 +17,7 @@ from .field_mappings import CSV_ROW_FIELDS
 
 from .fields import ExtraField
 from .fields import PersonExtraFieldValue
+from .fields import SimplePopoloField
 
 from .db import LoggedAction
 from .db import PersonRedirect

--- a/candidates/models/fields.py
+++ b/candidates/models/fields.py
@@ -1,10 +1,46 @@
 from __future__ import unicode_literals
 
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
 
 from popolo.models import Person
 
 from compat import python_2_unicode_compatible
+
+
+class SimplePopoloField(models.Model):
+    VALID_FIELDS = (
+        ('name', _('Name')),
+        ('family_name', _('Family Name')),
+        ('given_name', _('Given Name')),
+        ('additional_name', _('Additional Name')),
+        ('honorific_prefix', _('Honorific Prefix')),
+        ('honorific_suffix', _('Honorific Suffix')),
+        ('patronymic_name', _('Patronymic Name')),
+        ('sort_name', _('Sort Name')),
+        ('email', _('Email')),
+        ('gender', _('Gender')),
+        ('birth_date', _('Birth Date')),
+        ('death_date', _('Death Date')),
+        ('summary', _('Summary')),
+        ('biography', _('Biography')),
+        ('national_identity', _('National Identity')),
+    )
+
+    name = models.CharField(
+        choices=VALID_FIELDS,
+        max_length=256
+    )
+    label = models.CharField(max_length=256)
+    required = models.BooleanField(default=False)
+    info_type_key = models.CharField(
+        choices=(
+            ('text', _('Text Field')),
+            ('email', _('Email Field')),
+        ),
+        max_length=256
+    )
+    order = models.IntegerField(blank=True)
 
 
 @python_2_unicode_compatible

--- a/candidates/models/fields.py
+++ b/candidates/models/fields.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
 
 from popolo.models import Person
 
@@ -10,21 +9,21 @@ from compat import python_2_unicode_compatible
 
 class SimplePopoloField(models.Model):
     VALID_FIELDS = (
-        ('name', _('Name')),
-        ('family_name', _('Family Name')),
-        ('given_name', _('Given Name')),
-        ('additional_name', _('Additional Name')),
-        ('honorific_prefix', _('Honorific Prefix')),
-        ('honorific_suffix', _('Honorific Suffix')),
-        ('patronymic_name', _('Patronymic Name')),
-        ('sort_name', _('Sort Name')),
-        ('email', _('Email')),
-        ('gender', _('Gender')),
-        ('birth_date', _('Birth Date')),
-        ('death_date', _('Death Date')),
-        ('summary', _('Summary')),
-        ('biography', _('Biography')),
-        ('national_identity', _('National Identity')),
+        ('name', 'Name'),
+        ('family_name', 'Family Name'),
+        ('given_name', 'Given Name'),
+        ('additional_name', 'Additional Name'),
+        ('honorific_prefix', 'Honorific Prefix'),
+        ('honorific_suffix', 'Honorific Suffix'),
+        ('patronymic_name', 'Patronymic Name'),
+        ('sort_name', 'Sort Name'),
+        ('email', 'Email'),
+        ('gender', 'Gender'),
+        ('birth_date', 'Birth Date'),
+        ('death_date', 'Death Date'),
+        ('summary', 'Summary'),
+        ('biography', 'Biography'),
+        ('national_identity', 'National Identity'),
     )
 
     name = models.CharField(
@@ -35,8 +34,8 @@ class SimplePopoloField(models.Model):
     required = models.BooleanField(default=False)
     info_type_key = models.CharField(
         choices=(
-            ('text', _('Text Field')),
-            ('email', _('Email Field')),
+            ('text', 'Text Field'),
+            ('email', 'Email Field'),
         ),
         max_length=256
     )

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -27,7 +27,7 @@ from compat import python_2_unicode_compatible
 from .field_mappings import (
     form_simple_fields, form_complex_fields_locations
 )
-from .fields import ExtraField, PersonExtraFieldValue
+from .fields import ExtraField, PersonExtraFieldValue, SimplePopoloField
 from ..diffs import get_version_diffs
 from .versions import get_person_as_version_data
 
@@ -50,8 +50,8 @@ def update_person_from_form(person, person_extra, form):
         form_data['birth_date'] = repr(birth_date_date).replace("-00-00", "")
     else:
         form_data['birth_date'] = ''
-    for field_name in form_simple_fields.keys():
-        setattr(person, field_name, form_data[field_name])
+    for field in SimplePopoloField.objects.all():
+        setattr(person, field.name, form_data[field.name])
     for field_name, location in form_complex_fields_locations.items():
         person_extra.update_complex_field(location, form_data[field_name])
     for extra_field in ExtraField.objects.all():
@@ -345,8 +345,8 @@ class PersonExtra(HasImageMixin, models.Model):
 
     def get_initial_form_data(self):
         initial_data = {}
-        for field_name in form_simple_fields.keys():
-            initial_data[field_name] = getattr(self.base, field_name)
+        for field in SimplePopoloField.objects.all():
+            initial_data[field.name] = getattr(self.base, field.name)
         for field_name in form_complex_fields_locations.keys():
             initial_data[field_name] = getattr(self, field_name)
         for extra_field_value in PersonExtraFieldValue.objects.filter(

--- a/candidates/models/versions.py
+++ b/candidates/models/versions.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from .fields import ExtraField
+from .fields import ExtraField, SimplePopoloField
 from .field_mappings import form_simple_fields, form_complex_fields_locations
 
 from django.db.models import F
@@ -13,8 +13,8 @@ def get_person_as_version_data(person):
     result = {}
     person_extra = person.extra
     result['id'] = str(person.id)
-    for field, null_value in form_simple_fields.items():
-        result[field] = getattr(person, field) or null_value
+    for field in SimplePopoloField.objects.all():
+        result[field.name] = getattr(person, field.name) or ''
     for field in form_complex_fields_locations:
         result[field] = getattr(person_extra, field)
     extra_values = {
@@ -82,12 +82,12 @@ def revert_person_from_version_data(person, person_extra, version_data):
     from candidates.models import MembershipExtra
     from elections.models import Election
 
-    for field, null_value in form_simple_fields.items():
-        new_value = version_data.get(field)
+    for field in SimplePopoloField.objects.all():
+        new_value = version_data.get(field.name)
         if new_value:
-            setattr(person, field, new_value)
+            setattr(person, field.name, new_value)
         else:
-            setattr(person, field, null_value)
+            setattr(person, field.name, '')
 
     # Remove any old values in complex fields:
     for location in form_complex_fields_locations.values():

--- a/candidates/serializers.py
+++ b/candidates/serializers.py
@@ -394,3 +394,9 @@ class ExtraFieldSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = candidates_models.ExtraField
         fields = ('id', 'url',  'key', 'type', 'label')
+
+
+class SimplePopoloFieldSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = candidates_models.SimplePopoloField
+        fields = ('id', 'name', 'label', 'required', 'info_type_key', 'order')

--- a/candidates/templates/candidates/person-edit.html
+++ b/candidates/templates/candidates/person-edit.html
@@ -59,45 +59,16 @@
 
       <h2>{% trans "Personal details:" %}</h2>
 
-      {% if settings.ELECTION_APP == 'cr' %}
-      <input id="id_honorific_prefix" maxlength="256" name="honorific_prefix" type="hidden" value="">
-      {% else %}
-      <div class="form-item {% if form.honorific_prefix.errors %}form-item--errors{% endif %}">
+      {% for simple_field in personal_fields %}
+      <div class="form-item {% if simple_field.errors %}form-item--errors{% endif %}">
         <p>
-          {{ form.honorific_prefix.label_tag }}
-          {{ form.honorific_prefix }}
+          {{ simple_field.label_tag }}
+          {{ simple_field }}
         </p>
-        {{ form.honorific_prefix.errors }}
-      </div>
-      {% endif %}
-
-      <div class="form-item {% if form.name.errors %}form-item--errors{% endif %}">
-        <p>
-          {{ form.name.label_tag }}
-          {{ form.name }}
-        </p>
-        {{ form.name.errors }}
+        {{ simple_field.errors }}
       </div>
 
-      {% if settings.ELECTION_APP == 'cr' %}
-      <input id="id_honorific_suffix" maxlength="256" name="honorific_suffix" type="hidden" value="">
-      {% else %}
-      <div class="form-item {% if form.honorific_suffix.errors %}form-item--errors{% endif %}">
-        <p>
-          {{ form.honorific_suffix.label_tag }}
-          {{ form.honorific_suffix }}
-        </p>
-        {{ form.honorific_suffix.errors }}
-      </div>
-      {% endif %}
-
-      <div class="form-item {% if form.email.errors %}form-item--errors{% endif %}">
-        <p>
-          {{ form.email.label_tag }}
-          {{ form.email }}
-        </p>
-        {{ form.email.errors }}
-      </div>
+      {% endfor %}
 
       <div>
         <h2>{% trans "Constituencies:" %}</h2>
@@ -213,21 +184,16 @@
 
       <h2>{% trans "Demographics:" %}</h2>
 
-      <div class="form-item {% if form.gender.errors %}form-item--errors{% endif %}">
+      {% for simple_field in demographic_fields %}
+      <div class="form-item {% if simple_field.errors %}form-item--errors{% endif %}">
         <p>
-          {{ form.gender.label_tag }}
-          {{ form.gender }}
+          {{ simple_field.label_tag }}
+          {{ simple_field }}
         </p>
-        {{ form.gender.errors }}
+        {{ simple_field.errors }}
       </div>
 
-      <div class="form-item {% if form.birth_date.errors %}form-item--errors{% endif %}">
-        <p>
-          {{ form.birth_date.label_tag }}
-          {{ form.birth_date }}
-        </p>
-        {{ form.birth_date.errors }}
-      </div>
+      {% endfor %}
 
       {% if extra_fields %}
 

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -113,16 +113,29 @@
   <dl>
     <dt>{% trans "Name" %}</dt>
     <dd>{{ person.extra.name_with_honorifics }}</dd>
-    {% if person.other_names.exists %}
+    {% if person.other_names.exists or 'additional_name' in simple_fields and person.additional_name %}
       <dt>{% trans "Also known as" %}</dt>
+    {% endif %}
+    {% if 'additional_name' in simple_fields and person.additional_name %}
+      <dd>{{ person.additional_name }} ({% trans 'additional name' %})</dd>
     {% endif %}
     {% for other_name in person.other_names.all %}
       <dd>{{ other_name.name }}{% if other_name.note %} ({{ other_name.note }}){% endif %}</dd>
     {% endfor %}
-    <dt>{% trans "Email" %}</dt>
-    <dd>{% if person.email %}<a href="mailto:{{ person.email }}">{{ person.email }}</a>{% endif %}</dd>
+    {% if 'email' in simple_fields %}
+      <dt>{% trans "Email" %}</dt>
+      <dd>{% if person.email %}<a href="mailto:{{ person.email }}">{{ person.email }}</a>{% endif %}</dd>
+    {% endif %}
     <dt>{% trans "Party" %}</dt>
     <dd>{{ last_candidacy.on_behalf_of.name }}</dd>
+    {% if 'summary' in simple_fields %}
+      <dt>{% trans "Summary" %}</dt>
+      <dd>{% if person.summary %}{{ person.summary }}{% endif %}</dd>
+    {% endif %}
+    {% if 'biography' in simple_fields %}
+      <dt>{% trans "Biography" %}</dt>
+      <dd>{% if person.biography %}{{ person.biography }}{% endif %}</dd>
+    {% endif %}
   </dl>
 
   <h2>{% trans "Candidacies:" %}</h2>
@@ -165,38 +178,48 @@
     <dd>{% if person.extra.party_ppc_page_url %}<a rel="nofollow" href="{{ person.extra.party_ppc_page_url }}">{{ person.extra.party_ppc_page_url }}</a>{% endif %}</dd>
   </dl>
 
-  <h2>{% trans "Demographics:" %}</h2>
+  {% if has_demographics %}
+    <h2>{% trans "Demographics:" %}</h2>
 
-  <dl>
-    <dt>{% trans "Gender" %}</dt>
-    <dd>{% if person.gender %}{{ person.gender|title }}{% else %}{% trans "Unknown" %}{% endif %}</dd>
-    <dt>{% trans "Age" %}</dt>
-    {% with dob=person.birth_date %}
-      {% if dob %}
-        {% if dob|length_is:"4" %}
-          <dd>{{ person.extra.age }}
-            <small class="dob">({% blocktrans %}Year of birth: {{ dob }}{% endblocktrans %})</small>
-        {% else %}
-          <dd>{{ person.extra.age }}
-            <small class="dob">
-              {% comment %}
-                The 'S' format only gives an English ordinal suffix, so only
-                use it if the LANGUAGE is English.
-              {% endcomment %}
-              {% if LANGUAGE_CODE|slice:":2" == 'en' %}
-                ({% blocktrans with dob=person.extra.dob_as_date|date:"jS F Y" %}Date of birth: {{ dob }}
-                 {% endblocktrans %})
-              {% else %}
-                ({% blocktrans with dob=person.extra.dob_as_date|date:"j F Y" %}Date of birth: {{ dob }}
-                 {% endblocktrans %})
-              {% endif %}
-            </small>
-        {% endif %}
-      {% else %}
-        <dd>{% trans "Unknown" %}
-      {% endif %}</dd>
-    {% endwith %}
-  </dl>
+    <dl>
+      {% if 'gender' in simple_fields %}
+        <dt>{% trans "Gender" %}</dt>
+        <dd>{% if person.gender %}{{ person.gender|title }}{% else %}{% trans "Unknown" %}{% endif %}</dd>
+      {% endif %}
+      {% if 'birth_date' in simple_fields %}
+        <dt>{% trans "Age" %}</dt>
+        {% with dob=person.birth_date %}
+          {% if dob %}
+            {% if dob|length_is:"4" %}
+              <dd>{{ person.extra.age }}
+                <small class="dob">({% blocktrans %}Year of birth: {{ dob }}{% endblocktrans %})</small>
+            {% else %}
+              <dd>{{ person.extra.age }}
+                <small class="dob">
+                  {% comment %}
+                    The 'S' format only gives an English ordinal suffix, so only
+                    use it if the LANGUAGE is English.
+                  {% endcomment %}
+                  {% if LANGUAGE_CODE|slice:":2" == 'en' %}
+                    ({% blocktrans with dob=person.extra.dob_as_date|date:"jS F Y" %}Date of birth: {{ dob }}
+                     {% endblocktrans %})
+                  {% else %}
+                    ({% blocktrans with dob=person.extra.dob_as_date|date:"j F Y" %}Date of birth: {{ dob }}
+                     {% endblocktrans %})
+                  {% endif %}
+                </small>
+            {% endif %}
+          {% else %}
+            <dd>{% trans "Unknown" %}
+          {% endif %}</dd>
+        {% endwith %}
+      {% endif %}
+      {% if 'national_identity' in simple_fields %}
+        <dt>{% trans "National Identity" %}</dt>
+        <dd>{% if person.national_identity %}{{ person.national_identity }}{% endif %}</dd>
+      {% endif %}
+    </dl>
+  {% endif %}
 
   {% if extra_fields %}
     <h2>{% trans "Additional information:" %}</h2>

--- a/candidates/tests/test_simple_fields.py
+++ b/candidates/tests/test_simple_fields.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+import re
+from django.utils.six.moves.urllib_parse import urlsplit
+
+from django_webtest import WebTest
+from popolo.models import Person
+
+from candidates.models import PersonExtra, SimplePopoloField
+
+from .factories import (
+    AreaTypeFactory, PartySetFactory, ElectionFactory,
+    ParliamentaryChamberFactory
+)
+
+from .auth import TestUserMixin
+
+
+def get_next_dd(start):
+    return [t for t in start.next_siblings if t.name == 'dd'][0]
+
+
+class SimpleFieldsTests(TestUserMixin, WebTest):
+
+    def setUp(self):
+        # Standard setup (should be factored out):
+        wmc_area_type = AreaTypeFactory.create()
+        # commons = ParliamentaryChamberFactory.create()
+        # gb_parties = PartySetFactory.create(slug='gb', name='Great Britain')
+        ElectionFactory.create(
+            slug='2015',
+            name='2015 General Election',
+            area_types=(wmc_area_type,)
+        )
+
+        an_field = SimplePopoloField.objects.create(
+            name='additional_name',
+            label='Additional Name',
+            info_type_key='text',
+            order=4,
+        )
+
+        # Create one person with these fields already present:
+        self.person = Person.objects.create(
+            name="John the Well-Described",
+            additional_name="Very Well-Described"
+        )
+        PersonExtra.objects.create(base=self.person, versions='[]')
+
+    def test_create_form_has_fields(self):
+        response = self.app.get(
+            '/election/2015/person/create/',
+            user=self.user
+        )
+        self.assertEqual(response.status_code, 200)
+        an_label = response.html.find('label', {'for': 'id_additional_name'})
+        self.assertIsNotNone(an_label)
+        an_input = response.html.find('input', {'id': 'id_additional_name'})
+        self.assertIsNotNone(an_input)
+
+    def test_update_form_is_prefilled(self):
+        response = self.app.get(
+            '/person/{person_id}/update'.format(person_id=self.person.id),
+            user=self.user,
+        )
+        an_label = response.html.find('label', {'for': 'id_additional_name'})
+        self.assertIsNotNone(an_label)
+        an_input = response.html.find('input', {'id': 'id_additional_name'})
+        self.assertIsNotNone(an_input)
+        self.assertEqual(an_input.get('value'), 'Very Well-Described')
+
+    def test_fields_are_saved_when_editing(self):
+        response = self.app.get(
+            '/person/{person_id}/update'.format(person_id=self.person.id),
+            user=self.user,
+        )
+        form = response.forms['person-details']
+        form['additional_name'] = 'An extra name'
+        form['source'] = 'Testing setting simple fields'
+        submission_response = form.submit()
+
+        self.assertEqual(submission_response.status_code, 302)
+        split_location = urlsplit(submission_response.location)
+        self.assertEqual(
+            '/person/{person_id}'.format(person_id=self.person.id),
+            split_location.path
+        )
+
+        person = Person.objects.get(id=self.person.id)
+        self.assertEqual(person.additional_name, 'An extra name')
+
+    def test_fields_are_saved_when_creating(self):
+        response = self.app.get(
+            '/election/2015/person/create/',
+            user=self.user
+        )
+        form = response.forms['person-details']
+        form['name'] = 'Naomi Newperson'
+        form['additional_name'] = 'Naomi Newcomer'
+        form['standing_2015'] = 'not-standing'
+        form['source'] = 'Test creating someone with simple fields'
+        submission_response = form.submit()
+
+        self.assertEqual(submission_response.status_code, 302)
+        split_location = urlsplit(submission_response.location)
+        m = re.search(r'^/person/(.*)', split_location.path)
+        self.assertTrue(m)
+
+        person = Person.objects.get(id=m.group(1))
+        self.assertEqual(person.additional_name, 'Naomi Newcomer')
+
+    def test_view_additional_fields(self):
+        response = self.app.get(
+            '/person/{person_id}'.format(person_id=self.person.id)
+        )
+
+        an_dt = response.html.find('dt', text=u'Also known as')
+        an_dd = get_next_dd(an_dt)
+        self.assertEqual(an_dd.text.strip(), 'Very Well-Described (additional name)')

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -23,6 +23,7 @@ api_router.register(r'images', views.ImageViewSet)
 api_router.register(r'memberships', views.MembershipViewSet)
 api_router.register(r'logged_actions', views.LoggedActionViewSet)
 api_router.register(r'extra_fields', views.ExtraFieldViewSet)
+api_router.register(r'simple_fields', views.SimplePopoloFieldViewSet)
 
 urlpatterns = \
     patterns('',

--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -233,3 +233,8 @@ class LoggedActionViewSet(viewsets.ModelViewSet):
 class ExtraFieldViewSet(viewsets.ModelViewSet):
     queryset = extra_models.ExtraField.objects.order_by('id')
     serializer_class = serializers.ExtraFieldSerializer
+
+
+class SimplePopoloFieldViewSet(viewsets.ModelViewSet):
+    queryset = extra_models.SimplePopoloField.objects.order_by('id')
+    serializer_class = serializers.SimplePopoloFieldSerializer

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -140,6 +140,15 @@ class PersonView(TemplateView):
             context['elections_to_list'] = elections_by_date
         context['last_candidacy'] = self.person.extra.last_candidacy
         context['election_to_show'] = None
+        context['simple_fields'] = [
+            field.name for field in SimplePopoloField.objects.all()
+        ]
+        personal_fields, demographic_fields = get_field_groupings()
+        context['has_demographics'] = any(
+            demographic in context['simple_fields']
+            for demographic in demographic_fields
+        )
+
         if settings.ELECTION_APP == 'uk':
             context['election_to_show'] = Election.objects.get(slug='2015')
         context['extra_fields'] = get_extra_fields(self.person)

--- a/mysite/extra_translations.py
+++ b/mysite/extra_translations.py
@@ -10,3 +10,21 @@ from django.utils.translation import ugettext as _
 _('Profession')
 _('Important Roles')
 _('Standing for re-election')
+
+# Labels for the person fields which are setup in the database and it pulls
+# the label text from the database
+_('Name')
+_('Family Name')
+_('Given Name')
+_('Additional Name')
+_('Honorific Prefix')
+_('Honorific Suffix')
+_('Patronymic Name')
+_('Sort Name')
+_('Email')
+_('Gender')
+_('Birth Date')
+_('Death Date')
+_('Summary')
+_('Biography')
+_('National Identity')


### PR DESCRIPTION
This adds a table with a list of the simple PopoloFields that should be displayed on the site and then uses that list to determine which fields to display.

The set of fields is restricted to those that are part of the Popolo spec and are direct properties of the Person object.

NB: at the moment the Patronymic name isn't displayed anywhere because it's not clear how to do so.

This fixes #663 