### PR TITLE
Person page: don't show a big list of elections they're not standing in

### DIFF
--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -125,16 +125,18 @@
     <dd>{{ last_candidacy.on_behalf_of.name }}</dd>
   </dl>
 
-  <h2>{% trans "Constituencies:" %}</h2>
+  <h2>{% trans "Candidacies:" %}</h2>
 
   <dl>
-    {% for election_data in elections_by_date reversed %}
+    {% for election_data in elections_to_list %}
       <dt>{% if DATE_TODAY > election_data.election_date %}
            {% blocktrans with election_name=election_data.name %}Contested in the {{ election_name }}{% endblocktrans %}
         {% else %}
            {% blocktrans with election_name=election_data.name %}Contesting in the {{ election_name }}{% endblocktrans %}
         {% endif %}</dt>
       <dd>{{ person|post_in_election:election_data }}</dd>
+    {% empty %}
+      <p>{% trans "No candidacies known at the moment." %}</p>
     {% endfor %}
   </dl>
 

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -102,7 +102,16 @@ class PersonView(TemplateView):
         context['redirect_after_login'] = urlquote(path)
         context['canonical_url'] = self.request.build_absolute_uri(path)
         context['person'] = self.person
-        context['elections_by_date'] = Election.objects.by_date()
+        elections_by_date = Election.objects.by_date().order_by('-election_date')
+        # If there are lots of elections known to this site, don't
+        # show a big list of elections they're not standing in - just
+        # show those that they are standing in:
+        if len(elections_by_date) > 2:
+            context['elections_to_list'] = Election.objects.filter(
+                candidacies__base__person=self.person
+            ).order_by('-election_date')
+        else:
+            context['elections_to_list'] = elections_by_date
         context['last_candidacy'] = self.person.extra.last_candidacy
         context['election_to_show'] = None
         if settings.ELECTION_APP == 'uk_general_election_2015':


### PR DESCRIPTION
If there are 2 or fewer elections known to the site, it's probably
fine to show whether they're standing in both.  However, when there
are more elections, this begins to look weird - in the UK elections
in 2016, there'll just be a list of 10 or so "don't know" indications
in the "Constituencies" section.

So, this commit makes that cut-off, and if there are more than 2
elections known to the site, just shows the constituencies someone's
known to be standing in (or did stand in).

This also changes the section heading to "Candidacies" which is more
general than "Constituencies", and hopefully just as clear.

Fixes #472 