### PR TITLE
Fix for Google social login SSL error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4==4.4.1
 bleach==1.4.1
-certifi==2015.11.20.1
+certifi==2015.04.28
 cffi==1.5.0
 coverage==3.7.1
 cryptography==1.2.2


### PR DESCRIPTION
The following error is produced when using the Google social login:

  SSLError: [Errno bad handshake] [('SSL routines', 'SSL3_GET_SERVER_CERTIFICATE', 'certificate verify failed')]

... from requests.  I believe that this error is due to the servers we
(and Democracy Club) currently run having OpenSSL 1.0.1 and using a recent
version of the certifi Python package (which contains root
certificates).

A full explanation can be found here:

  https://github.com/certifi/python-certifi/issues/26

(found via: http://stackoverflow.com/a/34665344/223092 )

Since upgrading OpenSSL to 1.0.2 will be a pain, pinning certifi to the
old version is the easiest way to fix this error for the moment.
Hopefully we will upgrade the distributions on our servers in the near
future to one that supplies OpenSSL 1.0.2 and then we can switch to a
more recent certificate bundle.