### PR TITLE
Lose the Foundation presentational classes in 'image-review'

### DIFF
--- a/moderation_queue/static/moderation_queue/css/crop.scss
+++ b/moderation_queue/static/moderation_queue/css/crop.scss
@@ -1,4 +1,5 @@
-@import "../../foundation/scss/normalize";
+$include-html-classes: false;
+
 @import "../../foundation/scss/foundation";
 
 /* This removes all size-related styles from the image for review; if


### PR DESCRIPTION
Previously, all of Foundation would be duplicated inside
'image-review' - some 250 KB - causing rendering issues.