### PR TITLE
Log the rejection reason for photo moderation operations

### DIFF
--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -23,7 +23,7 @@ class LoggedActionAdmin(admin.ModelAdmin):
     list_filter = ('action_type',)
     list_display = ['user', 'ip_address', 'action_type',
                     'popit_person_new_version', 'person_link',
-                    'created', 'updated', 'source']
+                    'created', 'updated', 'source', 'note']
     ordering = ('-created',)
 
     def person_link(self, o):

--- a/candidates/migrations/0030_update_complexfields_help_text.py
+++ b/candidates/migrations/0030_update_complexfields_help_text.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0029_add_ordering_to_fields_meta'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='complexpopolofield',
+            name='info_type_key',
+            field=models.CharField(help_text="Name of the field in the array that stores the type ('note' for links, 'contact_type' for contacts, 'scheme' for identifiers)", max_length=100),
+        ),
+        migrations.AlterField(
+            model_name='complexpopolofield',
+            name='info_value_key',
+            field=models.CharField(help_text="Name of the field in the array that stores the value, e.g 'url' for links, 'value' for contact_type, 'identifier' for identifiers", max_length=100),
+        ),
+        migrations.AlterField(
+            model_name='complexpopolofield',
+            name='old_info_type',
+            field=models.CharField(help_text="Used for supporting info_types that have been renamed. As such it's rarely used.", max_length=100, blank=True),
+        ),
+    ]

--- a/candidates/migrations/0031_loggedaction_note.py
+++ b/candidates/migrations/0031_loggedaction_note.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0030_update_complexfields_help_text'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='loggedaction',
+            name='note',
+            field=models.TextField(null=True, blank=True),
+        ),
+    ]

--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -25,6 +25,7 @@ class LoggedAction(models.Model):
     updated = models.DateTimeField(auto_now=True)
     ip_address = models.CharField(max_length=50, blank=True, null=True)
     source = models.TextField()
+    note = models.TextField(blank=True, null=True)
 
 
 class PersonRedirect(models.Model):

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -314,6 +314,7 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
             self.assertEqual(la.action_type, 'photo-reject')
             self.assertEqual(la.person.id, 2009)
             self.assertEqual(la.source, 'Rejected a photo upload from john')
+            self.assertEqual(la.note, 'There\'s no clear source or copyright statement')
 
             mock_send_mail.assert_called_once_with(
                 'YNR image moderation results',

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -346,6 +346,7 @@ class PhotoReview(GroupRequiredMixin, TemplateView):
                 popit_person_new_version='',
                 person=person,
                 source=update_message,
+                note=form.cleaned_data['rejection_reason'],
             )
             retry_upload_link = self.request.build_absolute_uri(
                 reverse(


### PR DESCRIPTION
This adds a note field to the LoggedActions model and uses that to store the rejection reason when uploaded photos are rejected during moderation.

It also adds a migration to update the help text of the complex fields because there was a mismatch there.

Fixes #896 