### PR TITLE
Put the parties with the most candidates at the top of the party drop-down

### DIFF
--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -617,9 +617,54 @@ class PartySet(models.Model):
     def __str__(self):
         return self.name
 
-    def party_choices(self):
+    def party_choices_basic(self):
         result = list(self.parties.order_by('name').values_list('id', 'name'))
         result.insert(0, ('party:none', ''))
+        return result
+
+    def party_choices(self):
+        # For various reasons, we've found it's best to order the
+        # parties by those that have the most candidates - this means
+        # that the commonest parties to select are at the top of the
+        # drop down.  The logic here tries to build such an ordered
+        # list of candidates if there are enough that such an ordering
+        # makes sense.  Otherwise the fallback is to rank
+        # alphabetically.
+        candidacies_current_qs = Membership.objects.filter(
+            extra__election__current=True,
+            role=models.F('extra__election__candidate_membership_role'),
+            on_behalf_of__party_sets=self,
+        )
+        candidacies_ever_qs =  Membership.objects.filter(
+            role=models.F('extra__election__candidate_membership_role'),
+            on_behalf_of__party_sets=self,
+        )
+        minimum_count = settings.CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST
+        qs = None
+        if candidacies_current_qs.count() > minimum_count:
+            qs = candidacies_current_qs
+        elif candidacies_ever_qs.count() > minimum_count:
+            qs = candidacies_ever_qs
+        else:
+            return self.party_choices_basic()
+        result = [('party:none', '')]
+        parties_with_candidates = []
+        for party_tuple in qs \
+                .values('on_behalf_of', 'on_behalf_of__name') \
+                .order_by() \
+                .annotate(party_count=models.Count('pk')) \
+                .order_by('-party_count', 'on_behalf_of__name'):
+            parties_with_candidates.append(party_tuple['on_behalf_of'])
+            name_with_count = \
+                _('{party_name} ({number_of_candidates} candidates)').format(
+                    party_name=party_tuple['on_behalf_of__name'],
+                    number_of_candidates=party_tuple['party_count']
+                )
+            result.append(
+                (party_tuple['on_behalf_of'], name_with_count)
+            )
+        result += self.parties.exclude(id__in=parties_with_candidates) \
+            .order_by('name').values_list('id', 'name')
         return result
 
 

--- a/candidates/tests/test_party_dropdown_ordering.py
+++ b/candidates/tests/test_party_dropdown_ordering.py
@@ -1,0 +1,83 @@
+from django_webtest import WebTest
+
+from . import factories
+from .auth import TestUserMixin
+from .uk_examples import UK2015ExamplesMixin
+
+class TestPartyDropDownOrdering(TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def test_hardly_any_candidates_at_all(self):
+        party_choices = self.gb_parties.party_choices()
+        self.assertEqual(
+            party_choices,
+            [
+                (u'party:none', u''),
+                (self.conservative_party_extra.base.id, u'Conservative Party'),
+                (self.green_party_extra.base.id, u'Green Party'),
+                (self.labour_party_extra.base.id, u'Labour Party'),
+                (self.ld_party_extra.base.id, u'Liberal Democrats'),
+            ]
+        )
+
+    def create_lots_of_candidates(self, election, parties_and_counts):
+        posts_extra = [
+            self.edinburgh_east_post_extra,
+            self.edinburgh_north_post_extra,
+            self.dulwich_post_extra,
+            self.camberwell_post_extra,
+        ]
+        created = 0
+        for party, candidates_to_create in parties_and_counts:
+            for i in range(candidates_to_create):
+                person_id = created + 1
+                pe = factories.PersonExtraFactory.create(
+                    base__id=person_id,
+                    base__name='John Doe {0}'.format(person_id),
+                )
+                factories.CandidacyExtraFactory.create(
+                    election=election,
+                    base__person=pe.base,
+                    base__post=posts_extra[created % len(posts_extra)].base,
+                    base__on_behalf_of=party.base,
+                )
+                created += 1
+
+    def test_only_candidates_in_earlier_election(self):
+        self.create_lots_of_candidates(
+            self.earlier_election,
+            (
+                (self.labour_party_extra, 16),
+                (self.ld_party_extra, 8),
+            )
+        )
+        party_choices = self.gb_parties.party_choices()
+        self.assertEqual(
+            party_choices,
+            [
+                (u'party:none', u''),
+                (self.labour_party_extra.base.id, u'Labour Party (16 candidates)'),
+                (self.ld_party_extra.base.id, u'Liberal Democrats (8 candidates)'),
+                (self.conservative_party_extra.base.id, u'Conservative Party'),
+                (self.green_party_extra.base.id, u'Green Party')
+            ],
+        )
+
+    def test_enough_candidates_in_current_election(self):
+        self.create_lots_of_candidates(
+            self.election,
+            (
+                (self.ld_party_extra, 30),
+                (self.green_party_extra, 15),
+            )
+        )
+        party_choices = self.gb_parties.party_choices()
+        self.assertEqual(
+            party_choices,
+            [
+                (u'party:none', u''),
+                (self.ld_party_extra.base.id, u'Liberal Democrats (30 candidates)'),
+                (self.green_party_extra.base.id, u'Green Party (15 candidates)'),
+                (self.conservative_party_extra.base.id, u'Conservative Party'),
+                (self.labour_party_extra.base.id, u'Labour Party'),
+            ],
+        )

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -95,3 +95,10 @@ USE_UNIVERSAL_ANALYTICS: true
 # In all of the world apart from the United States, dd/mm is preferred
 # to mm/dd.  So if your site is for the USA, set this to false:
 DD_MM_DATE_FORMAT_PREFERRED: true
+
+# If there are more than this number of candidates (either in current
+# elections or all elections) for a particular party set we use a
+# "weighted" party list - i.e. the party drop-down is ordered from the
+# party in the party set with most candidates down to those with the
+# least:
+CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST: 20

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -434,6 +434,8 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
     if not conf.get('NEW_ACCOUNTS_ALLOWED', True):
         result['ACCOUNT_ADAPTER'] = \
             'mysite.account_adapter.NoNewUsersAccountAdapter'
+    result['CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST'] = \
+        conf.get('CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST', 20)
     if tests:
         result['NOSE_ARGS'] = [
             '--nocapture',


### PR DESCRIPTION
A first pass at this - no tests yet, and it doesn't do the nice formatting
of right-aligning the candidate numbers as Zarino's sketch suggested,
but it's a start:

![ranked-parties](https://cloud.githubusercontent.com/assets/7907/14443792/52326450-0039-11e6-8fc6-cd67c2e747ad.png)