### PR TITLE
Remove election_to_show from the context

### DIFF
--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -149,8 +149,6 @@ class PersonView(TemplateView):
             for demographic in demographic_fields
         )
 
-        if settings.ELECTION_APP == 'uk':
-            context['election_to_show'] = Election.objects.get(slug='2015')
         context['extra_fields'] = get_extra_fields(self.person)
         return context
 


### PR DESCRIPTION
It's not really clear why this was hardcoded, but it's not helpful now we have more than a single election.  

Later on, we need to think about this properly, so that it knows what elections are correct to show.

For now, let's just remove it.