### PR TITLE
Fix migrations for Python 3

### DIFF
--- a/alerts/migrations/0001_initial.py
+++ b/alerts/migrations/0001_initial.py
@@ -18,8 +18,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('target_object_id', models.CharField(max_length=255, null=True, blank=True)),
-                ('action', models.CharField(max_length=100, choices=[(b'created', b'Created'), (b'updated', b'Updated'), (b'deleted', b'Deleted'), (b'image_update', b'Images'), (b'all', b'All')])),
-                ('frequency', models.CharField(max_length=100, choices=[(b'hourly', b'Hourly'), (b'daily', b'Daily')])),
+                ('action', models.CharField(max_length=100, choices=[('created', 'Created'), ('updated', 'Updated'), ('deleted', 'Deleted'), ('image_update', 'Images'), ('all', 'All')])),
+                ('frequency', models.CharField(max_length=100, choices=[('hourly', 'Hourly'), ('daily', 'Daily')])),
                 ('last_sent', models.DateTimeField()),
                 ('enabled', models.BooleanField(default=True)),
                 ('target_content_type', models.ForeignKey(related_name='alert_target', blank=True, to='contenttypes.ContentType', null=True)),

--- a/candidates/migrations/0008_membershipextra_organizationextra_personextra_postextra.py
+++ b/candidates/migrations/0008_membershipextra_organizationextra_personextra_postextra.py
@@ -79,7 +79,7 @@ class Migration(migrations.Migration):
             name='ImageExtra',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('copyright', models.CharField(default=b'other', max_length=64, blank=True)),
+                ('copyright', models.CharField(default='other', max_length=64, blank=True)),
                 ('user_notes', models.TextField(blank=True)),
                 ('base', models.OneToOneField(related_name='extra', to='images.Image')),
                 ('md5sum', models.CharField(max_length=32, blank=True)),

--- a/candidates/migrations/0015_add_configurable_extra_fields.py
+++ b/candidates/migrations/0015_add_configurable_extra_fields.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('key', models.CharField(max_length=256)),
-                ('type', models.CharField(max_length=64, choices=[(b'line', b'A single line of text'), (b'longer-text', b'One or more paragraphs of text'), (b'url', b'A URL')])),
+                ('type', models.CharField(max_length=64, choices=[('line', 'A single line of text'), ('longer-text', 'One or more paragraphs of text'), ('url', 'A URL')])),
                 ('label', models.CharField(max_length=1024)),
             ],
         ),

--- a/candidates/migrations/0019_add_yesno_to_extra_field_types.py
+++ b/candidates/migrations/0019_add_yesno_to_extra_field_types.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='extrafield',
             name='type',
-            field=models.CharField(max_length=64, choices=[(b'line', b'A single line of text'), (b'longer-text', b'One or more paragraphs of text'), (b'url', b'A URL'), (b'yesno', b"A Yes/No/Don't know dropdown")]),
+            field=models.CharField(max_length=64, choices=[('line', 'A single line of text'), ('longer-text', 'One or more paragraphs of text'), ('url', 'A URL'), ('yesno', "A Yes/No/Don't know dropdown")]),
         ),
     ]

--- a/candidates/migrations/0021_simplepopolofield.py
+++ b/candidates/migrations/0021_simplepopolofield.py
@@ -15,10 +15,10 @@ class Migration(migrations.Migration):
             name='SimplePopoloField',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('name', models.CharField(max_length=256, choices=[(b'name', 'Name'), (b'family_name', 'Family Name'), (b'given_name', 'Given Name'), (b'additional_name', 'Additional Name'), (b'honorific_prefix', 'Honorific Prefix'), (b'honorific_suffix', 'Honorific Suffix'), (b'patronymic_name', 'Patronymic Name'), (b'sort_name', 'Sort Name'), (b'email', 'Email'), (b'gender', 'Gender'), (b'birth_date', 'Birth Date'), (b'death_date', 'Death Date'), (b'summary', 'Summary'), (b'biography', 'Biography'), (b'national_identity', 'National Identity')])),
