### PR TITLE
Only include the record winner button on or after election day

### DIFF
--- a/candidates/templates/candidates/_candidates_for_post.html
+++ b/candidates/templates/candidates/_candidates_for_post.html
@@ -132,13 +132,15 @@
                   {% include 'candidates/_source_confirmation.html' with standing='not-standing' action='candidacy-delete' %}
                 {% endif %}
                 {% endif %}
-                {% if user_can_record_results and show_confirm_result and not candidate_elected %}
-                  <form class="winner-confirm" action="{% url 'record-winner' election=election post_id=post_data.id %}" method="post">
-                    {% csrf_token %}
-                    <input type="hidden" name="person_id" value="{{ c.id }}">
-                    <input type="hidden" name="source" value="{% trans "[Quick update from the constituency page]" %}">
-                    <input type="submit" class="button" value="{% trans "This candidate was elected!" %}">
-                  </form>
+                {% if DATE_TODAY >= election_data.election_date %}
+                  {% if user_can_record_results and show_confirm_result and not candidate_elected %}
+                    <form class="winner-confirm" action="{% url 'record-winner' election=election post_id=post_data.id %}" method="post">
+                      {% csrf_token %}
+                      <input type="hidden" name="person_id" value="{{ c.id }}">
+                      <input type="hidden" name="source" value="{% trans "[Quick update from the constituency page]" %}">
+                      <input type="submit" class="button" value="{% trans "This candidate was elected!" %}">
+                    </form>
+                  {% endif %}
                 {% endif %}
               </li>
 

--- a/candidates/tests/dates.py
+++ b/candidates/tests/dates.py
@@ -1,0 +1,26 @@
+from datetime import date, timedelta
+
+from django.conf import settings
+
+date_in_near_future = date.today() + timedelta(days=14)
+
+FOUR_YEARS_IN_DAYS = 1462
+
+election_date_before = lambda r: {
+    'DATE_TODAY': date.today()
+}
+election_date_on_election_day = lambda r: {
+    'DATE_TODAY': date_in_near_future
+}
+election_date_after = lambda r: {
+    'DATE_TODAY': date.today() + timedelta(days=28)
+}
+
+processors = settings.TEMPLATE_CONTEXT_PROCESSORS
+
+processors_before = processors + \
+    ("candidates.tests.dates.election_date_before",)
+processors_on_election_day = processors + \
+    ("candidates.tests.dates.election_date_on_election_day",)
+processors_after = processors + \
+    ("candidates.tests.dates.election_date_after",)

--- a/candidates/tests/factories.py
+++ b/candidates/tests/factories.py
@@ -4,9 +4,7 @@ from datetime import date, timedelta
 
 import factory
 
-date_in_near_future = date.today() + timedelta(days=14)
-
-FOUR_YEARS_IN_DAYS = 1462
+from .dates import date_in_near_future, FOUR_YEARS_IN_DAYS
 
 
 class AreaTypeFactory(factory.DjangoModelFactory):

--- a/candidates/tests/test_hide_record_winner_buttons.py
+++ b/candidates/tests/test_hide_record_winner_buttons.py
@@ -1,0 +1,62 @@
+from __future__ import unicode_literals
+
+from django.test.utils import override_settings
+from django_webtest import WebTest
+
+from .auth import TestUserMixin
+from .dates import (
+    processors_before,
+    processors_on_election_day,
+    processors_after,
+)
+from .uk_examples import UK2015ExamplesMixin
+from .factories import CandidacyExtraFactory, PersonExtraFactory
+
+
+class TestWasElectedButtons(TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def setUp(self):
+        super(TestWasElectedButtons, self).setUp()
+        person_extra = PersonExtraFactory.create(
+            base__id='2009',
+            base__name='Tessa Jowell'
+        )
+        CandidacyExtraFactory.create(
+            election=self.election,
+            base__person=person_extra.base,
+            base__post=self.dulwich_post_extra.base,
+            base__on_behalf_of=self.labour_party_extra.base
+        )
+
+    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_before)
+    def test_no_was_elected_button_before(self):
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user_who_can_record_results,
+        )
+        self.assertNotIn(
+            '<input type="submit" class="button" value="This candidate was elected!">',
+            response,
+        )
+
+    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_on_election_day)
+    def test_show_was_elected_button_on_election_day(self):
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user_who_can_record_results,
+        )
+        self.assertIn(
+            '<input type="submit" class="button" value="This candidate was elected!">',
+            response,
+        )
+
+    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_after)
+    def test_show_was_elected_button_after(self):
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user_who_can_record_results,
+        )
+        self.assertIn(
+            '<input type="submit" class="button" value="This candidate was elected!">',
+            response,
+        )

