### PR TITLE
Add support for editing alternative names for people

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -17,7 +17,7 @@ from django.utils.translation import ugettext_lazy as _
 from candidates.models import (
     PartySet, parse_approximate_date, ExtraField, SimplePopoloField, ComplexPopoloField
 )
-from popolo.models import Organization, Post
+from popolo.models import Organization, OtherName, Post
 
 
 if django_version[:2] < (1, 9):
@@ -494,5 +494,24 @@ class ConstituencyRecordWinnerForm(forms.Form):
     )
     source = StrippedCharField(
         label=_("Source of information that they won"),
+        max_length=512,
+    )
+
+
+class OtherNameForm(forms.ModelForm):
+    class Meta:
+        model = OtherName
+        fields = ('name', 'note', 'start_date', 'end_date')
+        labels = {
+        }
+        help_texts = {
+            'start_date': _('(Optional) The date from which this name would be used'),
+            'end_date': _('(Optional) The date when this name stopped being used'),
+        }
+    source = StrippedCharField(
+        label=_("Source"),
+        help_text=_(
+            "Please indicate how you know that this is a valid alternative name"
+        ),
         max_length=512,
     )

--- a/candidates/models/versions.py
+++ b/candidates/models/versions.py
@@ -33,7 +33,7 @@ def get_person_as_version_data(person):
             'start_date': on.start_date,
             'end_date': on.end_date,
         }
-        for on in person.other_names.all()
+        for on in person.other_names.order_by('name', 'start_date', 'end_date')
     ]
     identifiers = list(person.identifiers.all())
     if identifiers:

--- a/candidates/static/candidates/_forms.scss
+++ b/candidates/static/candidates/_forms.scss
@@ -16,6 +16,15 @@
   @include css-triangle(20px, $confirmation-background-color, bottom);
 }
 
+.person-othernames-list .source-confirmation:before {
+  display: block;
+  content: "";
+  position: absolute;
+  top: -30px;
+  left: 56px;
+  @include css-triangle(20px, $confirmation-background-color, bottom);
+}
+
 .source-confirmation {
   position: relative;
   border-radius: 3px;
@@ -107,4 +116,8 @@ form.signup {
   p {
     margin-bottom: 0.5em;
   }
+}
+
+.alternative-names {
+  margin-top: 0.5em;
 }

--- a/candidates/static/candidates/_people.scss
+++ b/candidates/static/candidates/_people.scss
@@ -285,7 +285,7 @@
   }
 }
 
