### PR TITLE
Group elections more logically on pages that list all elections / posts

### DIFF
--- a/cached_counts/templates/reports.html
+++ b/cached_counts/templates/reports.html
@@ -19,64 +19,61 @@
      {% endblocktrans %}
   </p>
 
-  {% for era, elections in all_elections.items %}
-
-    <div class="statistics-elections {{ era }}">
-      <h2>{% if era == 'current' %}
+  {% for era in all_elections %}
+    <div class="statistics-elections {% if era.current %}current{% else %}past{% endif %}">
+      <h2>{% if era.current %}
         {% trans "Current Elections" %}
-      {% elif era == 'past' %}
+      {% else %}
         {% trans "Past Elections" %}
       {% endif %}</h2>
-
-      {% for election in elections %}
-        {% with election_name=election.name %}
-        <div id="statistics-election-{{ election.html_id }}">
-           <h3>{% blocktrans %}Statistics for the {{ election_name }}{% endblocktrans %}</h3>
-           <ul>
-             <li>{% blocktrans %}Total candidates:{% endblocktrans %} {{ election.total }}</li>
-             <li><a href="{% url "posts_counts" election=election.id %}">{% trans "Candidates per post" %}</a></li>
-             <li><a href="{% url "parties_counts" election=election.id %}">{% trans "Candidates per party" %}</a></li>
-             <li><a href="{% url "constituencies-unlocked" election=election.id %}">{% trans "See progress towards locking all posts" %}</a></li>
-           </ul>
-           {% if election.prior_elections %}
-             {% for prior_election in election.prior_elections %}
-               {% with prior_election_name=prior_election.name %}
-               <div "statistics-compared-to-prior-election">
-                 <h4>{% blocktrans %}Statistics compared to the {{ prior_election_name }}{% endblocktrans %}</h4>
-                 <ul>
-                   <li>{% blocktrans %}Total candidates in {{ prior_election_name }}:{% endblocktrans %}
-                     {{ prior_election.total }}
-                   </li>
-                   <li>{% blocktrans %}Percentage ({{ election_name }} / {{ prior_election_name }}):{% endblocktrans %}
-                     {{ prior_election.percentage|floatformat }}%
-                   </li>
-                   <li>{% blocktrans %}New candidates compared to the {{ prior_election_name }}:{% endblocktrans %}
-                     {{ prior_election.new_candidates|intcomma }}
-                   </li>
-                   <li>{% blocktrans %}Candidates standing again from the {{ prior_election_name }}:{% endblocktrans %}
-                     {{ prior_election.standing_again |intcomma }}
-                   </li>
-                   <li>{% blocktrans trimmed %}Candidates standing again from the {{ prior_election_name }}
-                     for the same party:{% endblocktrans %}
-                     {{ prior_election.standing_again_same_party|intcomma }}
-                   </li>
-                   <li>{% blocktrans trimmed %}Candidates standing again from the {{ prior_election_name }}
-                     for a different party:{% endblocktrans %}
-                     {{ prior_election.standing_again_different_party |intcomma }}
-                   </li>
-                 </ul>
-               </div>
-               {% endwith %}
-             {% endfor %}
-          {% endif %}
-        </div>
-        {% endwith %}
-      {% empty %}
-        <p>{% trans "No election data found." %}</p>
+      {% for role_data in era.roles %}
+        <h3>{{ role_data.role }}</h3>
+        {% for election in role_data.elections %}
+          <div id="statistics-election-{{ election.html_id }}">
+            {% with election_name=election.name %}
+              <h4>{% blocktrans %}Statistics for the {{ election_name }}{% endblocktrans %}</h4>
+              <ul>
+                <li>{% blocktrans %}Total candidates:{% endblocktrans %} {{ election.total }}</li>
+                <li><a href="{% url "posts_counts" election=election.id %}">{% trans "Candidates per post" %}</a></li>
+                <li><a href="{% url "parties_counts" election=election.id %}">{% trans "Candidates per party" %}</a></li>
+                <li><a href="{% url "constituencies-unlocked" election=election.id %}">{% trans "See progress towards locking all posts" %}</a></li>
+              </ul>
+              {% if election.prior_elections %}
+                {% for prior_election in election.prior_elections %}
+                  {% with prior_election_name=prior_election.name %}
+                  <div "statistics-compared-to-prior-election">
+                    <h5>{% blocktrans %}Statistics compared to the {{ prior_election_name }}{% endblocktrans %}</h5>
+                    <ul>
+                      <li>{% blocktrans %}Total candidates in {{ prior_election_name }}:{% endblocktrans %}
+                        {{ prior_election.total }}
+                      </li>
+                      <li>{% blocktrans %}Percentage ({{ election_name }} / {{ prior_election_name }}):{% endblocktrans %}
+                        {{ prior_election.percentage|floatformat }}%
+                      </li>
+                      <li>{% blocktrans %}New candidates compared to the {{ prior_election_name }}:{% endblocktrans %}
+                        {{ prior_election.new_candidates|intcomma }}
+                      </li>
+                      <li>{% blocktrans %}Candidates standing again from the {{ prior_election_name }}:{% endblocktrans %}
+                        {{ prior_election.standing_again |intcomma }}
+                      </li>
+                      <li>{% blocktrans trimmed %}Candidates standing again from the {{ prior_election_name }}
+                        for the same party:{% endblocktrans %}
+                        {{ prior_election.standing_again_same_party|intcomma }}
+                      </li>
+                      <li>{% blocktrans trimmed %}Candidates standing again from the {{ prior_election_name }}
+                        for a different party:{% endblocktrans %}
+                        {{ prior_election.standing_again_different_party |intcomma }}
+                      </li>
+                    </ul>
+                  </div>
+                  {% endwith %}
+                {% endfor %}
+              {% endif %}
+            {% endwith %}
+          </div>
+        {% endfor %}
       {% endfor %}
