### PR TITLE
Customize complex fields

### DIFF
--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -7,7 +7,7 @@ from django.forms import ModelForm
 
 from .models import (
     LoggedAction, PartySet, ExtraField, PersonExtraFieldValue,
-    SimplePopoloField, PostExtraElection
+    SimplePopoloField, ComplexPopoloField, PostExtraElection
 )
 
 
@@ -75,3 +75,9 @@ class PostExtraElectionAdmin(admin.ModelAdmin):
     list_filter = ('election__name', 'election__current')
 
     ordering = ('election', 'postextra__base__area__name')
+
+
+@admin.register(ComplexPopoloField)
+class ComplexPopoloFieldAdmin(admin.ModelAdmin):
+    list_display = ['name', 'label', 'order']
+    ordering = ('order',)

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -15,7 +15,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
 from candidates.models import (
-    PartySet, parse_approximate_date, ExtraField, SimplePopoloField
+    PartySet, parse_approximate_date, ExtraField, SimplePopoloField, ComplexPopoloField
 )
 from popolo.models import Organization, Post
 
@@ -121,46 +121,23 @@ class BasePersonForm(forms.Form):
             else:
                 self.fields[field.name] = forms.CharField(**opts)
 
+        for field in ComplexPopoloField.objects.all():
+            opts = {
+                'label': _(field.label),
+                'required': False
+            }
+
+            if field.field_type == 'url':
+                self.fields[field.name] = forms.URLField(**opts)
+            elif field.field_type == 'email':
+                self.fields[field.name] = forms.EmailField(**opts)
+            else:
+                self.fields[field.name] = forms.CharField(**opts)
+
     STANDING_CHOICES = (
         ('not-sure', _("Don’t Know")),
         ('standing', _("Yes")),
         ('not-standing', _("No")),
-    )
-
-    wikipedia_url = forms.URLField(
-        label=_("Wikipedia URL"),
-        max_length=256,
-        required=False,
-    )
-    homepage_url = forms.URLField(
-        label=_("Homepage URL"),
-        max_length=256,
-        required=False,
-    )
-    twitter_username = forms.CharField(
-        label=_("Twitter username (e.g. “democlub”)"),
-        max_length=256,
-        required=False,
-    )
-    facebook_personal_url = forms.URLField(
-        label=_("Facebook profile URL"),
-        max_length=256,
-        required=False,
-    )
-    facebook_page_url = forms.URLField(
-        label=_("Facebook page (e.g. for their campaign)"),
-        max_length=256,
-        required=False,
-    )
-    linkedin_url = forms.URLField(
-        label=_("LinkedIn URL"),
-        max_length=256,
-        required=False,
-    )
-    party_ppc_page_url = forms.URLField(
-        label=_("The party’s candidate page for this person"),
-        max_length=256,
-        required=False,
     )
 
     def clean_birth_date(self):

--- a/candidates/migrations/0026_complexpopolofield.py
+++ b/candidates/migrations/0026_complexpopolofield.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0025_remove_old_post_to_election_m2m_and_rename_new'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ComplexPopoloField',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=256)),
+                ('label', models.CharField(help_text='User facing description of the information', max_length=256)),
+                ('popolo_array', models.CharField(help_text='Name of the Popolo related type', max_length=256, choices=[('links', 'Links'), ('contact_details', 'Contact Details'), ('identifier', 'Identifier')])),
+                ('field_type', models.CharField(help_text='Type of HTML field the user will see', max_length=256, choices=[('text', 'Text Field'), ('url', 'URL Field'), ('email', 'Email Field')])),
+                ('info_type_key', models.CharField(help_text='Name of the field in the array that stores the type (note for links, contact_type for contacts, scheme for identifiers)', max_length=100)),
+                ('info_type', models.CharField(help_text='Value to put in the info_type_key e.g. twitter', max_length=100)),
+                ('old_info_type', models.CharField(max_length=100, blank=True)),
+                ('info_value_key', models.CharField(help_text='Name of the field in the array that stores the value, e.g url for links, value for contact_type, identifier for identifiers', max_length=100)),
+                ('order', models.IntegerField(blank=True, default=0)),
+            ],
+        ),
+    ]

