### PR TITLE
Display the party list position on the person page

### DIFF
--- a/candidates/static/candidates/_people.scss
+++ b/candidates/static/candidates/_people.scss
@@ -376,6 +376,19 @@
       margin-top: 0.5em;
     }
   }
+
+  .person-position {
+    display: block;
+    float: left;
+    font-size: 1em;
+    line-height: (4em / 2);
+    width: (4em / 2);
+    margin-right: (1.5em / 2);
+    text-align: center;
+    font-weight: bold;
+    background-color: $candidate-order-background-color;
+    color: $candidate-order-color;
+  }
 }
 
 @media #{$medium-up} {

--- a/candidates/static/candidates/_people.scss
+++ b/candidates/static/candidates/_people.scss
@@ -369,6 +369,13 @@
       border-color: mix($error-input-border-color, #fff, 50%);
     }
   }
+
+  .candidates__elected ul {
+    list-style: none;
+    li {
+      margin-top: 0.5em;
+    }
+  }
 }
 
 @media #{$medium-up} {

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -109,6 +109,20 @@
             {% endblocktrans %}</h4>
     </div>
     {% endif %}
+
+  {% for membership in elected_in %}
+  {% if forloop.first %}
+  <div class="candidates__elected">
+    <h3>{% trans "Elected as:" %}</h3>
+    <ul>
+  {% endif %}
+      <li>{% blocktrans with post_label=membership.post.label election_name=membership.extra.election.name %}{{ post_label }} in {{ election_name }}{% endblocktrans %}</li>
+  {% if forloop.last %}
+    </ul>
+  </div>
+  {% endif %}
+  {% endfor %}
+
   <h2>{% trans "Personal details:" %}</h2>
 
   <dl>

--- a/candidates/templatetags/standing.py
+++ b/candidates/templatetags/standing.py
@@ -41,6 +41,13 @@ def post_in_election(person, election):
         result += ' <span class="party">{0}</span>'.format(
             candidacy.on_behalf_of.name
         )
+
+        if candidacy.extra.party_list_position:
+            result = u'<div title="{0}" aria-label="{0}" class="person-position">{1}</div>{2}'.format(
+                _(u'Party list position'),
+                candidacy.extra.party_list_position,
+                result
+            )
     else:
         if election in person.extra.not_standing.all():
             if election.current:

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -121,6 +121,13 @@ class PersonView(TemplateView):
             ).order_by('-election_date')
         else:
             context['elections_to_list'] = elections_by_date
+
+        context['elected_in'] = self.person.memberships.filter(
+            extra__elected=True
+        ).select_related(
+            'post', 'extra__election'
+        ).order_by('-extra__election__election_date')
+
         context['last_candidacy'] = self.person.extra.last_candidacy
         context['election_to_show'] = None
         context['simple_fields'] = [


### PR DESCRIPTION
If a candidate has a party list position in an election this displays that alongside the candidacy in the Candidacies section of the person page.

Fixes #866