### PR TITLE
Fix "finder" styling on non-UK homepages

### DIFF
--- a/elections/uk/static/candidates/_finder.scss
+++ b/elections/uk/static/candidates/_finder.scss
@@ -110,9 +110,9 @@
     .header__hero {
       padding-top: 2em;
       padding-bottom: 4em;
+      text-align: center;
 
       .lead {
-        width: 50%;
         font-size: 1.5em;
         line-height: 1.4em;
         margin-top: 0.7em;
@@ -121,15 +121,19 @@
   }
 
   .finder__forms {
-    position: absolute;
-    z-index: 1; // sit on top of following elements
-    top: -5em; // overlap into header above
-    right: 0.9375em; // default bootstrap column gutter
-    margin: 0; // override auto margins from smaller screens
-    padding: 2em 3em;
-    width: 40%;
-    background-color: #fff;
-    box-shadow: 0 2px 2px rgba(0,0,0,0.1);
+    background-color: #f4f1ed;
+    max-width: 100%;
+
+    .finder__forms__container {
+      background-color: #FFF;
+      position: relative;
+      z-index: 1; // sit on top of following elements
+      top: -2em; // overlap into header above
+      margin: 0 auto; // override auto margins from smaller screens
+      padding: 2em 3em;
+      width: 40%;
+      box-shadow: 0 2px 2px rgba(0,0,0,0.1);
+    }
   }
 
   .finder__description {


### PR DESCRIPTION
3597b7e3022d9748422b45942077ca684b1a555f edited the `_finder.scss` styles in core, when really it should have been a UK-specific change.

This commit reverts those changes to core `_finder.scss`, and moves the `.finder__forms__container` and other related changes into a UK-specific override of the `_finder.scss` stylesheet.

Fixes #831.

# Before:

![screen shot 2016-04-15 at 13 24 02](https://cloud.githubusercontent.com/assets/739624/14561317/5e0b727c-030d-11e6-90ef-bb3fdef2f39b.png)

# After:

![screen shot 2016-04-15 at 13 23 12](https://cloud.githubusercontent.com/assets/739624/14561320/606ddf28-030d-11e6-9770-cf789f604256.png)

@mhl – could you give this a review? I've tested it locally by switching to the `uk` country, but all I see on the homepage is the location search form, rather than the extra stuff that’s visible on https://candidates.democracyclub.org.uk. I’m assuming there's some democracy club magic that I'm missing?