### PR TITLE
WIP Display winning candidates at the top of area/cons pages

### DIFF
--- a/candidates/templates/candidates/_candidates_for_post.html
+++ b/candidates/templates/candidates/_candidates_for_post.html
@@ -87,7 +87,11 @@
   {% for c, party in winners %}
     {% if forloop.first %}
     <div class="candidates__known">
-      <h3>{% blocktrans with post_label=post_data.label %}Winning candidates for <a href="{{ post_url }}">{{ post_label }}</a>{% endblocktrans %}</h3>
+      <h3>{% blocktrans with post_label=post_data.label count counter=winners|length %}
+        Winning candidate for <a href="{{ post_url }}">{{ post_label }}</a>
+        {% plural %}
+        Winning candidates for <a href="{{ post_url }}">{{ post_label }}</a>
+      {% endblocktrans %}</h3>
       <ul class="candidate-list">
       {% endif %}
         <li class="candidates-list__person candidates-list__person__winner{% if user_can_record_results %} hover-highlighting{% endif %}">

--- a/candidates/templates/candidates/_candidates_for_post.html
+++ b/candidates/templates/candidates/_candidates_for_post.html
@@ -84,8 +84,27 @@
     </form>
   {% endif %}
 
-  <div class="candidates__known">
+  {% for c, party in winners %}
+    {% if forloop.first %}
+    <div class="candidates__known">
+      <h3>{% blocktrans with post_label=post_data.label %}Winning candidates for <a href="{{ post_url }}">{{ post_label }}</a>{% endblocktrans %}</h3>
+      <ul class="candidate-list">
+      {% endif %}
+        <li class="candidates-list__person candidates-list__person__winner{% if user_can_record_results %} hover-highlighting{% endif %}">
+          {% include 'candidates/_person_in_list.html' with election=election %}
+          {% if user.is_authenticated %}
+          <p>
+            <a href="{% url 'person-update' person_id=c.id %}" class="button tiny secondary">{% trans "Edit" %}</a>
+          </p>
+          {% endif %}
+        </li>
+      {% if forloop.last %}
+        </ul>
+    </div>
+    {% endif %}
+  {% endfor %}
 
