### PR TITLE
Customize winner count per post

### DIFF
--- a/cached_counts/models.py
+++ b/cached_counts/models.py
@@ -15,7 +15,7 @@ def get_attention_needed_posts(max_results=None, random=False):
 SELECT pe.slug, p.label, ee.name, ee.slug, count(m.id) as count
   FROM popolo_post p
     INNER JOIN candidates_postextra pe ON pe.base_id = p.id
-    INNER JOIN candidates_postextra_elections cppee ON cppee.postextra_id = pe.id
+    INNER JOIN candidates_postextraelection cppee ON cppee.postextra_id = pe.id
     INNER JOIN elections_election ee ON cppee.election_id = ee.id
     LEFT OUTER JOIN
       (popolo_membership m

--- a/cached_counts/views.py
+++ b/cached_counts/views.py
@@ -152,7 +152,7 @@ class ConstituencyCountsView(ElectionMixin, TemplateView):
 SELECT pe.slug, p.label, count(m.id) as count
   FROM popolo_post p
     INNER JOIN candidates_postextra pe ON pe.base_id = p.id
-    INNER JOIN candidates_postextra_elections cppee ON cppee.postextra_id = pe.id
+    INNER JOIN candidates_postextraelection cppee ON cppee.postextra_id = pe.id
     INNER JOIN elections_election ee ON cppee.election_id = ee.id AND ee.id = %s
     LEFT OUTER JOIN
       (popolo_membership m

--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -13,6 +13,7 @@ class LoggedActionAdminForm(ModelForm):
     pass
 
 
+@admin.register(LoggedAction)
 class LoggedActionAdmin(admin.ModelAdmin):
     form = LoggedActionAdminForm
     search_fields = ('user__username', 'popit_person_new_version',
@@ -38,6 +39,7 @@ class PartySetAdminForm(ModelForm):
     pass
 
 
+@admin.register(PartySet)
 class PartySetAdmin(admin.ModelAdmin):
     form = PartySetAdminForm
 
@@ -46,6 +48,7 @@ class ExtraFieldAdminForm(ModelForm):
     pass
 
 
+@admin.register(ExtraField)
 class ExtraFieldAdmin(admin.ModelAdmin):
     form = ExtraFieldAdminForm
 
@@ -54,16 +57,11 @@ class PersonExtraFieldValueAdminForm(ModelForm):
     pass
 
 
+@admin.register(PersonExtraFieldValue)
 class PersonExtraFieldValueAdmin(admin.ModelAdmin):
     form = PersonExtraFieldValueAdminForm
 
 
+@admin.register(SimplePopoloField)
 class SimplePopoloFieldAdmin(admin.ModelAdmin):
     list_display = ['name', 'label']
-
-
-admin.site.register(LoggedAction, LoggedActionAdmin)
-admin.site.register(PartySet, PartySetAdmin)
-admin.site.register(ExtraField, ExtraFieldAdmin)
-admin.site.register(PersonExtraFieldValue, PersonExtraFieldValueAdmin)
-admin.site.register(SimplePopoloField, SimplePopoloFieldAdmin)

--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -5,8 +5,10 @@ from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.forms import ModelForm
 
-from .models import LoggedAction, PartySet, ExtraField, PersonExtraFieldValue, SimplePopoloField
-# Register your models here.
+from .models import (
+    LoggedAction, PartySet, ExtraField, PersonExtraFieldValue,
+    SimplePopoloField, PostExtraElection
+)
 
 
 class LoggedActionAdminForm(ModelForm):
@@ -65,3 +67,11 @@ class PersonExtraFieldValueAdmin(admin.ModelAdmin):
 @admin.register(SimplePopoloField)
 class SimplePopoloFieldAdmin(admin.ModelAdmin):
     list_display = ['name', 'label']
+
+
+@admin.register(PostExtraElection)
+class PostExtraElectionAdmin(admin.ModelAdmin):
+    list_display = ['postextra', 'election', 'winner_count']
+    list_filter = ('election__name', 'election__current')
+
+    ordering = ('election', 'postextra__base__area__name')

--- a/candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py
+++ b/candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py
@@ -10,7 +10,7 @@ from optparse import make_option
 import requests
 
 from popolo.models import Post, Area
-from candidates.models import PostExtra, AreaExtra, PartySet
+from candidates.models import PostExtra, AreaExtra, PartySet, PostExtraElection
 from elections.models import Election, AreaType
 
 
@@ -134,4 +134,7 @@ in the Election objects in the app.
                     defaults={'party_set': party_set},
                 )
 
-                post_extra.elections.add(election)
+                PostExtraElection.objects.get_or_create(
+                    postextra=post_extra,
+                    election=election,
+                )

--- a/candidates/management/commands/candidates_import_from_live_site.py
+++ b/candidates/management/commands/candidates_import_from_live_site.py
@@ -305,7 +305,10 @@ class Command(BaseCommand):
                 for election_data in post_data['elections']:
                     election = \
                         emodels.Election.objects.get(slug=election_data['id'])
-                    pe.elections.add(election)
+                    models.PostExtraElection.get_or_create(
+                        postextra=pe,
+                        election=election
+                    )
         extra_fields = {
             ef.key: ef for ef in models.ExtraField.objects.all()
         }

--- a/candidates/migrations/0023_create_post_to_elections_m2m_with_extra_fields.py
+++ b/candidates/migrations/0023_create_post_to_elections_m2m_with_extra_fields.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('elections', '0012_election_people_elected_per_post'),
+        ('candidates', '0022_create_standard_simple_fields'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PostExtraElection',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('winner_count', models.IntegerField(null=True, blank=True)),
+                ('election', models.ForeignKey(to='elections.Election')),
+                ('postextra', models.ForeignKey(to='candidates.PostExtra')),
+            ],
+        ),
+        migrations.AddField(
+            model_name='postextra',
+            name='new_elections',
+            field=models.ManyToManyField(related_name='new_posts', through='candidates.PostExtraElection', to='elections.Election'),
+        ),
+    ]

