### PR TITLE
Add a "current" filter for the elections API and page size customization

### DIFF
--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -209,6 +209,7 @@ class ElectionViewSet(viewsets.ModelViewSet):
     queryset = Election.objects.order_by('id')
     lookup_field = 'slug'
     serializer_class = serializers.ElectionSerializer
+    filter_fields = ('current',)
 
 
 class PartySetViewSet(viewsets.ModelViewSet):

--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -17,7 +17,7 @@ from candidates import serializers
 from candidates import models as extra_models
 from elections.models import AreaType, Election
 from popolo.models import Area, Membership, Person, Post
-from rest_framework import viewsets
+from rest_framework import pagination, viewsets
 
 from compat import text_type
 
@@ -131,6 +131,12 @@ class PostIDToPartySetView(View):
 
 # Now the django-rest-framework based API views:
 
+class ResultsSetPagination(pagination.PageNumberPagination):
+    page_size = 10
+    page_size_query_param = 'page_size'
+    max_page_size = 200
+
+
 class PersonViewSet(viewsets.ModelViewSet):
     queryset = Person.objects \
         .select_related('extra') \
@@ -197,11 +203,13 @@ class AreaViewSet(viewsets.ModelViewSet):
         .prefetch_related('extra') \
         .order_by('id')
     serializer_class = serializers.AreaSerializer
+    pagination_class = ResultsSetPagination
 
 
 class AreaTypeViewSet(viewsets.ModelViewSet):
     queryset = AreaType.objects.order_by('id')
     serializer_class = serializers.AreaTypeSerializer
+    pagination_class = ResultsSetPagination
 
 
 class ElectionViewSet(viewsets.ModelViewSet):
@@ -210,33 +218,40 @@ class ElectionViewSet(viewsets.ModelViewSet):
     lookup_field = 'slug'
     serializer_class = serializers.ElectionSerializer
     filter_fields = ('current',)
+    pagination_class = ResultsSetPagination
 
 
 class PartySetViewSet(viewsets.ModelViewSet):
     queryset = extra_models.PartySet.objects.order_by('id')
     serializer_class = serializers.PartySetSerializer
+    pagination_class = ResultsSetPagination
 
 
 class ImageViewSet(viewsets.ModelViewSet):
     queryset = Image.objects.order_by('id')
     serializer_class = serializers.ImageSerializer
+    pagination_class = ResultsSetPagination
 
 
 class MembershipViewSet(viewsets.ModelViewSet):
     queryset = Membership.objects.order_by('id')
     serializer_class = serializers.MembershipSerializer
+    pagination_class = ResultsSetPagination
 
 
 class LoggedActionViewSet(viewsets.ModelViewSet):
     queryset = extra_models.LoggedAction.objects.order_by('id')
     serializer_class = serializers.LoggedActionSerializer
+    pagination_class = ResultsSetPagination
 
 
 class ExtraFieldViewSet(viewsets.ModelViewSet):
     queryset = extra_models.ExtraField.objects.order_by('id')
     serializer_class = serializers.ExtraFieldSerializer
+    pagination_class = ResultsSetPagination
 
 
 class SimplePopoloFieldViewSet(viewsets.ModelViewSet):
     queryset = extra_models.SimplePopoloField.objects.order_by('id')
     serializer_class = serializers.SimplePopoloFieldSerializer
+    pagination_class = ResultsSetPagination

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -216,6 +216,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             'allauth.socialaccount.providers.facebook',
             'allauth.socialaccount.providers.twitter',
             'corsheaders',
+            'crispy_forms',
         ),
 
         'SITE_ID': 1,
@@ -404,6 +405,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'REST_FRAMEWORK': {
             'DEFAULT_PERMISSION_CLASSES': ('candidates.api_permissions.ReadOnly',),
             'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.URLPathVersioning',
+            'DEFAULT_FILTER_BACKENDS': ('rest_framework.filters.DjangoFilterBackend',),
             'PAGE_SIZE': 10,
         },
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ django-appconf==1.0.1
 django-braces==1.4.0
 django-cors-headers==1.1.0
 django-date-extensions==1.1.0
+django-crispy-forms==1.6.0
 django-debug-toolbar==1.3.2
 django-debug-toolbar-template-timings==0.6.4
 django-extensions==1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ django-pipeline==1.5.1
 -e git+https://github.com/mysociety/django-popolo@update-with-better-migrations-redux#egg=mysociety-django-popolo
 django-statici18n==1.1.5
 django-webtest==1.7.7
-djangorestframework==3.3.1
+djangorestframework==3.3.3
 docutils==0.10
 elasticsearch==0.4.5
 enum34==1.1.2


### PR DESCRIPTION
This fixes #744 and should obviate the need for https://github.com/DemocracyClub/yournextrepresentative/commit/84b9391ac9b875ff566d93c40ac66aa1661a747d

![election-filter-and-page-size](https://cloud.githubusercontent.com/assets/7907/13777544/ba2ae4c0-eaa8-11e5-9ee7-7bfae2e23802.png)
