### PR TITLE
Force Django REST Framework to support slugs containing '.'.

### DIFF
--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -205,6 +205,7 @@ class AreaTypeViewSet(viewsets.ModelViewSet):
 
 
 class ElectionViewSet(viewsets.ModelViewSet):
+    lookup_value_regex="(?!\.json$)[^/]+"
     queryset = Election.objects.order_by('id')
     lookup_field = 'slug'
     serializer_class = serializers.ElectionSerializer


### PR DESCRIPTION
DRF's default is to assume that a slug wont have a '.' in it.  UK Election IDs do have '.' in them, and are used as slugs, thus breaking the API with the defaults.