--- a/candidates/migrations/0024_port_existing_post_to_election_m2m_data.py
+++ b/candidates/migrations/0024_port_existing_post_to_election_m2m_data.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def old_post_election_m2m_to_new(apps, schema_editor):
+    PostExtraElection = apps.get_model('candidates', 'PostExtraElection')
+    PostExtra = apps.get_model('candidates', 'PostExtra')
+    for post in PostExtra.objects.all():
+        for election in post.elections.all():
+            PostExtraElection.objects.get_or_create(
+                postextra=post,
+                election=election
+            )
+
+
+def new_post_election_m2m_to_old(apps, schema_editor):
+    PostExtra = apps.get_model('candidates', 'PostExtra')
+
+    for post in PostExtra.objects.all():
+        for election in post.new_elections.all():
+            post.elections.add(election)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0023_create_post_to_elections_m2m_with_extra_fields'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            old_post_election_m2m_to_new,
+            new_post_election_m2m_to_old
+        )
+    ]

--- a/candidates/migrations/0025_remove_old_post_to_election_m2m_and_rename_new.py
+++ b/candidates/migrations/0025_remove_old_post_to_election_m2m_and_rename_new.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0024_port_existing_post_to_election_m2m_data'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='postextra',
+            name='elections',
+        ),
+        migrations.RenameField('PostExtra', 'new_elections', 'elections'),
+        migrations.AlterField(
+            model_name='postextra',
+            name='elections',
+            field=models.ManyToManyField(related_name='posts', through='candidates.PostExtraElection', to='elections.Election'),
+        ),
+    ]

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -12,6 +12,7 @@ from .popolo_extra import MembershipExtra
 from .popolo_extra import PartySet
 from .popolo_extra import ImageExtra
 from .popolo_extra import parse_approximate_date
+from .popolo_extra import PostExtraElection
 
 from .field_mappings import CSV_ROW_FIELDS
 

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -518,6 +518,11 @@ class PostExtra(HasImageMixin, models.Model):
 
     candidates_locked = models.BooleanField(default=False)
     elections = models.ManyToManyField(Election, related_name='posts')
