### PR TITLE
Use 'format' form of month names in candidate birth date

### DIFF
--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -192,10 +192,10 @@
                     use it if the LANGUAGE is English.
                   {% endcomment %}
                   {% if LANGUAGE_CODE|slice:":2" == 'en' %}
-                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"jS F Y" %}Date of birth: {{ dob }}
+                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"jS E Y" %}Date of birth: {{ dob }}
                      {% endblocktrans %})
                   {% else %}
-                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"j F Y" %}Date of birth: {{ dob }}
+                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"j E Y" %}Date of birth: {{ dob }}
                      {% endblocktrans %})
                   {% endif %}
                 </small>


### PR DESCRIPTION
The 'E' format character declines the month name.  See
https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#date

Closes #817.