### PR TITLE
Wrap long lines in multi-paragraph extra fields

### DIFF
--- a/candidates/static/candidates/_people.scss
+++ b/candidates/static/candidates/_people.scss
@@ -459,5 +459,5 @@
 }
 
 .plaintext-with-newlines {
-  white-space: pre
+  white-space: pre-line;
 }


### PR DESCRIPTION
``pre-line`` behaves the same way as ``normal``, save for
preserving new lines.  ``pre`` preserves new lines and repeated
spaces, and respects line length; it's what we'd use for
computer code.