### PR TITLE
Update API docs for fetching a post

### DIFF
--- a/candidates/templates/candidates/api.html
+++ b/candidates/templates/candidates/api.html
@@ -162,7 +162,7 @@ constituency.
     querying posts with the <tt>extra_slug</tt> filter
     parameter.  For example, for Dulwich and West Norwood, which
     has the ID <tt>65808</tt>, you would make the request:
-    <a href="{{ base_api_url }}posts/?extra__slug=65808">{{ base_api_url }}posts/?extra__slug=65808</a>
+    <a href="{{ base_api_url }}posts/65808/">{{ base_api_url }}posts/65808/</a>
   {% endblocktrans %}
 </p>
 


### PR DESCRIPTION
I find django rest framework a bit baffling… But routes like `/api/posts/[post_id]/` seem to work, whereas `/api/posts/?extra__slug=[post_id]` just return the index (i.e. the `post_id` is ignored).

I think other bits on this page could be updated too… Mostly replacing “constituency” with “post”.