### PR TITLE
Emit lock form variables in areas view

### DIFF
--- a/candidates/templates/candidates/areas.html
+++ b/candidates/templates/candidates/areas.html
@@ -17,7 +17,7 @@
 
   {% for post in posts %}
 
-    {% with election=post.election election_data=post.election_data candidate_list_edits_allowed=post.candidate_list_edits_allowed candidates_locked=post.candidates_locked post_data=post.post_data add_candidate_form=post.add_candidate_form candidacies=post.candidacies personal_fields=post.personal_fields demographic_fields=post.demographic_fields complex_fields=post.complex_fields extra_fields=post.extra_fields constituencies_form_fields=post.constituencies_form_fields %}
+    {% with election=post.election election_data=post.election_data candidate_list_edits_allowed=post.candidate_list_edits_allowed candidates_locked=post.candidates_locked post_data=post.post_data add_candidate_form=post.add_candidate_form candidacies=post.candidacies personal_fields=post.personal_fields demographic_fields=post.demographic_fields complex_fields=post.complex_fields extra_fields=post.extra_fields constituencies_form_fields=post.constituencies_form_fields lock_form=post.lock_form %}
 
       <h2>{{ election_data.name }}</h2>
 

--- a/candidates/views/areas.py
+++ b/candidates/views/areas.py
@@ -17,7 +17,7 @@ from candidates.models.auth import get_edits_allowed
 
 from elections.models import AreaType, Election
 
-from ..forms import NewPersonForm
+from ..forms import NewPersonForm, ToggleLockForm
 from .helpers import (
     split_candidacies, group_candidates_by_party,
     get_person_form_fields
@@ -84,6 +84,12 @@ class AreasView(TemplateView):
                         'label': post.label,
                     },
                     'candidates_locked': locked,
+                    'lock_form': ToggleLockForm(
+                        initial={
+                            'post_id': post.extra.slug,
+                            'lock': not locked
+                        },
+                    ),
                     'candidate_list_edits_allowed':
                     get_edits_allowed(self.request.user, locked),
                     'candidacies': current_candidacies,


### PR DESCRIPTION
This fixes being able to lock and unlock a post from an
areas view.