--- a/candidates/migrations/0027_create_standard_complex_fields.py
+++ b/candidates/migrations/0027_create_standard_complex_fields.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def remove_standard_fields(apps, schema_editor):
+    ComplexField = apps.get_model('candidates', 'ComplexPopoloField')
+    db_alias = schema_editor.connection.alias
+    ComplexField.objects.using(db_alias).all().delete()
+
+
+def create_complex_fields(apps, schema_editor):
+    ComplexField = apps.get_model('candidates', 'ComplexPopoloField')
+    db_alias = schema_editor.connection.alias
+
+    ComplexField.objects.using(db_alias).bulk_create([
+        ComplexField(
+            name='twitter_username',
+            label='Twitter username (e.g. democlub)',
+            field_type='text',
+            popolo_array='contact_details',
+            info_type_key='contact_type',
+            info_type='twitter',
+            info_value_key='value',
+            order=1,
+        ),
+        ComplexField(
+            name='facebook_personal_url',
+            label='Facebook profile URL',
+            field_type='url',
+            popolo_array='links',
+            info_type_key='note',
+            info_type='facebook personal',
+            info_value_key='url',
+            order=2,
+        ),
+        ComplexField(
+            name='facebook_page_url',
+            label='Facebook page (e.g. for their campaign)',
+            field_type='url',
+            popolo_array='links',
+            info_type_key='note',
+            info_type='facebook page',
+            info_value_key='url',
+            order=3,
+        ),
+        ComplexField(
+            name='homepage_url',
+            label='Homepage URL',
+            field_type='url',
+            popolo_array='links',
+            info_type_key='note',
+            info_type='homepage',
+            info_value_key='url',
+            order=4,
+        ),
+        ComplexField(
+            name='wikipedia_url',
+            label='Wikipedia URL',
+            field_type='url',
+            popolo_array='links',
+            info_type_key='note',
+            info_type='wikipedia',
+            info_value_key='url',
+            order=5,
+        ),
+        ComplexField(
+            name='linkedin_url',
+            label='LinkedIn URL',
+            field_type='url',
+            popolo_array='links',
+            info_type_key='note',
+            info_type='linkedin',
+            info_value_key='url',
+            order=6,
+        ),
+        ComplexField(
+            name='party_ppc_page_url',
+            label="The party's candidate page for this person",
+            field_type='url',
+            popolo_array='links',
+            info_type_key='note',
+            info_type='party candidate page',
+            old_info_type='party PPC page',
+            info_value_key='url',
+            order=7,
+        ),
+    ])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0026_complexpopolofield'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_complex_fields, remove_standard_fields),
+    ]

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -19,6 +19,7 @@ from .field_mappings import CSV_ROW_FIELDS
 from .fields import ExtraField
 from .fields import PersonExtraFieldValue
 from .fields import SimplePopoloField
+from .fields import ComplexPopoloField
 
 from .db import LoggedAction
 from .db import PersonRedirect

--- a/candidates/models/fields.py
+++ b/candidates/models/fields.py
@@ -42,6 +42,71 @@ class SimplePopoloField(models.Model):
     order = models.IntegerField(blank=True)
 
 
+class ComplexPopoloField(models.Model):
+    """
+    This model stores the name of the underlying relation, some details about
+    how it should be displayed ( label and field type ) and the details of
+    how to store the information in the generic relation.
+
+    The info_type_* properties are used to describe the key used to pull the
+    field value out of the underlying generic relation. _key being the name
+    of the field to store the value in info_type.
+
+    info_value_key is the name of the field in the underlying relation in
+    which to store the value of the complex field.
+
+    To get the value for a person you fetch the item from the generic relation
+    named in popolo_array where info_type_key matches info_type.
+    """
+    VALID_ARRAYS = (
+        ('links', 'Links'),
+        ('contact_details', 'Contact Details'),
+        ('identifier', 'Identifier'),
+    )
+
+    name = models.CharField(
+        max_length=256,
+    )
+    label = models.CharField(
+        max_length=256,
+        help_text="User facing description of the information",
+    )
+    popolo_array = models.CharField(
+        choices=VALID_ARRAYS,
+        max_length=256,
+        help_text="Name of the Popolo related type",
+    )
+
+    field_type = models.CharField(
+        choices=(
+            ('text', 'Text Field'),
+            ('url', 'URL Field'),
+            ('email', 'Email Field'),
+        ),
+        max_length=256,
+        help_text="Type of HTML field the user will see",
+    )
+    info_type_key = models.CharField(
+        max_length=100,
+        help_text="Name of the field in the array that stores the type ('note' for links, 'contact_type' for contacts, 'scheme' for identifiers)"
+    )
+    info_type = models.CharField(
+        max_length=100,
+        help_text="Value to put in the info_type_key e.g. twitter",
+    )
+    old_info_type = models.CharField(
+        max_length=100,
+        blank=True,
+        help_text="Used for supporting info_types that have been renamed. As such it's rarely used."
+    )
+    info_value_key = models.CharField(
+        max_length=100,
+        help_text="Name of the field in the array that stores the value, e.g 'url' for links, 'value' for contact_type, 'identifier' for identifiers",
+    )
+
+    order = models.IntegerField(blank=True, default=0)
+
+
 @python_2_unicode_compatible
 class ExtraField(models.Model):
 

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -25,9 +25,9 @@ from images.models import Image, HasImageMixin
 
 from compat import python_2_unicode_compatible
 from .field_mappings import (
-    form_simple_fields, form_complex_fields_locations
+    form_complex_fields_locations
 )