-.person__details, .candidates__new {
+.person__details, .candidates__new, .othername__details {
   h2 {
     @extend %person-section-heading;
   }

--- a/candidates/static/js/constituency.js
+++ b/candidates/static/js/constituency.js
@@ -9,6 +9,7 @@ $(function() {
      boxes and the add new candidate form. */
   $('.source-confirmation-standing').hide();
   $('.source-confirmation-not-standing').hide();
+  $('.source-confirmation-delete-other-name').hide()
   $('.candidates__new').hide();
 
   function getNewCandidateDiv(element) {
@@ -29,20 +30,30 @@ $(function() {
     newCandidate.slideUp();
   });
 
-  /* Handle showing/hiding the source confirmation box */
-  $('.js-toggle-source-confirmation').on('click', function(event){
-    var target = $(event.target),
-        standing = target.hasClass('standing') ? 'standing' : 'not-standing',
-        allConfirmationBoxes = $(this).parents('li').children('.source-confirmation'),
-        confirmationClass = '.source-confirmation-' + standing,
-        confirmation = $(this).parents('li').children(confirmationClass);
+  function toggleSourceConfirmation(button, classSuffix, target) {
+    var allConfirmationBoxes = $(button).parents('li').children('.source-confirmation'),
+    confirmationClass = '.source-confirmation-' + classSuffix,
+    confirmation = $(button).parents('li').children(confirmationClass);
     if(confirmation.is(':visible')){
       confirmation.hide();
     } else {
       allConfirmationBoxes.hide();
       confirmation.show().find('input:text').focus();
     }
-  })
+  }
+
+  /* Handle showing/hiding the source confirmation box */
+  $('.js-toggle-source-confirmation').on('click', function(event){
+    var i, validClass, target = $(event.target),
+    validClasses = ['standing', 'not-standing', 'delete-other-name'];
+    for (i = 0; i < validClasses.length; ++i ) {
+      validClass = validClasses[i];
+      if (target.hasClass(validClass)) {
+        toggleSourceConfirmation(this, validClass, target);
+        return;
+      }
+    }
+  });
 
   $('.winner-confirm').submit(function(e) {
     var enclosingDiv = $(e.target).parent(),

--- a/candidates/templates/candidates/_othername_form.html
+++ b/candidates/templates/candidates/_othername_form.html
@@ -1,0 +1,49 @@
+{% load i18n %}
+
+{% csrf_token %}
+
+<div class="form-item {% if form.name.errors %}form-item--errors{% endif %}">
+  <p>
+    {{ form.name.label_tag }}
+    {{ form.name }}
+  </p>
+  {{ form.name.errors }}
+</div>
+
+<div class="form-item {% if form.note.errors %}form-item--errors{% endif %}">
+  <p>
+    {{ form.note.label_tag }}
+    {{ form.note }}
+  </p>
+  {{ form.note.errors }}
+</div>
+
+<div class="form-item {% if form.start_date.errors %}form-item--errors{% endif %}">
+  <p>
+    {{ form.start_date.label_tag }}
+    {{ form.start_date }}
+  </p>
+  {{ form.start_date.errors }}
+</div>
+
+<div class="form-item {% if form.end_date.errors %}form-item--errors{% endif %}">
+  <p>
+    {{ form.end_date.label_tag }}
+    {{ form.end_date }}
+  </p>
+  {{ form.end_date.errors }}
+</div>
+
+<div class="source-confirmation {% if form.source.errors %}source-confirmation--errors{% endif %}">
+  <p>
+    <label for="{{ form.source.id_for_label }}">
+      {% if form.source.errors %}
+        {% trans "<strong>You forgot to reference a source!</strong> Can you show us <em>where</em> you got this information?" %}
+      {% else %}
+        {% trans "What’s your <strong>source of information</strong> for this name being used for the candidate?" %}
+      {% endif %}
+      {{ settings.SOURCE_HINTS }}
+    </label>
+    {{ form.source }}
+  </p>
+</div>

--- a/candidates/templates/candidates/_person_form.html
+++ b/candidates/templates/candidates/_person_form.html
@@ -23,6 +23,15 @@
         {{ simple_field }}
       </p>
       {{ simple_field.errors }}
+      {% if simple_field.name == 'name'%}
+        {% if not add_candidate_form %}
+          <p class="alternative-names">
+            <a href="{% url 'person-other-names' person_id=person.id %}">
+              {% trans "Manage alternative names..." %}
+          </a></p>
+        {% endif %}
+      {% endif %}
+
     </div>
 
     {% endfor %}

--- a/candidates/templates/candidates/othername_edit.html
+++ b/candidates/templates/candidates/othername_edit.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+
+{% load i18n %}
+{% load staticfiles %}
+
+{% block body_class %}person-othername-update{% endblock %}
+
+{% block title %}{% blocktrans with name=person.name %}Edit a name for {{ name }}{% endblocktrans %}{% endblock %}
+
+{% block content %}
+
+<h1>{% blocktrans with name=person.name %}Edit a name for {{ name }}{% endblocktrans %}</h1>
+
+  <div class="othername__details">
+
+    <form action="" method="post" id="person_update_other_name">
+      {% include 'candidates/_othername_form.html' %}
+      <input class="button" type="submit" value="{% trans 'Save' %}">
+    </form>
+
+  </div>
+
+{% endblock %}

--- a/candidates/templates/candidates/othername_list.html
+++ b/candidates/templates/candidates/othername_list.html
@@ -1,0 +1,62 @@
+{% extends 'base.html' %}
+
+{% load i18n %}
+{% load staticfiles %}
+
+{% block body_class %}person-othernames-list{% endblock %}
+
+{% block title %}{% blocktrans with name=person.name %}Other names for {{ name }}{% endblocktrans %}{% endblock %}
+
+{% block content %}
+
+  <h1>{% blocktrans trimmed with name=person.name person_url=person.extra.get_absolute_url %}
+    Other names for <a href="{{ person_url }}">{{ name }}</a>
+  {% endblocktrans %}</h1>
+
+  {% if othername_list %}
+    <ul>
+      {% for other_name in othername_list %}
+        <li>
+          <p>
+            <strong>{% trans "Name" %}</strong>: {{ other_name.name }}<br>
+            {% if other_name.start_date %}
+              <strong>{% trans "Start date" %}</strong>: {{ other_name.start_date }}<br>
+            {% endif %}
+            {% if other_name.end_date %}
+              <strong>{% trans "End date" %}</strong>: {{ other_name.end_date }}<br>
+            {% endif %}
+            <strong>{% trans "Note" %}</strong>: {{ other_name.note }}<br>
+          </p>
+
+          <p>
+            <a class="button tiny secondary" href="{% url 'person-other-name-update' pk=other_name.id person_id=person.id %}">
+              {% trans "Edit" %}
+            </a>
+            <a class="button tiny js-toggle-source-confirmation delete-other-name">{% trans 'Delete' %}</a>
+          </p>
+
+          <div class="source-confirmation source-confirmation-delete-other-name">
+            <form method="post" action="{% url 'person-other-name-delete' pk=other_name.id person_id=person.id %}">
+              {% csrf_token %}
+              <label for="id_source">{% trans "Before we delete this other name, can you tell us how you know it's not valid?" %} {{ settings.SOURCE_HINTS }}</label>
+              <div class="row">
+                <div class="small-12 medium-8 large-9 columns">
+                  <input type="text" name="source" id="id_source" maxlength="512" required="required"/>
+                </div>
+                <div class="small-6 medium-4 large-3 columns">
+                  <input type="submit" class="button expand" value="{% trans "Delete other name" %}" />
+                </div>
+              </div>
+            </form>
+          </div>
+
+        </li>
+      {% endfor %}
+    </ul>
+  {% else %}
+    <p>{% trans "No alternative names found" %}</p>
+  {% endif %}
+
+  <a class="button" href="{% url 'person-other-name-create' person_id=person.id %}">{% trans "Add another name" %}</a>
+
+{% endblock %}

--- a/candidates/templates/candidates/othername_new.html
+++ b/candidates/templates/candidates/othername_new.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+
+{% load i18n %}
+{% load staticfiles %}
+
+{% block body_class %}person-othername-new{% endblock %}
+
+{% block title %}{% blocktrans with name=person.name %}Add a new name for {{ name }}{% endblocktrans %}{% endblock %}
+
+{% block content %}
+
+<h1>{% blocktrans with name=person.name %}Add a new name for {{ name }}{% endblocktrans %}</h1>
+
+  <div class="othername__details">
+
+    <form action="" method="post" id="person_create_other_name">
+      {% include 'candidates/_othername_form.html' %}
+      <input class="button" type="submit" value="{% trans 'Add' %}">
+    </form>
+
+  </div>
+
+{% endblock %}

--- a/candidates/tests/test_other_names.py
+++ b/candidates/tests/test_other_names.py
@@ -1,0 +1,227 @@
+from __future__ import print_function, unicode_literals
+
+from django_webtest import WebTest
+
+from popolo.models import OtherName
+
+from .auth import TestUserMixin
+from .factories import PersonExtraFactory
+from .uk_examples import UK2015ExamplesMixin
+
+
+class TestOtherNamesViews(TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def setUp(self):
+        super(TestOtherNamesViews, self).setUp()
+        self.pe_no_other = PersonExtraFactory.create(
+            base__id=1234,
+            base__name='John Smith',
+        )
+        self.pe_other_names = PersonExtraFactory.create(
+            base__id=5678,
+            base__name='Fozzie',
+        )
+        self.fozziewig = OtherName.objects.create(
+            content_object=self.pe_other_names.base,
+            name='Mr Fozziewig',
+            note='In a Muppet Christmas Carol',
+        )
+        self.fozzie_bear = OtherName.objects.create(
+            content_object=self.pe_other_names.base,
+            name='Fozzie Bear',
+            note='Full name',
+        )
+
+    # Listing
+
+    def test_list_other_names_no_names(self):
+        response = self.app.get('/person/1234/other-names')
+        self.assertIn(
+            'No alternative names found',
+            response.text
+        )
+
+    def test_list_other_names_some_Names(self):
+        response = self.app.get('/person/5678/other-names')
+        self.assertIn(
+            '<strong>Name</strong>: Fozzie Bear',
+            response.text
+        )
+        self.assertIn(
+            '<strong>Name</strong>: Mr Fozziewig',
+            response.text
+        )
+
+    # Deleting
+
+    def test_delete_other_name_not_authenticated(self):
+        # Get the page so we'll have a CSRF token:
+        response = self.app.get('/person/5678/other-names')
+        url = '/person/5678/other-name/{on_id}/delete'.format(
+            on_id=self.fozzie_bear.id,
+        )
+        response = self.app.post(
+            url,
+            {
+                'csrfmiddlewaretoken': self.app.cookies['csrftoken'],
+                'source': 'Some good reasons for deleting this name',
+            },
+            expect_errors=True,
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_delete_other_name_authenticated_works(self):
+        # Get the page so we'll have a CSRF token:
+        response = self.app.get('/person/5678/other-names')
+        url = '/person/5678/other-name/{on_id}/delete'.format(
+            on_id=self.fozzie_bear.id,
+        )
+        response = self.app.post(
+            url,
+            {
+                'csrfmiddlewaretoken': self.app.cookies['csrftoken'],
+                'source': 'Some good reasons for deleting this name',
+            },
+            user=self.user,
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.location,
+            'http://localhost:80/person/5678/other-names'
+        )
+        self.assertEqual(
+            1,
+            self.pe_other_names.base.other_names.count(),
+        )
+        self.assertEqual(
+            self.pe_other_names.base.other_names.get().name,
+            'Mr Fozziewig',
+        )
+
+    # Adding
+
+    def test_add_other_name_get_not_authenticated(self):
+        # Get the create page:
+        response = self.app.get(
+            '/person/5678/other-names/create',
+            expect_errors=True,
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_add_other_name_post_not_authenticated(self):
+        # Get a page we can view to get the CSRF token:
+        response = self.app.get('/person/5678/other-names')
+        # Post to the create page:
+        response = self.app.post(
+            '/person/5678/other-names/create',
+            {
+                'name': 'J Smith',
+                'note': 'Name with just initials',
+                'csrfmiddlewaretoken': self.app.cookies['csrftoken'],
+            },
+            expect_errors=True,
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_add_other_name_authenticated_no_source(self):
+        # Get a page we can view to get the CSRF token:
+        response = self.app.get(
+            '/person/5678/other-names/create',
+            user=self.user,
+        )
+        form = response.forms['person_create_other_name']
+        form['name'] = 'J Smith'
+        submission_response = form.submit()
+        self.assertEqual(submission_response.status_code, 200)
+        self.assertIn(
+            'You forgot to reference a source',
+            submission_response.text
+        )
+
+    def test_add_other_name_authenticated_succeeds(self):
+        # Get a page we can view to get the CSRF token:
+        response = self.app.get(
+            '/person/5678/other-names/create',
+            user=self.user,
+        )
+        form = response.forms['person_create_other_name']
+        form['name'] = 'F Bear'
+        form['source'] = 'Some reasonable explanation'
+        submission_response = form.submit()
+        self.assertEqual(submission_response.status_code, 302)
+        self.assertEqual(
+            submission_response.location,
+            'http://localhost:80/person/5678/other-names'
+        )
+        self.assertEqual(
+            3,
+            self.pe_other_names.base.other_names.count(),
+        )
+
+    # Editing
+
+    def test_edit_other_name_get_not_authenticated(self):
+        # Get the edit page:
+        response = self.app.get(
+            '/person/5678/other-name/{on_id}/update'.format(
+                on_id=self.fozzie_bear.id,
+            ),
+            expect_errors=True,
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_edit_other_name_post_not_authenticated(self):
+        # Get a page we can view to get the CSRF token:
+        response = self.app.get('/person/5678/other-names')
+        # Post to the edit page:
+        response = self.app.post(
+            '/person/5678/other-name/{on_id}/update'.format(
+                on_id=self.fozzie_bear.id,
+            ),
+            {
+                'name': 'F Bear',
+                'note': 'Name with just initials',
+                'csrfmiddlewaretoken': self.app.cookies['csrftoken'],
+            },
+            expect_errors=True,
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_edit_other_name_authenticated_no_source(self):
+        # Get a page we can view to get the CSRF token:
+        response = self.app.get(
+            '/person/5678/other-name/{on_id}/update'.format(
+                on_id=self.fozzie_bear.id,
+            ),
+            user=self.user,
+        )
+        form = response.forms['person_update_other_name']
+        form['name'] = 'F Bear'
+        submission_response = form.submit()
+        self.assertEqual(submission_response.status_code, 200)
+        self.assertIn(
+            'You forgot to reference a source',
+            submission_response.text
+        )
+
+    def test_edit_other_name_authenticated_succeeds(self):
+        # Get a page we can view to get the CSRF token:
+        response = self.app.get(
+            '/person/5678/other-name/{on_id}/update'.format(
+                on_id=self.fozzie_bear.id,
+            ),
+            user=self.user,
+        )
+        form = response.forms['person_update_other_name']
+        form['name'] = 'F Bear'
+        form['source'] = 'Some reasonable explanation'
+        submission_response = form.submit()
+        self.assertEqual(submission_response.status_code, 302)
+        self.assertEqual(
+            submission_response.location,
+            'http://localhost:80/person/5678/other-names'
+        )
+        self.assertEqual(
+            2,
+            self.pe_other_names.base.other_names.count(),
+        )

--- a/candidates/tests/test_posts_view.py
+++ b/candidates/tests/test_posts_view.py
@@ -7,9 +7,6 @@ from .uk_examples import UK2015ExamplesMixin
 
 class TestPostsView(UK2015ExamplesMixin, WebTest):
 
-    def setUp(self):
-        super(TestPostsView, self).setUp()
-
     def test_single_election_posts_page(self):
 
         response = self.app.get('/posts')

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -129,6 +129,26 @@ patterns_to_format = [
         'name': 'person-merge'
     },
     {
+        'pattern': r'^person/(?P<person_id>\d+)/other-names$',
+        'view': views.PersonOtherNamesView.as_view(),
+        'name': 'person-other-names',
+    },
+    {
+        'pattern': r'^person/(?P<person_id>\d+)/other-names/create$',
+        'view': views.PersonOtherNameCreateView.as_view(),
+        'name': 'person-other-name-create',
+    },
+    {
+        'pattern': r'^person/(?P<person_id>\d+)/other-name/(?P<pk>\d+)/delete$',
+        'view': views.PersonOtherNameDeleteView.as_view(),
+        'name': 'person-other-name-delete',
+    },
+    {
+        'pattern': r'^person/(?P<person_id>\d+)/other-name/(?P<pk>\d+)/update$',
+        'view': views.PersonOtherNameUpdateView.as_view(),
+        'name': 'person-other-name-update',
+    },
+    {
         'pattern': r'^person/(?P<person_id>\d+)(?:/(?P<ignored_slug>.*))?$',
         'view': views.PersonView.as_view(),
         'name': 'person-view'

--- a/candidates/views/__init__.py
+++ b/candidates/views/__init__.py
@@ -10,3 +10,4 @@ from .people import *
 from .posts import *
 from .search import *
 from .users import *
+from .other_names import *

--- a/candidates/views/other_names.py
+++ b/candidates/views/other_names.py
@@ -1,0 +1,99 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.urlresolvers import reverse
+from django.utils.functional import cached_property
+from django.views.generic import CreateView, DeleteView, ListView, UpdateView
+
+from braces.views import LoginRequiredMixin
+
+from candidates.forms import OtherNameForm
+from popolo.models import OtherName, Person
+
+from .version_data import get_change_metadata
+
+
+class PersonMixin(object):
+
+    @cached_property
+    def person(self):
+        return Person.objects.get(pk=self.kwargs['person_id'])
+
+    def get_success_url(self):
+        return reverse(
+            'person-other-names', kwargs={'person_id': self.person.id}
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super(PersonMixin, self).get_context_data(**kwargs)
+        context['person'] = self.person
+        return context
+
+
+class PersonOtherNamesView(PersonMixin, ListView):
+
+    model = OtherName
+    template_name = 'candidates/othername_list.html'
+
+    def get_queryset(self):
+        qs = super(PersonOtherNamesView, self).get_queryset()
+        ct = ContentType.objects.get_for_model(Person)
+        return qs.filter(
+            content_type=ct,
+            object_id=self.kwargs['person_id'],
+        ).order_by('name', 'start_date', 'end_date')
+
+
+class PersonOtherNameCreateView(LoginRequiredMixin, PersonMixin, CreateView):
+
+    model = OtherName
+    form_class = OtherNameForm
+    template_name = 'candidates/othername_new.html'
+    raise_exception = True
+
+    def form_valid(self, form):
+        # This is similar to the example here:
+        #   https://docs.djangoproject.com/en/1.8/topics/class-based-views/generic-editing/#models-and-request-user
+        form.instance.content_object = self.person
+        result = super(
+            PersonOtherNameCreateView, self
+        ).form_valid(form)
+        change_metadata = get_change_metadata(
+            self.request, form.cleaned_data['source']
+        )
+        self.person.extra.record_version(change_metadata)
+        self.person.extra.save()
+        return result
+
+
+class PersonOtherNameDeleteView(LoginRequiredMixin, PersonMixin, DeleteView):
+
+    model = OtherName
+    raise_exception = True
+
+    def delete(self, request, *args, **kwargs):
+        result_redirect = super(PersonOtherNameDeleteView, self) \
+            .delete(request, *args, **kwargs)
+        change_metadata = get_change_metadata(
+            self.request, self.request.POST['source']
+        )
+        self.person.extra.record_version(change_metadata)
+        self.person.extra.save()
+        return result_redirect
+
+
+class PersonOtherNameUpdateView(LoginRequiredMixin, PersonMixin, UpdateView):
+
+    model = OtherName
+    form_class = OtherNameForm
+    template_name = 'candidates/othername_edit.html'
+    raise_exception = True
+
+    def form_valid(self, form):
+        result = super(
+            PersonOtherNameUpdateView, self
+        ).form_valid(form)
+        change_metadata = get_change_metadata(
+            self.request, form.cleaned_data['source']
+        )
+        self.person.extra.record_version(change_metadata)
+        self.person.extra.save()
+        return result


### PR DESCRIPTION
Previously there was no support for adding, deleting or editing
alternative names for people in YNR, although this is supported by the
Popolo data model.

This commit adds basic support for editing alternative names for
people; the page for managing a person's other names is linked to
from the person edit page under their full name.

Fixes #749

Things still to do (although this is usable without them):

- [x] Restrict editing to logged in users
- [x] Fix the position of the triangle on the source confirmation pointing up to the "Delete" button
- [ ] Make the display of these changes in the version history more readable
- [x] Add some tests to exercise these new views

### Link to the alternative names page

![link-to-manage-alternative-names](https://cloud.githubusercontent.com/assets/7907/14716845/b37849e6-07e6-11e6-9b56-f3ba012e3602.png)

### The alternative names page

![manage-other-names](https://cloud.githubusercontent.com/assets/7907/14716851/b86d1c60-07e6-11e6-9395-4d0cb22bd8c8.png)

### The add new name form

![add-new-form](https://cloud.githubusercontent.com/assets/7907/14716849/b650e718-07e6-11e6-8518-3481d20cbe7c.png)






