### PR TITLE
Restore the ``u`` prefix in 'SOURCE_HINTS'

### DIFF
--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -382,8 +382,8 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'TEST_RUNNER': 'django_nose.NoseTestSuiteRunner',
 
         'SOURCE_HINTS': _(
-            "Please don't quote third-party candidate sites \u2014 "
-            "we prefer URLs of news stories or official candidate pages."
+            u"Please don't quote third-party candidate sites \u2014 "
+            u"we prefer URLs of news stories or official candidate pages."
         ),
 
         # By default, cache successful results from MapIt for a day


### PR DESCRIPTION
Unicode escapes inside 'bare' strings are not understood by
``xgettext``, the utility that creates translatable strings
from Python source code.  The backslash would be doubled in the
.po file; '\u2014' ≠ '\\\u2014'; and no translations
would then be found for 'SOURCE_HINTS'.