+    new_elections = models.ManyToManyField(
+        Election,
+        related_name='new_posts',
+        through='PostExtraElection'
+    )
     group = models.CharField(max_length=1024, blank=True)
     party_set = models.ForeignKey('PartySet', blank=True, null=True)
 
@@ -531,6 +536,13 @@ class PostExtra(HasImageMixin, models.Model):
     def short_label(self):
         from candidates.election_specific import shorten_post_label
         return shorten_post_label(self.base.label)
+
+
+class PostExtraElection(models.Model):
+    postextra = models.ForeignKey(PostExtra)
+    election = models.ForeignKey(Election)
+
+    winner_count = models.IntegerField(blank=True, null=True)
 
 
 class MembershipExtra(models.Model):

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -517,10 +517,9 @@ class PostExtra(HasImageMixin, models.Model):
     slug = models.CharField(max_length=256, blank=True, unique=True)
 
     candidates_locked = models.BooleanField(default=False)
-    elections = models.ManyToManyField(Election, related_name='posts')
-    new_elections = models.ManyToManyField(
+    elections = models.ManyToManyField(
         Election,
-        related_name='new_posts',
+        related_name='posts',
         through='PostExtraElection'
     )
     group = models.CharField(max_length=1024, blank=True)

--- a/candidates/tests/factories.py
+++ b/candidates/tests/factories.py
@@ -145,6 +145,12 @@ class PostFactory(factory.DjangoModelFactory):
     role = 'Member of Parliament'
 
 
+class PostExtraElectionFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = 'candidates.PostExtraElection'
+
+
 class PostExtraFactory(factory.DjangoModelFactory):
 
     class Meta:
@@ -159,7 +165,10 @@ class PostExtraFactory(factory.DjangoModelFactory):
             return
         if extracted:
             for election in extracted:
-                self.elections.add(election)
+                PostExtraElectionFactory.create(
+                    postextra=self,
+                    election=election
+                )
 
 
 EXAMPLE_PARTIES = [

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -29,12 +29,26 @@ from ..forms import NewPersonForm, ToggleLockForm, ConstituencyRecordWinnerForm
 from ..models import (
     TRUSTED_TO_LOCK_GROUP_NAME, get_edits_allowed,
     RESULT_RECORDERS_GROUP_NAME, LoggedAction, PostExtra, OrganizationExtra,
-    MembershipExtra, PartySet, SimplePopoloField, ExtraField
+    MembershipExtra, PartySet, PostExtraElection
 )
 from official_documents.models import OfficialDocument
 from results.models import ResultEvent
 
 from popolo.models import Membership, Post, Organization, Person
+
+
+def get_max_winners(post, election):
+    max_winners = election.people_elected_per_post
+    post_extra_election = PostExtraElection.objects.filter(
+        postextra__base=post,
+        election=election,
+        winner_count__isnull=False,
+    ).first()
+    if post_extra_election:
+        max_winners = post_extra_election.winner_count
+
+    return max_winners
+
 
 class ConstituencyDetailView(ElectionMixin, TemplateView):
     template_name = 'candidates/constituency.html'
@@ -159,7 +173,7 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
             if c.extra.elected is not None:
                 context['show_retract_result'] = True
 
-        max_winners = self.election_data.people_elected_per_post
+        max_winners = get_max_winners(mp_post, self.election_data)
         context['show_confirm_result'] = (max_winners < 0) \
             or number_of_winners < max_winners
 
@@ -339,7 +353,7 @@ class ConstituencyRecordWinnerView(ElectionMixin, GroupRequiredMixin, FormView):
                 extra__elected=True,
                 extra__election=self.election_data
             ).count()
-            max_winners = self.election_data.people_elected_per_post
+            max_winners = get_max_winners(self.post_data, self.election_data)
             if max_winners >= 0 and number_of_existing_winners >= max_winners:
                 msg = "There were already {n} winners of {post_label}" \
                     "and the maximum in election {election_name} is {max}"

--- a/elections/cr/management/commands/cr_create_basic_site.py
+++ b/elections/cr/management/commands/cr_create_basic_site.py
@@ -8,7 +8,7 @@ from django.db import transaction
 from django.utils.text import slugify
 
 from candidates.models import (
-    AreaExtra, OrganizationExtra, PostExtra, PartySet
+    AreaExtra, OrganizationExtra, PostExtra, PartySet, PostExtraElection
 )
 from elections.models import AreaType, Election
 from popolo.models import Area, Organization, Post
@@ -132,4 +132,7 @@ class Command(BaseCommand):
                     post_extra.party_set = party_set
                     post_extra.save()
                     post_extra.elections.clear()
-                    post_extra.elections.add(election)
+                    PostExtraElection.objects.create(
+                        postextra=post_extra,
+                        election=election,
+                    )

--- a/elections/jamaica/management/commands/jamaica_create_basic_site.py
+++ b/elections/jamaica/management/commands/jamaica_create_basic_site.py
@@ -7,7 +7,7 @@ from django.db import transaction
 from django.utils.text import slugify
 
 from candidates.models import (
-    AreaExtra, OrganizationExtra, PostExtra, PartySet
+    AreaExtra, OrganizationExtra, PostExtra, PartySet, PostExtraElection
 )
 from elections.models import AreaType, Election
 from popolo.models import Area, Organization, Post
@@ -215,4 +215,7 @@ class Command(BaseCommand):
                     post_extra.party_set = party_set
                     post_extra.save()
                     post_extra.elections.clear()
-                    post_extra.elections.add(election)
+                    PostExtraElection.objects.create(
+                        postextra=post_extra,
+                        election=election,
+                    )

--- a/elections/uk/management/commands/uk_create_mayoral_posts.py
+++ b/elections/uk/management/commands/uk_create_mayoral_posts.py
@@ -4,7 +4,9 @@ from datetime import date
 
 from django.core.management.base import BaseCommand
 
-from candidates.models import AreaExtra, OrganizationExtra, PartySet, PostExtra
+from candidates.models import (
+    AreaExtra, OrganizationExtra, PartySet, PostExtra, PostExtraElection
+)
 from elections.models import AreaType, Election
 from popolo.models import Area, Organization, Post
 
@@ -152,4 +154,7 @@ class Command(BaseCommand):
                 'party_set': self.gb_parties,
             },
         )
