### PR TITLE
Show big party list position numbers on post and area pages too

### DIFF
--- a/candidates/templates/candidates/_candidates_for_post.html
+++ b/candidates/templates/candidates/_candidates_for_post.html
@@ -110,7 +110,7 @@
               {% endif %}
           {% endif %}
 
-          {% for c, candidate_elected in people %}
+          {% for position_in_list, c, candidate_elected in people %}
             {% if forloop.first %}
               <ul class="candidate-list">
             {% endif %}
@@ -146,7 +146,7 @@
               </ul>
             {% endif %}
 
-          {% endfor %} {# end of 'for c, candidate_elected in people' #}
+          {% endfor %} {# end of 'for position_in_list, c, candidate_elected in people' #}
 
         </div>
 
@@ -208,7 +208,7 @@
               {% endif %}
 
               <ul class="candidate-list">
-                {% for c, candidate_elected in people %}
+                {% for position_in_list, c, candidate_elected in people %}
 
                   <li class="candidates-list__person">
                     {% include 'candidates/_person_in_list.html' %}
@@ -226,7 +226,7 @@
                     {% endif %}
                     {% endif %}
                   </li>
-                {% endfor %} {# end of 'for c, candidate_elected in people' #}
+                {% endfor %} {# end of 'for position_in_list, c, candidate_elected in people' #}
               </ul>
 
             </div>
@@ -254,7 +254,7 @@
               {% endif %}
 
               <ul class="candidate-list">
-                {% for c, candidate_elected in people %}
+                {% for position_in_list, c, candidate_elected in people %}
 
                   <li class="candidates-list__person">
                     {% include 'candidates/_person_in_list.html' %}
@@ -270,7 +270,7 @@
                     {% endif %}
                     {% endif %}
                   </li>
-                {% endfor %} {# end of 'for c, candidate_elected in people' #}
+                {% endfor %} {# end of 'for position_in_list, c, candidate_elected in people' #}
               </ul>
 
             </div>

--- a/candidates/views/helpers.py
+++ b/candidates/views/helpers.py
@@ -218,9 +218,7 @@ def group_candidates_by_party(election_data, candidacies, party_list=True, max_p
                     'truncated': party_truncated[k],
                     'total_count': party_total[k],
                 },
-                # throw away the party list position data we
-                # were only using for sorting
-                [(p[1], p[2]) for p in v]
+                v
             )
             for k, v in party_id_to_people.items()
         ]
@@ -229,7 +227,7 @@ def group_candidates_by_party(election_data, candidacies, party_list=True, max_p
     if party_list:
         result.sort(key=lambda t: t[0]['name'])
     else:
-        result.sort(key=lambda t: t[1][0][0].name.split()[-1])
+        result.sort(key=lambda t: t[1][0][1].name.split()[-1])
     return {
         'party_lists_in_use': party_list,
         'parties_and_people': result


### PR DESCRIPTION
I  made this change for the UK, to respond to a request from @symroe 
and @JoeMitchell - it means that the big numerals that were present on
the party list pages will now be used on the post and area pages too.

I was unsure about whether this would be generally welcomed by all
redeployers of YNR, but I think it's quite nice having the numbers on all
pages that display party lists. Do you have a view on that, @wfdd ?