--- a/candidates/tests/test_person_view.py
+++ b/candidates/tests/test_person_view.py
@@ -7,12 +7,7 @@ import re
 from django.test.utils import override_settings
 from django_webtest import WebTest
 
-from .auth import TestUserMixin
-from .dates import (
-    processors_before,
-    processors_on_election_day,
-    processors_after,
-)
+from .dates import processors_before, processors_after
 from .factories import (
     CandidacyExtraFactory, PersonExtraFactory
 )
@@ -64,52 +59,3 @@ class TestPersonView(UK2015ExamplesMixin, WebTest):
             expect_errors=True
         )
         self.assertEqual(response.status_code, 404)
-
-
-class TestWasElectedButtons(TestUserMixin, UK2015ExamplesMixin, WebTest):
-
-    def setUp(self):
-        super(TestWasElectedButtons, self).setUp()
-        person_extra = PersonExtraFactory.create(
-            base__id='2009',
-            base__name='Tessa Jowell'
-        )
-        CandidacyExtraFactory.create(
-            election=self.election,
-            base__person=person_extra.base,
-            base__post=self.dulwich_post_extra.base,
-            base__on_behalf_of=self.labour_party_extra.base
-        )
-
-    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_before)
-    def test_no_was_elected_button_before(self):
-        response = self.app.get(
-            '/election/2015/post/65808/dulwich-and-west-norwood',
-            user=self.user_who_can_record_results,
-        )
-        self.assertNotIn(
-            '<input type="submit" class="button" value="This candidate was elected!">',
-            response,
-        )
-
-    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_on_election_day)
-    def test_show_was_elected_button_on_election_day(self):
-        response = self.app.get(
-            '/election/2015/post/65808/dulwich-and-west-norwood',
-            user=self.user_who_can_record_results,
-        )
-        self.assertIn(
-            '<input type="submit" class="button" value="This candidate was elected!">',
-            response,
-        )
-
-    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_after)
-    def test_show_was_elected_button_after(self):
-        response = self.app.get(
-            '/election/2015/post/65808/dulwich-and-west-norwood',
-            user=self.user_who_can_record_results,
-        )
-        self.assertIn(
-            '<input type="submit" class="button" value="This candidate was elected!">',
-            response,
-        )

--- a/candidates/tests/test_person_view.py
+++ b/candidates/tests/test_person_view.py
@@ -9,13 +9,18 @@ from django.conf import settings
 from django.test.utils import override_settings
 from django_webtest import WebTest
 
+from .auth import TestUserMixin
+from .factories import (
+    CandidacyExtraFactory, PersonExtraFactory, date_in_near_future
+)
 from .uk_examples import UK2015ExamplesMixin
-from .factories import CandidacyExtraFactory, PersonExtraFactory
 
 election_date_before = lambda r: {'DATE_TODAY': date.today()}
+election_date_on_election_day = lambda r: {'DATE_TODAY': date_in_near_future}
 election_date_after = lambda r: {'DATE_TODAY': date.today() + timedelta(days=28)}
 processors = settings.TEMPLATE_CONTEXT_PROCESSORS
 processors_before = processors + ("candidates.tests.test_person_view.election_date_before",)
+processors_on_election_day = processors + ("candidates.tests.test_person_view.election_date_on_election_day",)
 processors_after = processors + ("candidates.tests.test_person_view.election_date_after",)
 
 
