### PR TITLE
Add a country that just redirects to Democracy Club's site

### DIFF
--- a/elections/uk_redirect_to_dc/settings.py
+++ b/elections/uk_redirect_to_dc/settings.py
@@ -1,0 +1,6 @@
+from __future__ import unicode_literals
+
+MAPIT_BASE_URL = 'http://mapit.democracyclub.org.uk/'
+
+SITE_OWNER = 'Democracy Club'
+COPYRIGHT_HOLDER = 'Democracy Club Limited'

--- a/elections/uk_redirect_to_dc/urls.py
+++ b/elections/uk_redirect_to_dc/urls.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = [
+    url(r'', views.RedirectToDCView.as_view(), name='dc-redirect'),
+]

--- a/elections/uk_redirect_to_dc/views.py
+++ b/elections/uk_redirect_to_dc/views.py
@@ -1,0 +1,18 @@
+from __future__ import unicode_literals
+
+from django.utils.six.moves.urllib_parse import urljoin
+from django.views.generic import RedirectView
+
+
+class RedirectToDCView(RedirectView):
+
+    """Redirect all URLs to Democracy Club's new candidates site"""
+
+    permanent = True
+
+    def get_redirect_url(self, *args, **kwargs):
+        new_url = urljoin(
+            'https://candidates.democracyclub.org.uk',
+            self.request.get_full_path(),
+        )
+        return new_url


### PR DESCRIPTION
We want to redirect all requests to edit.yournextmp.com to Democracy
Club's candidates site (https://candidates.democracyclub.org.uk) from
now on.  This adds a new country we can switch edit.yournextmp.com to
use which will just redirect.