### PR TITLE
Store Twitter user IDs as well as screen names

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -18,7 +18,7 @@ from candidates.models import (
     PartySet, parse_approximate_date, ExtraField, SimplePopoloField, ComplexPopoloField
 )
 from popolo.models import Organization, OtherName, Post
-
+from .twitter_api import get_twitter_user_id, TwitterAPITokenMissing
 
 if django_version[:2] < (1, 9):
     class StrippedCharField(forms.CharField):
@@ -192,6 +192,16 @@ class BasePersonForm(forms.Form):
         if not re.search(r'^\w*$', username):
             message = _("The Twitter username must only consist of alphanumeric characters or underscore")
             raise ValidationError(message)
+        try:
+            user_id = get_twitter_user_id(username)
+            if not user_id:
+                message = _("The Twitter account {screen_name} doesn't exist")
+                raise ValidationError(message.format(screen_name=username))
+        except TwitterAPITokenMissing:
+            # If there's no API token, we can't check the screen name,
+            # but don't fail validation because the site owners
+            # haven't set that up.
+            return username
         return username
 
     def check_party_and_constituency_are_selected(self, cleaned_data):

--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -1,0 +1,169 @@
+from __future__ import print_function, unicode_literals
+
+from datetime import datetime
+from random import randint
+import sys
+
+from django.db import transaction
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.utils.translation import ugettext as _
+from django.utils.six import text_type
+
+from popolo.models import ContactDetail, Identifier, Person
+import requests
+
+MAX_IN_A_REQUEST = 100
+VERBOSE = False
+
+
+def verbose(*args, **kwargs):
+    if VERBOSE:
+        print(*args, **kwargs)
+
+
+class Command(BaseCommand):
+
+    help = "Use the Twitter API to check / fix Twitter screen names and user IDs"
+
+    def record_new_version(self, person):
+        msg = 'Updated by the automated Twitter account checker ' \
+              '(candidates_update_twitter_usernames)'
+        person.extra.record_version(
+            {
+                'information_source': msg,
+                'version_id': "{0:016x}".format(randint(0, sys.maxsize)),
+                'timestamp': datetime.utcnow().isoformat()
+            }
+        )
+        person.extra.save()
+
+    def handle_person(self, person):
+        # Get the Twitter screen name and user ID if they exist:
+        try:
+            screen_name = person.contact_details \
+                .get(contact_type='twitter').value
+        except ContactDetail.DoesNotExist:
+            screen_name = None
+        try:
+            user_id = person.identifiers \
+                .get(scheme='twitter').identifier
+        except Identifier.DoesNotExist:
+            user_id = None
+        # If they have a Twitter user ID, then check to see if we
+        # need to update the screen name from that; if so, update
+        # the screen name.  Skip to the next person. This catches
+        # people who have changed their Twitter screen name, or
+        # anyone who had a user ID set but not a screen name
+        # (which should be rare).
+        if user_id:
+            verbose(_("{person} has a Twitter user ID: {user_id}").format(
+                person=person, user_id=user_id
+            ))
+            if user_id not in self.user_id_to_screen_name:
+                print(_("Warning: user ID {user_id} not found for {person_name}: {person_url}").format(
+                    user_id=user_id,
+                    person_name=person.name,
+                    person_url=person.extra.get_absolute_url(),
+                ))
+                return
+            correct_screen_name = self.user_id_to_screen_name[user_id]
+            if (screen_name is None) or (screen_name != correct_screen_name):
+                verbose(_("Correcting the screen name from {old_screen_name} to {correct_screen_name}").format(
+                    old_screen_name=screen_name,
+                    correct_screen_name=correct_screen_name
+                ))
+                person.contact_details.update_or_create(
+                    contact_type='twitter',
+                    defaults={'value': correct_screen_name},
+                )
+                self.record_new_version(person)
+            else:
+                verbose(_("The screen name ({screen_name}) was already correct").format(
+                    screen_name=screen_name
+                ))
+        # Otherwise, if they have a Twitter screen name (but no
+        # user ID, since we already dealt with that case) then
+        # find their Twitter user ID and set that as an identifier.
+        elif screen_name:
+            verbose(_("{person} has Twitter screen name ({screen_name}) but no user ID").format(
+                person=person, screen_name=screen_name
+            ))
+            if screen_name not in self.screen_name_to_user_id:
+                print(_("Warning: screen name {screen_name} not found for {person_name}: {person_url}").format(
+                    screen_name=screen_name,
+                    person_name=person.name,
+                    person_url=person.extra.get_absolute_url(),
+                ))
+                return
+            verbose(_("Adding the user ID {user_id}").format(
+                user_id=self.screen_name_to_user_id[screen_name]
+            ))
+            person.identifiers.create(
+                scheme='twitter',
+                identifier=self.screen_name_to_user_id[screen_name]
+            )
+            self.record_new_version(person)
+        else:
+            verbose(_("{person} had no Twitter account information").format(
+                person=person
+            ))
+
+    def handle(self, *args, **options):
+        global VERBOSE
+        VERBOSE = int(options['verbosity']) > 1
+        token = settings.TWITTER_APP_ONLY_BEARER_TOKEN
+        if not token:
+            raise CommandError(_("TWITTER_APP_ONLY_BEARER_TOKEN was not set"))
+        headers = {'Authorization': 'Bearer {token}'.format(token=token)}
+
+        # Find all unique Twitter screen names in the database:
+        all_screen_names = list(
+            ContactDetail.objects.filter(contact_type='twitter'). \
+                values_list('value', flat=True).distinct()
+        )
+
+        # Find all unique Twitter identifiers in the database:
+        all_user_ids = list(
+            Identifier.objects.filter(scheme='twitter'). \
+                values_list('identifier', flat=True).distinct()
+        )
+
+        self.screen_name_to_user_id = {}
+        self.user_id_to_screen_name = {}
+        for i in range(0, len(all_screen_names), MAX_IN_A_REQUEST):
+            screen_names = all_screen_names[i:(i + MAX_IN_A_REQUEST)]
+            r = requests.post(
+                'https://api.twitter.com/1.1/users/lookup.json',
+                data={
+                    'screen_name': ','.join(screen_names)
+                },
+                headers=headers,
+            )
+            for d in r.json():
+                self.screen_name_to_user_id[d['screen_name']] = text_type(d['id'])
+                self.user_id_to_screen_name[text_type(d['id'])] = d['screen_name']
+
+        # Now look for any user IDs in the database that weren't found
+        # from the above query:
+        remaining_user_ids = list(
+            set(all_user_ids) - set(self.user_id_to_screen_name.keys())
+        )
+        for i in range(0, len(remaining_user_ids), MAX_IN_A_REQUEST):
+            user_ids = remaining_user_ids[i:(i + MAX_IN_A_REQUEST)]
+            r = requests.post(
+                'https://api.twitter.com/1.1/users/lookup.json',
+                data={
+                    'user_id': ','.join(user_ids)
+                },
+                headers=headers,
+            )
+            for d in r.json():
+                self.screen_name_to_user_id[d['screen_name']] = text_type(d['id'])
+                self.user_id_to_screen_name[d['id']] = text_type(d['id'])
+
+        # Now go through every person in the database and check their
+        # Twitter details:
+        for person in Person.objects.select_related('extra'):
+            with transaction.atomic():
+                self.handle_person(person)