@@ -64,3 +69,52 @@ class TestPersonView(UK2015ExamplesMixin, WebTest):
             expect_errors=True
         )
         self.assertEqual(response.status_code, 404)
+
+
+class TestWasElectedButtons(TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def setUp(self):
+        super(TestWasElectedButtons, self).setUp()
+        person_extra = PersonExtraFactory.create(
+            base__id='2009',
+            base__name='Tessa Jowell'
+        )
+        CandidacyExtraFactory.create(
+            election=self.election,
+            base__person=person_extra.base,
+            base__post=self.dulwich_post_extra.base,
+            base__on_behalf_of=self.labour_party_extra.base
+        )
+
+    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_before)
+    def test_no_was_elected_button_before(self):
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user_who_can_record_results,
+        )
+        self.assertNotIn(
+            '<input type="submit" class="button" value="This candidate was elected!">',
+            response,
+        )
+
+    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_on_election_day)
+    def test_show_was_elected_button_on_election_day(self):
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user_who_can_record_results,
+        )
+        self.assertIn(
+            '<input type="submit" class="button" value="This candidate was elected!">',
+            response,
+        )
+
+    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_after)
+    def test_show_was_elected_button_after(self):
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user_who_can_record_results,
+        )
+        self.assertIn(
+            '<input type="submit" class="button" value="This candidate was elected!">',
+            response,
+        )

--- a/candidates/tests/test_person_view.py
+++ b/candidates/tests/test_person_view.py
@@ -2,26 +2,21 @@
 
 from __future__ import unicode_literals
 
-from datetime import date, timedelta
 import re
 
-from django.conf import settings
 from django.test.utils import override_settings
 from django_webtest import WebTest
 
 from .auth import TestUserMixin
+from .dates import (
+    processors_before,
+    processors_on_election_day,
+    processors_after,
+)
 from .factories import (
-    CandidacyExtraFactory, PersonExtraFactory, date_in_near_future
+    CandidacyExtraFactory, PersonExtraFactory
 )
 from .uk_examples import UK2015ExamplesMixin
-
-election_date_before = lambda r: {'DATE_TODAY': date.today()}
-election_date_on_election_day = lambda r: {'DATE_TODAY': date_in_near_future}
-election_date_after = lambda r: {'DATE_TODAY': date.today() + timedelta(days=28)}
-processors = settings.TEMPLATE_CONTEXT_PROCESSORS
-processors_before = processors + ("candidates.tests.test_person_view.election_date_before",)
-processors_on_election_day = processors + ("candidates.tests.test_person_view.election_date_on_election_day",)
-processors_after = processors + ("candidates.tests.test_person_view.election_date_after",)
 
 
 class TestPersonView(UK2015ExamplesMixin, WebTest):

--- a/candidates/tests/test_record_winner.py
+++ b/candidates/tests/test_record_winner.py
@@ -11,7 +11,7 @@ from .auth import TestUserMixin
 from .factories import (
     CandidacyExtraFactory, MembershipFactory, PersonExtraFactory,
 )
-from .test_person_view import processors_after
+from .dates import processors_after
 from .uk_examples import UK2015ExamplesMixin
 
 

--- a/candidates/tests/test_record_winner.py
+++ b/candidates/tests/test_record_winner.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.core.urlresolvers import reverse
+from django.test.utils import override_settings
 from django_webtest import WebTest
 
 from popolo.models import Person
@@ -10,6 +11,7 @@ from .auth import TestUserMixin
 from .factories import (
     CandidacyExtraFactory, MembershipFactory, PersonExtraFactory,
 )
+from .test_person_view import processors_after
 from .uk_examples import UK2015ExamplesMixin
 
 
@@ -49,6 +51,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
             organization=self.labour_party_extra.base
         )
 
+    @override_settings(TEMPLATE_CONTEXT_PROCESSORS=processors_after)
     def test_record_winner_link_present(self):
         response = self.app.get(
             '/election/2015/post/65808/dulwich-and-west-norwood',


### PR DESCRIPTION
These buttons add lots of visual clutter to the candidate lists, and are
only actually useful on election day or afterwards, so don't show them
until then.

Fixes #779