### PR TITLE
Fix the GeoLocatorView for multiple MapIt generations

### DIFF
--- a/candidates/views/frontpage.py
+++ b/candidates/views/frontpage.py
@@ -46,14 +46,14 @@ class GeoLocatorView(View):
             lookup_url += '&generation={0}'.format(generation)
             mapit_result = requests.get(lookup_url)
             mapit_result = mapit_result.json()
-        if 'error' in mapit_result:
-            message = _("The area lookup returned an error: '{0}'") \
-                .format(mapit_result['error'])
-            return HttpResponse(
-                json.dumps({'error': message}),
-                content_type='application/json',
-            )
-        mapit_json += mapit_result.items()
+            if 'error' in mapit_result:
+                message = _("The area lookup returned an error: '{0}'") \
+                    .format(mapit_result['error'])
+                return HttpResponse(
+                    json.dumps({'error': message}),
+                    content_type='application/json',
+                )
+            mapit_json += mapit_result.items()
 
         if len(mapit_json) == 0:
             message = _("Your location does not seem to be covered by this site")


### PR DESCRIPTION
The logic here was wrong, so it would think there were no results
at all if the first query to MapIt returned some, but the second query
returned none.

Combined with errors in the MapIt generation data in the DC install
of YNR this meant that any geolocation query would say "Your location
does not seem to be covered by this site".

Partial fix for #751