### PR TITLE
Fix searches featuring apostrophes

### DIFF
--- a/candidates/tests/test_search.py
+++ b/candidates/tests/test_search.py
@@ -56,6 +56,17 @@ class TestSearchView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form['party_gb_2015'] = self.labour_party_extra.base_id
         form.submit()
 
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user,
+        )
+        form = response.forms['new-candidate-form']
+        form['name'] = "Charlotte O'Lucas" # testers license
+        form['email'] = 'charlotte@example.com'
+        form['source'] = 'Testing adding a new person to a post'
+        form['party_gb_2015'] = self.labour_party_extra.base_id
+        form.submit()
+
         # check searching finds them
         response = self.app.get('/search?q=Elizabeth')
         self.assertTrue(
@@ -117,6 +128,15 @@ class TestSearchView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertFalse(
             re.search(
                 r'''<a[^>]*>Elizabeth Jones''',
+                response.text
+            )
+        )
+
+        # check that searching for names with apostrophe works
+        response = self.app.get("/search?q=O'Lucas")
+        self.assertTrue(
+            re.search(
+                r'''<a[^>]*>Charlotte''',
                 response.text
             )
         )

--- a/candidates/views/search.py
+++ b/candidates/views/search.py
@@ -1,5 +1,20 @@
+from django.utils.html import escape
+
 from haystack.generic_views import SearchView
+from haystack.forms import SearchForm
+
+
+class PersonSearchForm(SearchForm):
+    """
+    When Haystack indexed things into its sythesized text field
+    it HTML escapes everything. This means that we also need to
+    escape our search terms as otherwise names with apostrophes
+    and the like never match as the entry in the search index
+    is O&#39;Reilly and our search term is O'Reilly
+    """
+    def clean_q(self):
+        return escape(self.cleaned_data['q'])
 
 
 class PersonSearch(SearchView):
-    pass
+    form_class = PersonSearchForm


### PR DESCRIPTION
The search uses the text field in the index which is generated by
Haystack and escapes the content as it goes in. Search terms were not
being escaped which meant that names with an apostrophe in them never
matched.

This escapes search terms so they should not match the values in the
text field in the search index.

Fixes #862