--- a/candidates/models/field_mappings.py
+++ b/candidates/models/field_mappings.py
@@ -82,4 +82,5 @@ CSV_ROW_FIELDS = [
     'image_copyright',
     'image_uploading_user',
     'image_uploading_user_notes',
+    'twitter_user_id',
 ]

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -21,7 +21,9 @@ from slugify import slugify
 from django_date_extensions.fields import ApproximateDate
 
 from elections.models import Election, AreaType
-from popolo.models import Person, Organization, Post, Membership, Area
+from popolo.models import (
+    Person, Organization, Post, Membership, Area, Identifier
+)
 from images.models import Image, HasImageMixin
 
 from compat import python_2_unicode_compatible
@@ -494,6 +496,12 @@ class PersonExtra(HasImageMixin, models.Model):
                 pass
         else:
             primary_image_url = ''
+        try:
+            twitter_user_id = self.base.identifiers.get(
+                scheme='twitter',
+            ).identifier
+        except Identifier.DoesNotExist:
+            twitter_user_id = ''
 
         row = {
             'id': self.base.id,
@@ -511,6 +519,7 @@ class PersonExtra(HasImageMixin, models.Model):
             'elected': elected_for_csv,
             'email': self.base.email,
             'twitter_username': self.twitter_username,
+            'twitter_user_id': twitter_user_id,
             'facebook_page_url': self.facebook_page_url,
             'linkedin_url': self.linkedin_url,
             'party_ppc_page_url': self.party_ppc_page_url,

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -30,6 +30,7 @@ from .field_mappings import (
 )
 from .fields import ExtraField, PersonExtraFieldValue, SimplePopoloField, ComplexPopoloField
 from ..diffs import get_version_diffs
+from ..twitter_api import update_twitter_user_id, TwitterAPITokenMissing
 from .versions import get_person_as_version_data
 
 """Extensions to the base django-popolo classes for YourNextRepresentative
@@ -63,6 +64,10 @@ def update_person_from_form(person, person_extra, form):
             )
     person.save()
     person_extra.save()
+    try:
+        update_twitter_user_id(person)
+    except TwitterAPITokenMissing:
+        pass
     for election_data in form.elections_with_fields:
         post_id = form_data.get('constituency_' + election_data.slug)
         standing = form_data.pop('standing_' + election_data.slug, 'standing')

--- a/candidates/tests/test_constituency_view.py
+++ b/candidates/tests/test_constituency_view.py
@@ -142,6 +142,7 @@ class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
                 'mapit_url': '',
                 'proxy_image_url_template': '',
                 'twitter_username': '',
+                'twitter_user_id': '',
                 'post_id': '65808',
                 'party_id': 'party:53',
                 'image_copyright': '',

--- a/candidates/tests/test_csv_export.py
+++ b/candidates/tests/test_csv_export.py
@@ -77,20 +77,20 @@ class CSVTests(UK2015ExamplesMixin, TestCase):
 
     def test_as_dict(self):
         person_dict = self.gb_person_extra.as_dict(self.election)
-        self.assertEqual(len(person_dict), 26)
+        self.assertEqual(len(person_dict), 27)
         self.assertEqual(person_dict['id'], 2009)
 
     def test_as_dict_2010(self):
         # Could do with a person example who changes constituency
         person_dict = self.gb_person_extra.as_dict(self.earlier_election)
-        self.assertEqual(len(person_dict), 26)
+        self.assertEqual(len(person_dict), 27)
         self.assertEqual(person_dict['id'], 2009)
 
     def test_csv_output(self):
         example_output = (
-            b'id,name,honorific_prefix,honorific_suffix,gender,birth_date,election,party_id,party_name,post_id,post_label,mapit_url,elected,email,twitter_username,facebook_page_url,party_ppc_page_url,facebook_personal_url,homepage_url,wikipedia_url,linkedin_url,image_url,proxy_image_url_template,image_copyright,image_uploading_user,image_uploading_user_notes\r\n'
-            b'2009,Tessa Jowell,Ms,DBE,female,,2015,party:53,Labour Party,65913,Camberwell and Peckham,http://mapit.mysociety.org/area/65913,,jowell@example.com,,,,,,,,,,,,\r\n'
-            b'1953,Daith\xc3\xad McKay,,,male,,2015,party:39,Sinn F\xc3\xa9in,66135,North Antrim,http://mapit.mysociety.org/area/66135,,,,,,,,,,,,,,\r\n'
+            b'id,name,honorific_prefix,honorific_suffix,gender,birth_date,election,party_id,party_name,post_id,post_label,mapit_url,elected,email,twitter_username,facebook_page_url,party_ppc_page_url,facebook_personal_url,homepage_url,wikipedia_url,linkedin_url,image_url,proxy_image_url_template,image_copyright,image_uploading_user,image_uploading_user_notes,twitter_user_id\r\n'
+            b'2009,Tessa Jowell,Ms,DBE,female,,2015,party:53,Labour Party,65913,Camberwell and Peckham,http://mapit.mysociety.org/area/65913,,jowell@example.com,,,,,,,,,,,,,\r\n'
+            b'1953,Daith\xc3\xad McKay,,,male,,2015,party:39,Sinn F\xc3\xa9in,66135,North Antrim,http://mapit.mysociety.org/area/66135,,,,,,,,,,,,,,,\r\n'
         ).decode('utf-8')
         self.assertEqual(
             list_to_csv(

--- a/candidates/twitter_api.py
+++ b/candidates/twitter_api.py
@@ -1,0 +1,63 @@
+from django.conf import settings
+from django.core.cache import cache
+from django.utils.six import text_type
+
+import requests
+
+from popolo.models import ContactDetail
+
+
+class TwitterAPITokenMissing(Exception):
+    pass
+
+
+def get_twitter_user_id(twitter_screen_name):
+    cache_key = 'twitter-screen-name'
+    cached_result = cache.get(cache_key)
+    if cached_result:
+        return cached_result
+    token = settings.TWITTER_APP_ONLY_BEARER_TOKEN
+    if not token:
+        raise TwitterAPITokenMissing()
+    headers = {'Authorization': 'Bearer {token}'.format(token=token)}
+    r = requests.post(
+        'https://api.twitter.com/1.1/users/lookup.json',
+        data={'screen_name': twitter_screen_name},
+        headers=headers,
+    )
+    data = r.json()
+    if data:
+        if 'errors' in data:
+            all_errors = data['errors']
+            if any(d['code'] == 17 for d in all_errors):
+                # (That's the error code for not being able to find the
+                # user.)
+                result = ''
+            else:
+                raise Exception("The Twitter API says: {error_messages}".format(
+                    error_messages=data['errors']
+                ))
+        else:
+            result = text_type(data[0]['id'])
+    else:
+        result = ''
+    # Cache Twitter screen name -> user ID results for 5 minutes -
+    # this is largely so we usually only make one API call for both
+    # validating a screen name in a form and acting on submission of
+    # that form.
+    cache.set(cache_key, result, 60 * 5)
+    return result
+
+def update_twitter_user_id(person):
+    try:
+        screen_name = person.contact_details \
+            .get(contact_type='twitter').value
+    except ContactDetail.DoesNotExist:
+        return
+    user_id = get_twitter_user_id(screen_name)
+    if not user_id:
+        return
+    person.identifiers.update_or_create(
+        scheme='twitter',
+        defaults={'identifier': user_id}
+    )

--- a/conf/crontab.ugly
+++ b/conf/crontab.ugly
@@ -9,6 +9,9 @@ MAILTO=ynr@mysociety.org
 # Run face detection every 15 minutes, again offset a bit:
 10,25,40,55 * * * * !!(*= $user *)!! /data/vhost/!!(*= $vhost *)!!/venv/bin/python /data/vhost/!!(*= $vhost *)!!/yournextrepresentative/manage.py moderation_queue_detect_faces_in_queued_images
 
+# Make sure that the Twitter screen names and user IDs are consistent
+20 3 * * * !!(*= $user *)!! /data/vhost/!!(*= $vhost *)!!/venv/bin/python /data/vhost/!!(*= $vhost *)!!/yournextrepresentative/manage.py candidates_update_twitter_usernames
+
 # Fetch data from TheyWorkForYou and check for any new parlparse
 # IDs. (The people.json file is being updated on 5n, so fetch data a few
 # minutes later, at 5n + 3.)

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -103,10 +103,18 @@ DD_MM_DATE_FORMAT_PREFERRED: true
 # least:
 CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST: 20
 
-# A Twitter application-only bearer token.  This is used by
-# candidates_update_twitter_usernames to map between twitter user IDs
-# and screen names. You can generate one of these by following the
-# instructions here: https://dev.twitter.com/oauth/application-only If
-# you don't set this then the only thing that won't work is
-# candidates_update_twitter_usernames
+# A Twitter application-only bearer token.  This is important so that
+# (a) Twitter usernames can be validated as actually existing when
+# they're supplied by a user (b) the stable Twitter user ID is stored
+# when someone sets a Twitter username and (c) the
+# candidates_update_twitter_usernames command (which deals with
+# changes of screen name) will work.
+#
+# You can generate an application-only bearer token with:
+#   curl -u "$CONSUMER_KEY:$CONSUMER_SECRET" \
+#       --data 'grant_type=client_credentials' \
+#       'https://api.twitter.com/oauth2/token'
+#
+# Or see https://dev.twitter.com/oauth/application-only for more
+# details.
 TWITTER_APP_ONLY_BEARER_TOKEN: ''

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -102,3 +102,11 @@ DD_MM_DATE_FORMAT_PREFERRED: true
 # party in the party set with most candidates down to those with the
 # least:
 CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST: 20
+
+# A Twitter application-only bearer token.  This is used by
+# candidates_update_twitter_usernames to map between twitter user IDs
+# and screen names. You can generate one of these by following the
+# instructions here: https://dev.twitter.com/oauth/application-only If
+# you don't set this then the only thing that won't work is
+# candidates_update_twitter_usernames
+TWITTER_APP_ONLY_BEARER_TOKEN: ''

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -402,6 +402,10 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'RESTRICT_RENAMES': conf.get('RESTRICT_RENAMES'),
         'EDITS_ALLOWED': conf.get('EDITS_ALLOWED', True),
 
+        # A bearer token for the Twitter API for mapping between
+        # Twitter usernames and IDs.
+        'TWITTER_APP_ONLY_BEARER_TOKEN': conf.get('TWITTER_APP_ONLY_BEARER_TOKEN'),
+
         # Django Rest Framework settings:
         'REST_FRAMEWORK': {
             'DEFAULT_PERMISSION_CLASSES': ('candidates.api_permissions.ReadOnly',),


### PR DESCRIPTION
This pull request adds:

* A management command for looking for (and fixing) any mismatches
  between Twitter screen names (in a ContactDetail with contact_type
  'twitter') and user IDs (in an Identifier with scheme 'twitter'). The user
  ID, if present is treated as the more reliable source (since it is - people
  can change screen names, and their user ID will remain the same).
* Validation of Twitter screen names to check that the named Twitter
  account for someone exists before letting you save that entry.
* Code that looks up and saves the Twitter user ID on adding and editing
  a candidate.
* A `twitter_user_id` column to CSV output.

The management command (`candidates_update_twitter_usernames`) could reasonably be run once a day. It finds many Twitter screen names currently associated with people that don't exist, and will print them to standard output, so we should get an email if any such cases appear when this command is run from cron.  (We should go through these by hand probably.)

The above changes depend on adding a new configuration option to conf/general,yml, which is `TWITTER_APP_ONLY_BEARER_TOKEN`

Fixes #271