-from .fields import ExtraField, PersonExtraFieldValue, SimplePopoloField
+from .fields import ExtraField, PersonExtraFieldValue, SimplePopoloField, ComplexPopoloField
 from ..diffs import get_version_diffs
 from .versions import get_person_as_version_data
 
@@ -52,8 +52,8 @@ def update_person_from_form(person, person_extra, form):
         form_data['birth_date'] = ''
     for field in SimplePopoloField.objects.all():
         setattr(person, field.name, form_data[field.name])
-    for field_name, location in form_complex_fields_locations.items():
-        person_extra.update_complex_field(location, form_data[field_name])
+    for field in ComplexPopoloField.objects.all():
+        person_extra.update_complex_field(field, form_data[field.name])
     for extra_field in ExtraField.objects.all():
         if extra_field.key in form_data:
             PersonExtraFieldValue.objects.update_or_create(
@@ -178,16 +178,17 @@ class PersonExtra(HasImageMixin, models.Model):
     images = GenericRelation(Image)
 
     def __getattr__(self, name):
-        if name in form_complex_fields_locations:
-            loc = form_complex_fields_locations[name]
+        # TODO: this does not seem optimal
+        field = ComplexPopoloField.objects.filter(name=name).first()
+        if field:
             # Iterate rather than using filter because that would
             # cause an extra query when the relation has already been
             # populated via select_related:
-            for e in getattr(self.base, loc['sub_array']).all():
-                info_type_key = getattr(e, loc['info_type_key'])
-                if (info_type_key == loc['info_type']) or \
-                   (info_type_key == loc.get('old_info_type')):
-                    return getattr(e, loc['info_value_key'])
+            for e in getattr(self.base, field.popolo_array).all():
+                info_type_key = getattr(e, field.info_type_key)
+                if (info_type_key == field.info_type) or \
+                   (info_type_key == field.old_info_type):
+                    return getattr(e, field.info_value_key)
             return ''
         else:
             message = _("'PersonExtra' object has no attribute '{name}'")
@@ -327,19 +328,19 @@ class PersonExtra(HasImageMixin, models.Model):
         self.versions = json.dumps(versions)
 
     def update_complex_field(self, location, new_value):
-        existing_info_types = [location['info_type']]
-        if 'old_info_type' in location:
-            existing_info_types.append(location['old_info_type'])
-        related_manager = getattr(self.base, location['sub_array'])
+        existing_info_types = [location.info_type]
+        if location.old_info_type:
+            existing_info_types.append(location.old_info_type)
+        related_manager = getattr(self.base, location.popolo_array)
         # Remove the old entries of that type:
         kwargs = {
-            (location['info_type_key'] + '__in'): existing_info_types
+            (location.info_type_key + '__in'): existing_info_types
         }
         related_manager.filter(**kwargs).delete()
         if new_value:
             kwargs = {
-                location['info_type_key']: location['info_type'],
-                location['info_value_key']: new_value,
+                location.info_type_key: location.info_type,
+                location.info_value_key: new_value,
             }
             related_manager.create(**kwargs)
 
@@ -347,8 +348,8 @@ class PersonExtra(HasImageMixin, models.Model):
         initial_data = {}
         for field in SimplePopoloField.objects.all():
             initial_data[field.name] = getattr(self.base, field.name)
-        for field_name in form_complex_fields_locations.keys():
-            initial_data[field_name] = getattr(self, field_name)
+        for field in ComplexPopoloField.objects.all():
+            initial_data[field.name] = getattr(self, field.name)
         for extra_field_value in PersonExtraFieldValue.objects.filter(
                 person=self.base
         ).select_related('field'):

--- a/candidates/models/versions.py
+++ b/candidates/models/versions.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
-from .fields import ExtraField, SimplePopoloField
-from .field_mappings import form_simple_fields, form_complex_fields_locations
+from .fields import ExtraField, SimplePopoloField, ComplexPopoloField
 
 from django.db.models import F
 
@@ -15,8 +14,8 @@ def get_person_as_version_data(person):
     result['id'] = str(person.id)
     for field in SimplePopoloField.objects.all():
         result[field.name] = getattr(person, field.name) or ''
-    for field in form_complex_fields_locations:
-        result[field] = getattr(person_extra, field)
+    for field in ComplexPopoloField.objects.all():
+        result[field.name] = getattr(person_extra, field.name)
     extra_values = {
         extra_value.field.key: extra_value.value
         for extra_value in person.extra_field_values.select_related('field')
@@ -90,16 +89,16 @@ def revert_person_from_version_data(person, person_extra, version_data):
             setattr(person, field.name, '')
 
     # Remove any old values in complex fields:
-    for location in form_complex_fields_locations.values():
-        related_manager = getattr(person, location['sub_array'])
-        type_kwargs = {location['info_type_key']: location['info_type']}
+    for field in ComplexPopoloField.objects.all():
+        related_manager = getattr(person, field.popolo_array)
+        type_kwargs = {field.info_type_key: field.info_type}
         related_manager.filter(**type_kwargs).delete()
 
     # Then recreate any that should be there:
-    for field, location in form_complex_fields_locations.items():
-        new_value = version_data.get(field, '')
+    for field in ComplexPopoloField.objects.all():
+        new_value = version_data.get(field.name, '')
         if new_value:
-            person_extra.update_complex_field(location, version_data[field])
+            person_extra.update_complex_field(field, version_data[field.name])
 
     # Remove any extra field data and create them from the JSON:
     person.extra_field_values.all().delete()

--- a/candidates/templates/candidates/_person_form.html
+++ b/candidates/templates/candidates/_person_form.html
@@ -89,66 +89,30 @@
 
     <h2>{% trans "Links and social media:" %}</h2>
 
-    <div class="form-item {% if form.twitter_username.errors %}form-item--errors{% endif %}">
-      {{ form.twitter_username.label_tag }}
-      <div class="row collapse">
-        <div class="small-1 columns">
-          <span class="prefix">@</span>
+    {% for field_info, tag in complex_fields %}
+      {% if field_info.info_type == 'twitter' %}
+        <div class="form-item {% if tag.errors %}form-item--errors{% endif %}">
+          {{ tag.label_tag }}
+          <div class="row collapse">
+            <div class="small-1 columns">
+              <span class="prefix">@</span>
+            </div>
+            <div class="small-11 columns">
+              {{ tag }}
+            </div>
+          </div>
+          {{ tag.errors }}
         </div>
-        <div class="small-11 columns">
-          {{ form.twitter_username }}
+      {% else %}
+        <div class="form-item {% if tag.errors %}form-item--errors{% endif %}">
+          <p>
+            {{ tag.label_tag }}
+            {{ tag }}
+          </p>
+          {{ tag.errors }}
         </div>
-      </div>
-      {{ form.twitter_username.errors }}
-    </div>
-
-    <div class="form-item {% if form.facebook_personal_url.errors %}form-item--errors{% endif %}">
-      <p>
-        {{ form.facebook_personal_url.label_tag }}
-        {{ form.facebook_personal_url }}
-      </p>
-      {{ form.facebook_personal_url.errors }}
-    </div>
-
-    <div class="form-item {% if form.facebook_page_url.errors %}form-item--errors{% endif %}">
-      <p>
-        {{ form.facebook_page_url.label_tag }}
-        {{ form.facebook_page_url }}
-      </p>
-      {{ form.facebook_page_url.errors }}
-    </div>
-
-    <div class="form-item {% if form.homepage_url.errors %}form-item--errors{% endif %}">
-      <p>
-        {{ form.homepage_url.label_tag }}
-        {{ form.homepage_url }}
-      </p>
-      {{ form.homepage_url.errors }}
-    </div>
-
-    <div class="form-item {% if form.wikipedia_url.errors %}form-item--errors{% endif %}">
-      <p>
-        {{ form.wikipedia_url.label_tag }}
-        {{ form.wikipedia_url }}
-      </p>
-      {{ form.wikipedia_url.errors }}
-    </div>
-
-    <div class="form-item {% if form.linkedin_url.errors %}form-item--errors{% endif %}">
-      <p>
-        {{ form.linkedin_url.label_tag }}
-        {{ form.linkedin_url }}
-      </p>
-      {{ form.linkedin_url.errors }}
-    </div>
-
-    <div class="form-item {% if form.party_ppc_page_url.errors %}form-item--errors{% endif %}">
-      <p>
-        {{ form.party_ppc_page_url.label_tag }}
-        {{ form.party_ppc_page_url }}
-      </p>
-      {{ form.party_ppc_page_url.errors }}
-    </div>
+      {% endif %}
+    {% endfor %}
 
     <h2>{% trans "Demographics:" %}</h2>
 

--- a/candidates/templates/candidates/areas.html
+++ b/candidates/templates/candidates/areas.html
@@ -17,7 +17,7 @@
 
   {% for post in posts %}
 
-    {% with election=post.election election_data=post.election_data candidate_list_edits_allowed=post.candidate_list_edits_allowed candidates_locked=post.candidates_locked post_data=post.post_data add_candidate_form=post.add_candidate_form candidacies=post.candidacies personal_fields=post.personal_fields demographic_fields=post.demographic_fields extra_fields=post.extra_fields constituencies_form_fields=post.constituencies_form_fields %}
+    {% with election=post.election election_data=post.election_data candidate_list_edits_allowed=post.candidate_list_edits_allowed candidates_locked=post.candidates_locked post_data=post.post_data add_candidate_form=post.add_candidate_form candidacies=post.candidacies personal_fields=post.personal_fields demographic_fields=post.demographic_fields complex_fields=post.complex_fields extra_fields=post.extra_fields constituencies_form_fields=post.constituencies_form_fields %}
 
       <h2>{{ election_data.name }}</h2>
 

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -156,26 +156,16 @@
   <h2>{% trans "Links and social media:" %}</h2>
 
   <dl>
-    <dt>Twitter</dt>
-    <dd>{% if person.extra.twitter_username %}<a rel="nofollow" href="https://twitter.com/{{ person.extra.twitter_username }}">@{{ person.extra.twitter_username }}</a>{% endif %}</dd>
-    <dt>Facebook</dt>
-    {% if person.extra.facebook_personal_url %}
-      <dd><a rel="nofollow" href="{{ person.extra.facebook_personal_url }}">{{ person.extra.facebook_personal_url }}</a> <small>{% trans "(personal profile)" %}</small></dd>
-    {% endif %}
-    {% if person.extra.facebook_page_url %}
-      <dd><a rel="nofollow" href="{{ person.extra.facebook_page_url }}">{{ person.extra.facebook_page_url }}</a> <small>{% trans "(campaign page)" %}</small></dd>
-    {% endif %}
-    {% if not person.extra.facebook_personal_url and not person.extra.facebook_page_url %}
-      <dd></dd>
-    {% endif %}
-    <dt>{% trans "Homepage" %}</dt>
-    <dd>{% if person.extra.homepage_url %}<a rel="nofollow" href="{{ person.extra.homepage_url }}">{{ person.extra.homepage_url }}</a>{% endif %}</dd>
-    <dt>{% trans "Wikipedia page" %}</dt>
-    <dd>{% if person.extra.wikipedia_url %}<a rel="nofollow" href="{{ person.extra.wikipedia_url }}">{{ person.extra.wikipedia_url }}</a>{% endif %}</dd>
-    <dt>{% trans "LinkedIn page" %}</dt>
-    <dd>{% if person.extra.linkedin_url %}<a rel="nofollow" href="{{ person.extra.linkedin_url }}">{{ person.extra.linkedin_url }}</a>{% endif %}</dd>
-    <dt>{% trans "Party candidate page" %}</dt>
-    <dd>{% if person.extra.party_ppc_page_url %}<a rel="nofollow" href="{{ person.extra.party_ppc_page_url }}">{{ person.extra.party_ppc_page_url }}</a>{% endif %}</dd>
+    {% for field, value in complex_fields %}
+        <dt>{{ field.label }}</dt>
+      {% if field.info_type == 'twitter' %}
+        <dd>{% if value %}<a rel="nofollow" href="https://twitter.com/{{ value }}">@{{ value }}</a>{% endif %}</dd>
+      {% elif field.field_type == 'url' %}
+        <dd>{% if value %}<a rel="nofollow" href="{{ value }}">{{ value }}</a>{% endif %}</dd>
+      {% else %}
+        <dd>{{ value }}</dt>
+      {% endif %}
+    {% endfor %}
   </dl>
 
   {% if has_demographics %}

--- a/candidates/tests/test_areas_view.py
+++ b/candidates/tests/test_areas_view.py
@@ -357,6 +357,26 @@ class TestAreasView(TestUserMixin, WebTest):
             )
         )
 