+                ('name', models.CharField(max_length=256, choices=[('name', 'Name'), ('family_name', 'Family Name'), ('given_name', 'Given Name'), ('additional_name', 'Additional Name'), ('honorific_prefix', 'Honorific Prefix'), ('honorific_suffix', 'Honorific Suffix'), ('patronymic_name', 'Patronymic Name'), ('sort_name', 'Sort Name'), ('email', 'Email'), ('gender', 'Gender'), ('birth_date', 'Birth Date'), ('death_date', 'Death Date'), ('summary', 'Summary'), ('biography', 'Biography'), ('national_identity', 'National Identity')])),
                 ('label', models.CharField(max_length=256)),
                 ('required', models.BooleanField(default=False)),
-                ('info_type_key', models.CharField(max_length=256, choices=[(b'text', 'Text Field'), (b'email', 'Email Field')])),
+                ('info_type_key', models.CharField(max_length=256, choices=[('text', 'Text Field'), ('email', 'Email Field')])),
                 ('order', models.IntegerField(blank=True)),
             ],
         ),

--- a/elections/migrations/0001_initial.py
+++ b/elections/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.CharField(max_length=128)),
-                ('source', models.CharField(help_text=b'e.g MapIt', max_length=128, blank=True)),
+                ('source', models.CharField(help_text='e.g MapIt', max_length=128, blank=True)),
             ],
         ),
         migrations.CreateModel(

--- a/moderation_queue/migrations/0001_initial.py
+++ b/moderation_queue/migrations/0001_initial.py
@@ -17,9 +17,9 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('copyright_assigned', models.BooleanField(default=False)),
-                ('decision', models.CharField(default=b'undecided', max_length=32, choices=[(b'approved', b'Approved'), (b'rejected', b'Rejected'), (b'undecided', b'Undecided')])),
+                ('decision', models.CharField(default='undecided', max_length=32, choices=[('approved', 'Approved'), ('rejected', 'Rejected'), ('undecided', 'Undecided')])),
                 ('justification_for_use', models.TextField()),
-                ('image', models.ImageField(max_length=512, upload_to=b'queued-images/%Y/%m/%d')),
+                ('image', models.ImageField(max_length=512, upload_to='queued-images/%Y/%m/%d')),
                 ('popit_person_id', models.CharField(max_length=256)),
                 ('user', models.ForeignKey(blank=True, to=settings.AUTH_USER_MODEL, null=True)),
             ],

--- a/moderation_queue/migrations/0004_queuedimage_why_allowed.py
+++ b/moderation_queue/migrations/0004_queuedimage_why_allowed.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='queuedimage',
             name='why_allowed',
-            field=models.CharField(default=b'other', max_length=64, choices=[(b'public-domain', b'This photograph is free of any copyright restrictions'), (b'copyright-assigned', b'I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on YourNextMP'), (b'profile-photo', b"This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page")]),
+            field=models.CharField(default='other', max_length=64, choices=[('public-domain', 'This photograph is free of any copyright restrictions'), ('copyright-assigned', 'I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on YourNextMP'), ('profile-photo', "This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page")]),
             preserve_default=True,
         ),
     ]

--- a/moderation_queue/migrations/0007_auto_20150303_1420.py
+++ b/moderation_queue/migrations/0007_auto_20150303_1420.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='queuedimage',
             name='why_allowed',
-            field=models.CharField(default=b'other', max_length=64, choices=[(b'public-domain', b'This photograph is free of any copyright restrictions'), (b'copyright-assigned', b'I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on YourNextMP'), (b'profile-photo', b"This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page"), (b'other', b'Other')]),
+            field=models.CharField(default='other', max_length=64, choices=[('public-domain', 'This photograph is free of any copyright restrictions'), ('copyright-assigned', 'I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on YourNextMP'), ('profile-photo', "This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page"), ('other', 'Other')]),
             preserve_default=True,
         ),
     ]

--- a/moderation_queue/migrations/0008_add_ignore_to_decision_choices.py
+++ b/moderation_queue/migrations/0008_add_ignore_to_decision_choices.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='queuedimage',
             name='decision',
