### PR TITLE
On merging / reverting remove Memberships as well as MembershipExtras

### DIFF
--- a/candidates/models/versions.py
+++ b/candidates/models/versions.py
@@ -133,9 +133,9 @@ def revert_person_from_version_data(person, person_extra, version_data):
         )
 
     # Remove all candidacies, and recreate:
-    MembershipExtra.objects.filter(
-        base__person=person_extra.base,
-        base__role=F('election__candidate_membership_role')
+    Membership.objects.filter(
+        person=person_extra.base,
+        role=F('extra__election__candidate_membership_role')
     ).delete()
     # Also remove the indications of elections that this person is
     # known not to be standing in:

--- a/candidates/tests/test_merge_view.py
+++ b/candidates/tests/test_merge_view.py
@@ -11,7 +11,7 @@ from django.test.utils import override_settings
 
 from django_webtest import WebTest
 
-from popolo.models import Person
+from popolo.models import Membership, Person
 
 from candidates.models import PersonRedirect, MembershipExtra, ImageExtra
 from mysite.helpers import mkdir_p
@@ -342,6 +342,16 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         for c, expected_election in zip(candidacies, ('2010', '2015')):
             self.assertEqual(c.election.slug, expected_election)
             self.assertEqual(c.base.post.extra.slug, '65808')
+
+        # Check that there are only two Membership objects, since
+        # there has been a bug where the MembershipExtra objects were
+        # cleared on merging, but the Membership objects were left
+        # behind.  So make sure there are only two as a regression
+        # test.
+        self.assertEqual(
+            2,
+            Membership.objects.filter(person=merged_person).count()
+        )
 
         other_names = list(merged_person.other_names.all())
         self.assertEqual(len(other_names), 1)


### PR DESCRIPTION
This was a bug - the revert_person_from_version_data method,
which was used to implement merges of two candidates as well
as reverting them to an earlier version, deletes all existing
candidacies of a person and then recreates the ones that
should be there.  However, the code was only actually removing
the MembershipExtra objects and leaving the Membership objects
in the database.  These weren't shown on the user-facing site
because of missing the MembershipExtra objects, but would be
shown in the API output which was causing confusion.

This commit fixes that problem; a delete on the Membership
queryset deletes the corresponding MembershipExtras too.

Thanks to Sym Roe (@symroe) for spotting this and figuring
out that it related to merging.

Fixes #866 