+        # make sure we've got the complex fields
+        self.assertTrue(
+            response.html.find(
+                'input', {'id': 'id_twitter_username'}
+            )
+        )
+
+        # make sure we've got the simple personal fields
+        self.assertTrue(
+            response.html.find(
+                'input', {'id': 'id_name'}
+            )
+        )
+
+        # make sure we've got the simple demographic fields
+        self.assertTrue(
+            response.html.find(
+                'input', {'id': 'id_gender'}
+            )
+        )
 
     def test_get_malformed_url(self):
         response = self.app.get(

--- a/candidates/tests/test_complex_fields.py
+++ b/candidates/tests/test_complex_fields.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+import re
+from django.utils.six.moves.urllib_parse import urlsplit
+
+from django_webtest import WebTest
+from popolo.models import Person
+
+from candidates.models import PersonExtra, ComplexPopoloField
+
+from .factories import (
+    AreaTypeFactory, PartySetFactory, ElectionFactory,
+    ParliamentaryChamberFactory
+)
+
+from .auth import TestUserMixin
+
+
+def get_next_dd(start):
+    return [t for t in start.next_siblings if t.name == 'dd'][0]
+
+
+class ComplexFieldsTests(TestUserMixin, WebTest):
+
+    def setUp(self):
+        # Standard setup (should be factored out):
+        wmc_area_type = AreaTypeFactory.create()
+        # commons = ParliamentaryChamberFactory.create()
+        # gb_parties = PartySetFactory.create(slug='gb', name='Great Britain')
+        ElectionFactory.create(
+            slug='2015',
+            name='2015 General Election',
+            area_types=(wmc_area_type,)
+        )
+
+        an_field = ComplexPopoloField.objects.create(
+            name='additional_link',
+            label='Additional Link',
+            popolo_array='links',
+            field_type='url',
+            info_type_key='note',
+            info_type='additional_link',
+            info_value_key='url',
+            order=0,
+        )
+
+        # Create one person with these fields already present:
+        self.person = Person.objects.create(
+            name="John the Well-Described",
+        )
+        self.person_extra = PersonExtra.objects.create(base=self.person, versions='[]')
+        self.person_extra.update_complex_field(an_field, 'http://example.com/additional')
+
+    def test_create_form_has_fields(self):
+        response = self.app.get(
+            '/election/2015/person/create/',
+            user=self.user
+        )
+        self.assertEqual(response.status_code, 200)
+        an_label = response.html.find('label', {'for': 'id_additional_link'})
+        self.assertIsNotNone(an_label)
+        an_input = response.html.find('input', {'id': 'id_additional_link'})
+        self.assertIsNotNone(an_input)
+
+    def test_update_form_is_prefilled(self):
+        response = self.app.get(
+            '/person/{person_id}/update'.format(person_id=self.person.id),
+            user=self.user,
+        )
+        an_label = response.html.find('label', {'for': 'id_additional_link'})
+        self.assertIsNotNone(an_label)
+        an_input = response.html.find('input', {'id': 'id_additional_link'})
+        self.assertIsNotNone(an_input)
+        self.assertEqual(an_input.get('value'), 'http://example.com/additional')
+
+    def test_fields_are_saved_when_editing(self):
+        response = self.app.get(
+            '/person/{person_id}/update'.format(person_id=self.person.id),
+            user=self.user,
+        )
+        form = response.forms['person-details']
+        form['additional_link'] = 'http://example.com/anotherlink'
+        form['source'] = 'Testing setting complex fields'
+        submission_response = form.submit()
+
+        self.assertEqual(submission_response.status_code, 302)
+        split_location = urlsplit(submission_response.location)
+        self.assertEqual(
+            '/person/{person_id}'.format(person_id=self.person.id),
+            split_location.path
+        )
+
+        person = Person.objects.get(id=self.person.id)
+        self.assertEqual(person.extra.additional_link, 'http://example.com/anotherlink')
+
+    def test_fields_are_saved_when_creating(self):
+        response = self.app.get(
+            '/election/2015/person/create/',
+            user=self.user
+        )
+        form = response.forms['new-candidate-form']
+        form['name'] = 'Naomi Newperson'
+        form['additional_link'] = 'http://example.com/morelink'
+        form['standing_2015'] = 'not-standing'
+        form['source'] = 'Test creating someone with simple fields'
+        submission_response = form.submit()
+
+        self.assertEqual(submission_response.status_code, 302)
+        split_location = urlsplit(submission_response.location)
+        m = re.search(r'^/person/(.*)', split_location.path)
+        self.assertTrue(m)
+
+        person = Person.objects.get(id=m.group(1))
+        self.assertEqual(person.extra.additional_link, 'http://example.com/morelink')
+
+    def test_view_additional_fields(self):
+        response = self.app.get(
+            '/person/{person_id}'.format(person_id=self.person.id)
+        )
+
+        an_dt = response.html.find('dt', text=u'Additional Link')
+        an_dd = get_next_dd(an_dt)
+        self.assertEqual(an_dd.text.strip(), 'http://example.com/additional')

--- a/candidates/tests/test_new_person_view.py
+++ b/candidates/tests/test_new_person_view.py
@@ -64,6 +64,28 @@ class TestNewPersonView(TestUserMixin, WebTest):
             '/election/2015/post/65808/dulwich-and-west-norwood',
             user=self.user,
         )