-            field=models.CharField(default=b'undecided', max_length=32, choices=[(b'approved', b'Approved'), (b'rejected', b'Rejected'), (b'undecided', b'Undecided'), (b'ignore', b'Ignore')]),
+            field=models.CharField(default='undecided', max_length=32, choices=[('approved', 'Approved'), ('rejected', 'Rejected'), ('undecided', 'Undecided'), ('ignore', 'Ignore')]),
             preserve_default=True,
         ),
     ]

--- a/moderation_queue/migrations/0013_auto_20150916_1753.py
+++ b/moderation_queue/migrations/0013_auto_20150916_1753.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='queuedimage',
             name='why_allowed',
-            field=models.CharField(default=b'other', max_length=64, choices=[(b'public-domain', 'This photograph is free of any copyright restrictions'), (b'copyright-assigned', 'I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on this site'), (b'profile-photo', "This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page"), (b'other', 'Other')]),
+            field=models.CharField(default='other', max_length=64, choices=[('public-domain', 'This photograph is free of any copyright restrictions'), ('copyright-assigned', 'I own copyright of this photo and I assign the copyright to Democracy Club Limited in return for it being displayed on this site'), ('profile-photo', "This is the candidate's public profile photo from social media (e.g. Twitter, Facebook) or their official campaign page"), ('other', 'Other')]),
         ),
     ]

--- a/official_documents/migrations/0001_initial.py
+++ b/official_documents/migrations/0001_initial.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('modified', django_extensions.db.fields.ModificationDateTimeField(default=django.utils.timezone.now, verbose_name='modified', editable=False, blank=True)),
                 ('uploaded_file', models.FileField(max_length=800, upload_to=official_documents.models.document_file_name)),
                 ('mapit_id', models.CharField(max_length=50)),
-                ('source_url', models.URLField(help_text=b'The page that links to this document', blank=True)),
+                ('source_url', models.URLField(help_text='The page that links to this document', blank=True)),
             ],
             options={
                 'ordering': ('-modified', '-created'),

--- a/official_documents/migrations/0002_officialdocument_document_type.py
+++ b/official_documents/migrations/0002_officialdocument_document_type.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='officialdocument',
             name='document_type',
-            field=models.CharField(default='Nomination paper', max_length=100, choices=[(b'nomination_paper', b'Nomination paper')]),
+            field=models.CharField(default='Nomination paper', max_length=100, choices=[('nomination_paper', 'Nomination paper')]),
             preserve_default=False,
         ),
     ]

--- a/official_documents/migrations/0004_auto_20150410_1054.py
+++ b/official_documents/migrations/0004_auto_20150410_1054.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='officialdocument',
             name='document_type',
-            field=models.CharField(max_length=100, choices=[(b'Nomination paper', b'Nomination paper')]),
+            field=models.CharField(max_length=100, choices=[('Nomination paper', 'Nomination paper')]),
             preserve_default=True,
         ),
     ]

--- a/official_documents/migrations/0005_auto_20150410_1307.py
+++ b/official_documents/migrations/0005_auto_20150410_1307.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='officialdocument',
             name='source_url',
-            field=models.URLField(help_text=b'The page that links to this document', max_length=1000, blank=True),
+            field=models.URLField(help_text='The page that links to this document', max_length=1000, blank=True),
             preserve_default=True,
         ),
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ django-model-utils==2.3.1
 django-nose==1.4.1
 django-notifications-hq==1.0.0
 django-pipeline==1.6.8
--e git+https://github.com/mysociety/django-popolo@update-with-better-migrations-redux#egg=mysociety-django-popolo
+-e git+https://github.com/mysociety/django-popolo@fix-migrations-for-python-3#egg=mysociety-django-popolo
 django-statici18n==1.1.5
 django-webtest==1.7.7
 djangorestframework==3.3.3


### PR DESCRIPTION
``makemigrations`` fails in Python 3 if migrations contain both
bytes and Unicode strings.

Closes #847.