-        post_extra.elections.add(election['election_object'])
+        PostExtraElection.objects.update_or_create(
+            postextra=post_extra,
+            election=election['election_object'],
+        )

--- a/elections/uk/management/commands/uk_create_pcc_posts.py
+++ b/elections/uk/management/commands/uk_create_pcc_posts.py
@@ -10,7 +10,9 @@ from django.utils.text import slugify
 
 import requests
 
-from candidates.models import AreaExtra, OrganizationExtra, PartySet, PostExtra
+from candidates.models import (
+    AreaExtra, OrganizationExtra, PartySet, PostExtra
+)
 from elections.models import AreaType, Election
 from elections.uk import mapit
 from popolo.models import Area, Organization, Post
@@ -154,4 +156,7 @@ class Command(BaseCommand):
                 'party_set': self.gb_parties,
             },
         )
-        post_extra.elections.add(self.election)
+        PostExtra.objects.update_or_create(
+            postextra=post_extra,
+            election=self.election,
+        )

--- a/elections/uk/management/commands/uk_create_regional_assembly_posts.py
+++ b/elections/uk/management/commands/uk_create_regional_assembly_posts.py
@@ -8,7 +8,9 @@ from django.utils.six.moves.urllib_parse import urljoin
 
 import requests
 
-from candidates.models import AreaExtra, OrganizationExtra, PartySet, PostExtra
+from candidates.models import (
+    AreaExtra, OrganizationExtra, PartySet, PostExtra, PostExtraElection
+)
 from elections.models import AreaType, Election
 from elections.uk import mapit
 from popolo.models import Area, Organization, Post
@@ -190,4 +192,7 @@ class Command(BaseCommand):
                         'party_set': gb_parties,
                     },
                 )
-                post_extra.elections.add(election)
+                PostExtraElection.objects.update_or_create(
+                    postextra=post_extra,
+                    election=election
+                )


### PR DESCRIPTION
Allow the number of winners in an election to be set on a per post level by using a custom M2M model between PostExtra and Election.

For #691 