+
+        # make sure we've got the complex fields
+        self.assertTrue(
+            response.html.find(
+                'input', {'id': 'id_twitter_username'}
+            )
+        )
+
+        # make sure we've got the simple personal fields
+        self.assertTrue(
+            response.html.find(
+                'input', {'id': 'id_name'}
+            )
+        )
+
+        # make sure we've got the simple demographic fields
+        self.assertTrue(
+            response.html.find(
+                'input', {'id': 'id_gender'}
+            )
+        )
+
         form = response.forms['new-candidate-form']
         form['name'] = 'Elizabeth Bennet'
         form['email'] = 'lizzie@example.com'

--- a/candidates/views/helpers.py
+++ b/candidates/views/helpers.py
@@ -10,7 +10,8 @@ from elections.models import Election
 from slugify import slugify
 
 from ..models import (
-    MembershipExtra, PartySet, SimplePopoloField, ExtraField
+    MembershipExtra, PartySet, SimplePopoloField, ExtraField,
+    ComplexPopoloField
 )
 
 
@@ -61,6 +62,11 @@ def get_person_form_fields(context, form):
         context['extra_fields'].append(
             form[field.key]
         )
+
+    context['complex_fields'] = []
+    complex_fields = ComplexPopoloField.objects.order_by('order').all()
+    for field in complex_fields:
+        context['complex_fields'].append((field, form[field.name]))
 
     personal_fields, demographic_fields = get_field_groupings()
     context['personal_fields'] = []

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -38,7 +38,7 @@ from ..models.versions import (
 )
 from ..models import (
     PersonExtra, merge_popit_people, ExtraField, PersonExtraFieldValue,
-    SimplePopoloField
+    SimplePopoloField, ComplexPopoloField
 )
 from .helpers import (
     get_field_groupings, get_person_form_fields
@@ -128,6 +128,10 @@ class PersonView(TemplateView):
             demographic in context['simple_fields']
             for demographic in demographic_fields
         )
+        context['complex_fields'] = [
+            (field, getattr(self.person.extra, field.name))
+            for field in ComplexPopoloField.objects.all()
+        ]
 
         context['extra_fields'] = get_extra_fields(self.person)
         return context


### PR DESCRIPTION
This allows people to add custom fields based on contact details and links where the underlying data is stored in a related table and not as a direct property of the person.

The setup of them does require knowing what you are doing but there are hints in the admin interface to make it a bit easier.

It also has a migration to set up the standard fields that all existing YNR install have.

Fixes #683