+  <div class="candidates__known">
     {# Use the post label here, since multiple posts may be used on a page #}
     {% url 'constituency' election=election post_id=post_data.id ignored_slug=post_data.label|slugify as post_url %}
     <h3>{% blocktrans with post_label=post_data.label %}Known candidates for <a href="{{ post_url }}">{{ post_label }}</a>{% endblocktrans %}
@@ -106,39 +125,41 @@
           {% endif %}
 
           {% for c, candidate_elected in people %}
-            {% if forloop.first %}
-              <ul class="candidate-list">
-            {% endif %}
+            {% if not candidate_elected %}
+              {% if forloop.first %}
+                <ul class="candidate-list">
+              {% endif %}
 
-              <li class="candidates-list__person{% if user_can_record_results %} hover-highlighting{% endif %}{% if candidate_elected %} candidates-list__person__winner{% endif %}">
-                {% if candidate_elected %}
-                  <h4 class="candidates-list__person__elected-text">{% trans "Winner" %}</h4>
-                {% endif %}
-
-                {% include 'candidates/_person_in_list.html' with election=election %}
-                {% if user.is_authenticated %}
-                <p>
-                  {% if candidate_list_edits_allowed %}
-                    <a class="button tiny js-toggle-source-confirmation not-standing">{% trans "Not actually standing?" %}</a>
+                <li class="candidates-list__person{% if user_can_record_results %} hover-highlighting{% endif %}{% if candidate_elected %} candidates-list__person__winner{% endif %}">
+                  {% if candidate_elected %}
+                    <h4 class="candidates-list__person__elected-text">{% trans "Winner" %}</h4>
                   {% endif %}
-                  <a href="{% url 'person-update' person_id=c.id %}" class="button tiny secondary">{% trans "Edit" %}</a>
-                </p>
-                {% if candidate_list_edits_allowed %}
-                  {% include 'candidates/_source_confirmation.html' with standing='not-standing' action='candidacy-delete' %}
-                {% endif %}
-                {% endif %}
-                {% if user_can_record_results and show_confirm_result and not candidate_elected %}
-                  <form class="winner-confirm" action="{% url 'record-winner' election=election post_id=post_data.id %}" method="post">
-                    {% csrf_token %}
-                    <input type="hidden" name="person_id" value="{{ c.id }}">
-                    <input type="hidden" name="source" value="{% trans "[Quick update from the constituency page]" %}">
-                    <input type="submit" class="button" value="{% trans "This candidate was elected!" %}">
-                  </form>
-                {% endif %}
-              </li>
 
-            {% if forloop.last %}
-              </ul>
+                  {% include 'candidates/_person_in_list.html' with election=election %}
+                  {% if user.is_authenticated %}
+                  <p>
+                    {% if candidate_list_edits_allowed %}
+                      <a class="button tiny js-toggle-source-confirmation not-standing">{% trans "Not actually standing?" %}</a>
+                    {% endif %}
+                    <a href="{% url 'person-update' person_id=c.id %}" class="button tiny secondary">{% trans "Edit" %}</a>
+                  </p>
+                  {% if candidate_list_edits_allowed %}
+                    {% include 'candidates/_source_confirmation.html' with standing='not-standing' action='candidacy-delete' %}
+                  {% endif %}
+                  {% endif %}
+                  {% if user_can_record_results and show_confirm_result and not candidate_elected %}
+                    <form class="winner-confirm" action="{% url 'record-winner' election=election post_id=post_data.id %}" method="post">
+                      {% csrf_token %}
+                      <input type="hidden" name="person_id" value="{{ c.id }}">
+                      <input type="hidden" name="source" value="{% trans "[Quick update from the constituency page]" %}">
+                      <input type="submit" class="button" value="{% trans "This candidate was elected!" %}">
+                    </form>
+                  {% endif %}
+                </li>
+
+              {% if forloop.last %}
+                </ul>
+              {% endif %}
             {% endif %}
 
           {% endfor %} {# end of 'for c, candidate_elected in people' #}

--- a/candidates/templates/candidates/areas.html
+++ b/candidates/templates/candidates/areas.html
@@ -17,7 +17,7 @@
 
   {% for post in posts %}
 
-    {% with election=post.election election_data=post.election_data candidate_list_edits_allowed=post.candidate_list_edits_allowed candidates_locked=post.candidates_locked post_data=post.post_data add_candidate_form=post.add_candidate_form candidacies=post.candidacies personal_fields=post.personal_fields demographic_fields=post.demographic_fields extra_fields=post.extra_fields constituencies_form_fields=post.constituencies_form_fields %}
+    {% with election=post.election election_data=post.election_data candidate_list_edits_allowed=post.candidate_list_edits_allowed candidates_locked=post.candidates_locked post_data=post.post_data add_candidate_form=post.add_candidate_form candidacies=post.candidacies personal_fields=post.personal_fields demographic_fields=post.demographic_fields extra_fields=post.extra_fields constituencies_form_fields=post.constituencies_form_fields winners=post.winners %}
 
       <h2>{{ election_data.name }}</h2>
 

--- a/candidates/tests/test_constituency_view.py
+++ b/candidates/tests/test_constituency_view.py
@@ -198,6 +198,7 @@ class TestConstituencyDetailView(TestUserMixin, WebTest):
 
     def test_constituency_with_winner(self):
         response = self.app.get('/election/2015/post/14419/edinburgh-east')
+        response.mustcontain('Winning candidate for')
         response.mustcontain('<li class="candidates-list__person candidates-list__person__winner">')
 
         response.mustcontain(no='Unset the current winners')

--- a/candidates/tests/test_record_winner.py
+++ b/candidates/tests/test_record_winner.py
@@ -238,6 +238,12 @@ class TestRecordWinner(TestUserMixin, WebTest):
         person = Person.objects.get(id=2009)
         self.assertTrue(person.extra.get_elected(self.election))
 
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user_who_can_record_results,
+        )
+        response.mustcontain('Winning candidates for')
+
     def test_record_multiple_winners_per_post_setting(self):
         post_election = PostExtraElection.objects.get(
             postextra=self.post_extra,

--- a/candidates/views/areas.py
+++ b/candidates/views/areas.py
@@ -20,7 +20,7 @@ from elections.models import AreaType, Election
 from ..forms import NewPersonForm
 from .helpers import (
     split_candidacies, group_candidates_by_party,
-    get_person_form_fields
+    get_person_form_fields, get_winning_candidates
 )
 
 class AreasView(TemplateView):
@@ -70,6 +70,7 @@ class AreasView(TemplateView):
                         'on_behalf_of__extra', 'organization'
                     ).all()
                 )
+                winners = get_winning_candidates(current_candidacies)
                 current_candidacies = group_candidates_by_party(
                     election,
                     current_candidacies,
@@ -86,6 +87,7 @@ class AreasView(TemplateView):
                     'candidates_locked': locked,
                     'candidate_list_edits_allowed':
                     get_edits_allowed(self.request.user, locked),
+                    'winners': winners,
                     'candidacies': current_candidacies,
                     'add_candidate_form': NewPersonForm(
                         election=election.slug,

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -21,7 +21,8 @@ from auth_helpers.views import GroupRequiredMixin
 from .helpers import (
     get_party_people_for_election_from_memberships,
     split_candidacies, get_redirect_to_post,
-    group_candidates_by_party, get_person_form_fields
+    group_candidates_by_party, get_person_form_fields,
+    get_winning_candidates
 )
 from .version_data import get_client_ip, get_change_metadata
 from ..csv_helpers import list_to_csv
@@ -121,6 +122,7 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
                 ).all()
             )
 
+        winners = get_winning_candidates(current_candidacies)
         current_candidates = set(c.person for c in current_candidacies)
         past_candidates = set(c.person for c in past_candidacies)
 
@@ -173,6 +175,7 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
             if c.extra.elected is not None:
                 context['show_retract_result'] = True
 
+        context['winners'] = winners
         max_winners = get_max_winners(mp_post, self.election_data)
         context['show_confirm_result'] = (max_winners < 0) \
             or number_of_winners < max_winners

--- a/candidates/views/helpers.py
+++ b/candidates/views/helpers.py
@@ -224,3 +224,11 @@ def group_candidates_by_party(election_data, candidacies, party_list=True, max_p
         'party_lists_in_use': party_list,
         'parties_and_people': result
     }
+
+
+def get_winning_candidates(candidacies):
+    return [
+        (c.person, c.on_behalf_of)
+        for c in candidacies
+        if c.extra.elected
+    ]


### PR DESCRIPTION
Generate a list of winner candidates from the list of current
candidacies and use that to display a list of winners at the top of the
page.

Also skip display of winners in list of known candidates becuase we
don't want to repeat information

Fixes #692 