-
-    </div>
-
+  </div>
   {% endfor %}
 
 {% endblock content %}

--- a/cached_counts/tests.py
+++ b/cached_counts/tests.py
@@ -86,34 +86,50 @@ class CachedCountTestCase(UK2015ExamplesMixin, WebTest):
         data = json.loads(response.body.decode('utf-8'))
         self.assertEqual(
             data,
-            {
-                'current': [
-                    {
-                        'total': 18,
-                        'id': "2015",
-                        'html_id': "2015",
-                        'name': "2015 General Election",
-                        'prior_elections': [
-                            {
-                                "percentage": 900.0,
-                                "name": '2010 General Election',
-                                "new_candidates": 16,
-                                "standing_again": 2,
-                                "standing_again_different_party": 1,
-                                "standing_again_same_party": 1
-                            },
-                        ]
-                    }
-                ],
-                'past': [
-                    {
-                        'total': 2,
-                        'id': "2010",
-                        'html_id': '2010',
-                        'name': "2010 General Election"
-                    }
-                ]
-            }
+            [
+                {
+                    'current': True,
+                    'roles': [
+                        {
+                            'role': 'Member of Parliament',
+                            'elections': [
+                                {
+                                    'prior_elections': [
+                                        {
+                                            'name': '2010 General Election',
+                                            'standing_again': 2,
+                                            'new_candidates': 16,
+                                            'percentage': 900.0,
+                                            'standing_again_different_party': 1,
+                                            'standing_again_same_party': 1
+                                        }
+                                    ],
+                                    'total': 18,
+                                    'id': '2015',
+                                    'html_id': '2015',
+                                    'name': '2015 General Election'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    'current': False,
+                    'roles': [
+                        {
+                            'role': 'Member of Parliament',
+                            'elections': [
+                                {
+                                    'total': 2,
+                                    'name': '2010 General Election',
+                                    'html_id': '2010',
+                                    'id': '2010'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
         )
 
     def test_attention_needed_page(self):

--- a/cached_counts/views.py
+++ b/cached_counts/views.py
@@ -92,6 +92,7 @@ def get_counts():
                             election_id_to_candidates.get(pe.id, 0), pe
                         )
                         for pe in past_elections
+                        if pe.for_post_role == e.for_post_role
                     ]
                 election_data.update(election_counts)
                 del election_data['election']

--- a/cached_counts/views.py
+++ b/cached_counts/views.py
@@ -66,32 +66,36 @@ def get_counts():
             .values('extra__election') \
             .annotate(count=Count('extra__election'))
     }
-    all_elections_counts = {}
-    current_elections = list(Election.objects.current().by_date())
-    past_elections = list(Election.objects.current(False).by_date())
-    for era, elections in (
-            ('current', current_elections),
-            ('past', past_elections),
-    ):
-        all_elections_counts[era] = []
-        for e in elections:
-            total = election_id_to_candidates.get(e.id, 0)
-            election_counts = {
-                'id': e.slug,
-                'html_id': e.slug.replace('.', '-'),
-                'name': e.name,
-                'total': total,
-            }
-            if era == 'current':
-                election_counts['prior_elections'] = [
-                    get_prior_election_data(
-                        total, e,
-                        election_id_to_candidates.get(pe.id, 0), pe
-                    )
-                    for pe in past_elections
-                ]
-            all_elections_counts[era].append(election_counts)
-    return all_elections_counts
+    grouped_elections = Election.group_and_order_elections()
+    past_elections = [
+        election_data['election']
+        for era_data in grouped_elections
+        for role_data in era_data['roles']
+        for election_data in role_data['elections']
+        if not era_data['current']
+    ]
+    for era_data in grouped_elections:
+        for role_data in era_data['roles']:
+            for election_data in role_data['elections']:
+                e = election_data['election']
+                total = election_id_to_candidates.get(e.id, 0)
+                election_counts = {
+                    'id': e.slug,
+                    'html_id': e.slug.replace('.', '-'),
+                    'name': e.name,
+                    'total': total,
+                }
+                if era_data['current']:
+                    election_counts['prior_elections'] = [
+                        get_prior_election_data(
+                            total, e,
+                            election_id_to_candidates.get(pe.id, 0), pe
+                        )
+                        for pe in past_elections
+                    ]
+                election_data.update(election_counts)
+                del election_data['election']
+    return grouped_elections
 
 
 class ReportsHomeView(TemplateView):

--- a/candidates/templates/candidates/api.html
+++ b/candidates/templates/candidates/api.html
@@ -20,34 +20,35 @@ programmatically via a RESTful API.
 
 <h2>{% trans "CSV/Excel Download" %}</h2>
 
-<h3>{% trans "Current elections" %}</h3>
+  <h3>{% trans "All Candidates" %}</h3>
 
-<p>
+  <p>{% blocktrans trimmed %}
+    This CSV file contains details of all candidates in the database
+  {% endblocktrans %}</p>
+
   <ul>
-    {% for csv in current_csv_list %}
-      {% with slug=csv.slug title=csv.name %}
-      <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} candidates {% endblocktrans %}</a></li>
-      {% endwith %}
-    {% endfor %}
+    <li><a href="{{ MEDIA_URL }}candidates-all.csv">{% blocktrans %}Download of the all candidates {% endblocktrans %}</a></li>
   </ul>
-</p>
 
-
-{% if historic_csv_list %}
-
-<h3>{% trans "Historic elections" %}</h3>
-
-<p>
-  <ul>
-    {% for csv in historic_csv_list %}
-      {% with slug=csv.slug title=csv.name %}
-      <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} candidates {% endblocktrans %}</a></li>
-      {% endwith %}
-    {% endfor %}
-  </ul>
-</p>
-{% endif %}
-
+  {% for era in grouped_elections %}
+    <div>
+      <h3>{% if era.current %}
+        {% trans "Current Elections" %}
+      {% else %}
+        {% trans "Past Elections" %}
+      {% endif %}</h3>
+      {% for role_data in era.roles %}
+        <h4>{{ role_data.role }}</h4>
+        <ul>
+          {% for election in role_data.elections %}
+            {% with slug=election.election.slug title=election.election.name %}
+              <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} candidates {% endblocktrans %}</a></li>
+            {% endwith %}
+          {% endfor %}
+        </ul>
+      {% endfor %}
+  </div>
+  {% endfor %}
 
 <h2>{% trans "API" %}</h2>
 

--- a/candidates/templates/candidates/posts.html
+++ b/candidates/templates/candidates/posts.html
@@ -13,18 +13,24 @@
 
   <p>{% trans "Follow one of the links below to see the known candidates for that post:" %}</p>
 
-  {% for election_data in all_posts %}
-    {% with election=election_data.election posts=election_data.posts %}
-        <h2>{{ election.name }}</h2>
-
-        <ul>
-          {% for p in posts %}
-            <li>
-             <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-    {% endwith %}
+  {% for era in elections_and_posts %}
+    {% if era.current %}
+      {% for role_data in era.roles %}
+        <h2>{{ role_data.role }}</h2>
+        {% for election_data in role_data.elections %}
+          {% with election=election_data.election %}
+            <h3>{{ election.name }}</h3>
+            <ul>
+              {% for p in election_data.posts %}
+                <li>
+                 <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endwith %}
+        {% endfor %}
+      {% endfor %}
+    {% endif %}
   {% endfor %}
 
 {% endblock %}

--- a/candidates/tests/test_group_elections.py
+++ b/candidates/tests/test_group_elections.py
@@ -1,0 +1,146 @@
+from django.test import TestCase
+
+from elections.models import Election
+
+from .uk_examples import UK2015ExamplesMixin
+from .factories import ElectionFactory
+
+
+class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
+
+    def setUp(self):
+        super(TestElectionGrouping, self).setUp()
+        self.sp_c_election = ElectionFactory(
+            slug='sp.c.2016-05-05',
+            name='2016 Scottish Parliament Election (Constituencies)',
+            election_date='2016-05-05',
+            for_post_role='Member of the Scottish Parliament',
+        )
+        self.sp_r_election = ElectionFactory(
+            slug='sp.r.2016-05-05',
+            name='2016 Scottish Parliament Election (Regions)',
+            election_date='2016-05-05',
+            for_post_role='Member of the Scottish Parliament',
+        )
+
+    def test_election_grouping(self):
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                Election.group_and_order_elections(),
+                [
+                    {
+                        'current': True,
+                        'roles': [
+                            {
+                                'role': 'Member of Parliament',
+                                'elections': [
+                                    {'election': self.election},
+                                ]
+                            },
+                            {
+                                'role': 'Member of the Scottish Parliament',
+                                'elections': [
+                                    {'election': self.sp_c_election},
+                                    {'election': self.sp_r_election},
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'current': False,
+                        'roles': [
+                            {
+                                'role': 'Member of Parliament',
+                                'elections': [
+                                    {'election': self.earlier_election},
+                                ]
+                            }
+                        ]
+                    },
+                ]
+            )
+
+    def test_election_grouping_with_posts(self):
+        with self.assertNumQueries(2):
+            self.assertEqual(
+                Election.group_and_order_elections(include_posts=True),
+                [
+                    {
+                        'current': True,
+                        'roles': [
+                            {
+                                'role': 'Member of Parliament',
+                                'elections': [
+                                    {
+                                        'election': self.election,
+                                        'posts': [
+                                            self.camberwell_post_extra,
+                                            self.dulwich_post_extra,
+                                            self.edinburgh_east_post_extra,
+                                            self.edinburgh_north_post_extra,
+                                        ]
+                                    },
+                                ]
+                            },
+                            {
+                                'role': 'Member of the Scottish Parliament',
+                                'elections': [
+                                    {'election': self.sp_c_election, 'posts': []},
+                                    {'election': self.sp_r_election, 'posts': []},
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        'current': False,
+                        'roles': [
+                            {
+                                'role': 'Member of Parliament',
+                                'elections': [
+                                    {
+                                        'election': self.earlier_election,
+                                        'posts': [
+                                            self.camberwell_post_extra,
+                                            self.dulwich_post_extra,
+                                            self.edinburgh_east_post_extra,
+                                            self.edinburgh_north_post_extra,
+                                        ]
+                                    },
+                                ]
+                            }
+                        ]
+                    },
+                ]
+            )
+
+    def test_election_just_general_elections(self):
+        self.sp_c_election.delete()
+        self.sp_r_election.delete()
+        with self.assertNumQueries(1):
+            self.assertEqual(
+                Election.group_and_order_elections(),
+                [
+                    {
+                        'current': True,
+                        'roles': [
+                            {
+                                'role': 'Member of Parliament',
+                                'elections': [
+                                    {'election': self.election},
+                                ]
+                            },
+                        ]
+                    },
+                    {
+                        'current': False,
+                        'roles': [
+                            {
+                                'role': 'Member of Parliament',
+                                'elections': [
+                                    {'election': self.earlier_election},
+                                ]
+                            }
+                        ]
+                    },
+                ]
+            )

--- a/candidates/tests/test_posts_view.py
+++ b/candidates/tests/test_posts_view.py
@@ -13,7 +13,7 @@ class TestPostsView(UK2015ExamplesMixin, WebTest):
 
         self.assertTrue(
             response.html.find(
-                'h2', text='2015 General Election'
+                'h3', text='2015 General Election'
             )
         )
 
@@ -32,12 +32,12 @@ class TestPostsView(UK2015ExamplesMixin, WebTest):
 
         self.assertTrue(
             response.html.find(
-                'h2', text='2010 General Election'
+                'h3', text='2010 General Election'
             )
         )
 
         self.assertTrue(
             response.html.find(
-                'h2', text='2015 General Election'
+                'h3', text='2015 General Election'
             )
         )

--- a/candidates/tests/uk_examples.py
+++ b/candidates/tests/uk_examples.py
@@ -18,11 +18,13 @@ class UK2015ExamplesMixin(object):
         self.election = factories.ElectionFactory.create(
             slug='2015',
             name='2015 General Election',
+            for_post_role='Member of Parliament',
             area_types=(self.wmc_area_type,)
         )
         self.earlier_election = factories.EarlierElectionFactory.create(
             slug='2010',
             name='2010 General Election',
+            for_post_role='Member of Parliament',
             area_types=(self.wmc_area_type,)
         )
         # Create some example parties:

--- a/candidates/views/help.py
+++ b/candidates/views/help.py
@@ -11,16 +11,7 @@ class HelpApiView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(HelpApiView, self).get_context_data(**kwargs)
 
-        context['current_csv_list'] = []
-        for election_data in Election.objects.current().by_date():
-            context['current_csv_list'].append({'slug': election_data.slug, 'name': election_data.name})
-
-        context['historic_csv_list'] = []
-        current_slugs = [election['slug'] for election in context['current_csv_list']]
-        for election_data in Election.objects.by_date():
-            if election_data.slug not in current_slugs:
-                context['historic_csv_list'].append(
-                    {'slug': election_data.slug, 'name': election_data.name})
+        context['grouped_elections'] = Election.group_and_order_elections()
 
         context['base_api_url'] = self.request.build_absolute_uri(
             reverse('api-root', kwargs={'version': 'v0.9'})

--- a/candidates/views/posts.py
+++ b/candidates/views/posts.py
@@ -1,9 +1,7 @@
 from __future__ import unicode_literals
 
-from django.db.models import Prefetch
 from django.views.generic import TemplateView
 
-from candidates.models import PostExtra
 from elections.models import Election
 
 class PostListView(TemplateView):
@@ -11,20 +9,6 @@ class PostListView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super(PostListView, self).get_context_data(**kwargs)
-
-        prefetch_qs = \
-            PostExtra.objects.order_by('base__label').select_related('base')
-
-        context['all_posts'] = \
-            [
-                {
-                    'election': election,
-                    'posts': election.posts.all()
-                }
-                for election in
-                Election.objects.current().order_by('-election_date'). \
-                    prefetch_related(
-                        Prefetch('posts', queryset=prefetch_qs)
-                    )
-            ]
+        context['elections_and_posts'] = \
+            Election.group_and_order_elections(include_posts=True)
         return context

--- a/elections/st_paul_municipal_2015/templates/candidates/posts.html
+++ b/elections/st_paul_municipal_2015/templates/candidates/posts.html
@@ -13,20 +13,24 @@
 
   <p>{% trans "Follow one of the links below to see the known candidates for that post:" %}</p>
 
-  {% for election_data in all_posts %}
-
-    {% with election=election_data.election posts=election_data.posts %}
-        <h2>{{ election.name }}</h2>
-
-        <ul>
-          {% for p in posts %}
-            <li>
-             <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
-            </li>
-          {% endfor %}
-        </ul>
-    {% endwith %}
-
+  {% for era in elections_and_posts %}
+    {% if era.current %}
+      {% for role_data in era.roles %}
+        <h2>{{ role_data.role }}</h2>
+        {% for election_data in role_data.elections %}
+          {% with election=election_data.election %}
+            <h3>{{ election.name }}</h3>
+            <ul>
+              {% for p in election_data.posts %}
+                <li>
+                 <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endwith %}
+        {% endfor %}
+      {% endfor %}
+    {% endif %}
   {% endfor %}
 
 {% endblock %}

--- a/elections/st_paul_municipal_2015/tests.py
+++ b/elections/st_paul_municipal_2015/tests.py
@@ -172,8 +172,6 @@ class StPaulTests(WebTest):
 
     def test_posts_page(self):
         response = self.app.get('/posts')
-        with open('foo.html', 'w') as f:
-            f.write(str(response))
         self.assertIn(
             '<h3>City Council Election</h3>',
             response,

--- a/elections/st_paul_municipal_2015/tests.py
+++ b/elections/st_paul_municipal_2015/tests.py
@@ -175,7 +175,7 @@ class StPaulTests(WebTest):
         with open('foo.html', 'w') as f:
             f.write(str(response))
         self.assertIn(
-            '<h2>City Council Election</h2>',
+            '<h3>City Council Election</h3>',
             response,
         )
         self.assertIn(
@@ -183,7 +183,7 @@ class StPaulTests(WebTest):
             response,
         )
         self.assertIn(
-            '<h2>School Board Election</h2>',
+            '<h3>School Board Election</h3>',
             response,
         )
         self.assertIn(

--- a/elections/uk/migrations/0003_adjust_roles_for_grouping.py
+++ b/elections/uk/migrations/0003_adjust_roles_for_grouping.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import re
+
+from django.db import migrations
+
+
+def adjust_roles_for_grouping(apps, schema_editor):
+    Election = apps.get_model('elections', 'Election')
+    for election in Election.objects.all():
+        if re.search(r'^local\.[^.]+\.2016', election.slug):
+            election.for_post_role = 'Local Councillor'
+            election.save()
+        if re.search(r'^mayor\.[^.]+\.2016', election.slug):
+            election.for_post_role = 'Mayor'
+            election.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('uk', '0002_remove-gb-prefix'),
+    ]
+
+    operations = [
+        migrations.RunPython(adjust_roles_for_grouping),
+    ]


### PR DESCRIPTION
These commits change the following pages:

* `/numbers`
* `/posts`
* `/help/api`

... so that elections and posts are groups by:

* Group by `current=True`, then `current=False`
  * Group by `for_post_role` (ordered alphabetically)
    * Order election by election date (new to old) then election name
      * Order posts by post label

When there are a lot of elections, this should make their structure
more obvious.  Grouping by `for_post_role` means that the elections
representing constituency and regional elections in the Scottish
Parliament Elections come together.

This also adds a link to the all candidates CSV file, which was
missing.

Fixes #863 
Fixes #598 

![new-posts-page](https://cloud.githubusercontent.com/assets/7907/14895444/8a224e0e-0d70-11e6-9eeb-3cb6df6c9997.png)
