### PR TITLE
WIP: Improve date parsing in candidate forms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,9 @@ python:
   - '3.4'
   - '3.5'
 addons:
+  apt:
+    packages:
+      - libicu-dev
   postgresql: "9.1"
 
 install:

--- a/candidates/date_parsing.py
+++ b/candidates/date_parsing.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+
+from collections import OrderedDict, namedtuple
+import datetime as dt
+import enum
+import itertools as it
+import re
+
+from django.core.exceptions import ValidationError
+from django.utils.translation import ugettext_lazy as _l
+import icu
+
+from compat import StrippedCharField
+
+__all__ = ('DatePrecision', 'DateParser', 'Date', 'DateCharField')
+
+
+class DatePrecision(enum.IntEnum):
+
+    DAY = 0
+    MONTH = 1
+    YEAR = 2
+
+
+class _cached_parser_property(object):
+
+    def __init__(self, fn):
+        self.fn_name = fn.__name__
+
+    def __get__(self, _, owner):
+        parser_instance = owner()
+        # Replace the original ``DateParser.default_parser`` with our
+        # ``parser_instance``
+        setattr(owner, self.fn_name, parser_instance)
+        return parser_instance
+
+
+class DateParser(object):
+    """A utility to parse short- and long-form date strings into date objects.
+
+    ``DateParser`` converts user-submitted dates into Python ``datetime.date``
+    objects.  It does this by generating localised date patterns and checking
+    if any match the input.  ``DateParser`` also has limited support for
+    partial dates.
+
+        >>> dp = DateParser(locale='el')
+        >>> date = dp.parse('Μάιος 2016')
+        >>> date
+        Date(date=datetime.date(2016, 5, 1), precision=<DatePrecision.MONTH: 1>)
+        >>> str(date) == '2016-05'
+        True
+
+    ``DateParser`` won't parse any date that deviates from the canonical
+    representations in the Unicode CLDR - with the exception of ISO 8601 -
+    leaving little leeway for long dates.  Rather, ``DateParser`` and the
+    accompanying ``DateCharField`` are optimised for the input of short
+    dates.  The is because: (a) people are trained to abbreviate dates;
+    and (b) long dates are complex and existing solutions are Anglocentric.
+    """
+
+    # The skeleton keys correspond to IDs in the Unicode CLDR
+    _skeletons = OrderedDict(
+        (('yMMMMd', DatePrecision.DAY),       # November
+         ('yMMMd', DatePrecision.DAY),        # Nov
+         ('yMd', DatePrecision.DAY),          # 12/12/12 and the like
+         ('yMMMM', DatePrecision.MONTH),
+         ('yMMM', DatePrecision.MONTH)))
+    _patterns = OrderedDict(
+        (('yyyy-MM-dd', DatePrecision.DAY),   # ISO 8601
+         ('d-M-yyyy', DatePrecision.DAY),     # 10-6-2016
+         ('yyyy-MM', DatePrecision.MONTH),
+         ('LLLL y', DatePrecision.MONTH),     # Μάιος, cf. Μαΐου (see http://unicode.org/cldr/trac/ticket/8456)
+         ('LLL y', DatePrecision.MONTH),      # Μάι, cf. Μαΐ
+         ('y', DatePrecision.YEAR)))
+    _skeletons_and_patterns = dict(it.chain(_skeletons.items(),
+                                            _patterns.items()))
+
+    # FIXME: there might be a way to accomplish this in ICU
+    _validators = dict(it.chain(
+        ((k, lambda v: v) for k in _skeletons_and_patterns),
+        (('yyyy-MM-dd',
+          lambda v, _r=re.compile(r'\d{4}-\d{2}-\d{2}$'): _r.match(v)),
+         ('d-M-yyyy',
+          lambda v, _r=re.compile(r'\d{1,2}-\d{1,2}-\d{4}$'): _r.match(v)),
+         ('yyyy-MM',
+          lambda v, _r=re.compile(r'\d{4}-\d{2}$'): _r.match(v)),
+         ('y',
+          lambda v, _r=re.compile(r'\d{4}$'): _r.match(v)))))
+
+    def _prepare_parser_fns(self, locale):
+        locale = icu.Locale(locale)
+        dtpg = icu.DateTimePatternGenerator.createInstance(locale)
+        parsers = it.chain(((f, icu.SimpleDateFormat(dtpg.getBestPattern(f),
+                                                     locale))
+                            for f in self._skeletons),
+                           ((f, icu.SimpleDateFormat(f, locale))
+                            for f in self._patterns))
+        parsers = OrderedDict(parsers)
+        # Make sure dates are parsed reasonably strictly.  As of ICU 57.1,
+        # the parse flags are:
+        #   UDAT_PARSE_ALLOW_WHITESPACE = 0              | |
+        #   UDAT_PARSE_ALLOW_NUMERIC = 1                 | |
+        #   UDAT_PARSE_PARTIAL_LITERAL_MATCH = 2         |x|
+        #   UDAT_PARSE_MULTIPLE_PATTERNS_FOR_MATCH = 3   |x|
+        #   UDAT_BOOLEAN_ATTRIBUTE_COUNT = 4             |x|
+        # However, for compatibility with older version of ICU, we're
+        # only able to switch off the first two.
+        for k in parsers:
+            parsers[k].setLenient(False)
+        return parsers
+
+    def __init__(self, locale=None):
+        if not locale:
+            from django.conf import settings
+            locale = settings.LANGUAGE_CODE
+        if locale == 'en':
+            # Default to BrEng.  If you'd like for m/d/y, use
+            # the 'en-us' locale
+            locale = 'en-gb'
+        self._locale = locale
+        self._parser_fns = self._prepare_parser_fns(locale)
+        super(DateParser, self).__init__()
+
+    @_cached_parser_property
+    def default_parser():
+        """A cached parser that's instantiated on first access."""
+
+    def parse(self, initial_date):
+        """Parse a date string into a ``Date`` object."""
+        for parser in self._parser_fns:
+            try:
+                if not self._validators[parser](initial_date):
+                    continue
+                date = dt.date.fromtimestamp(self._parser_fns[parser]
+                                             .parse(initial_date))
+            except icu.ICUError:
+                continue
+            return Date(date, self._skeletons_and_patterns[parser])
+        else:
+            raise ValueError
+
+    @property
+    def canonical_short_date(self):
+        """The canonical 'short' date in the ``self.locale``."""
+        return self._parser_fns['yMd']
+
+
+class Date(namedtuple('Date', 'date precision')):
+
+    __slots__ = ()
+
+    def __str__(self):
+        """Convert to ISO and chop off the day and/or month if imprecise.
+
+        Birth and death dates are copied into ``django-popolo``'s
+        ``start_date`` and ``birth_date``, which require partial dates
+        be in the form 'YYYY-MM' and 'YYYY'.  The actual birth and date
+        fields have no such constraints and also differ in that they're not
+        nullable.
+        """
+        date_string = self.date.isoformat()
+        if self.precision is DatePrecision.MONTH:
+            date_string, _, _  = date_string.rpartition('-')
+        elif self.precision is DatePrecision.YEAR:
+            date_string, _, _ = date_string.partition('-')
+        return date_string
+
+
+class DateCharField(StrippedCharField):
+
+    default_error_messages = {
+        'invalid': _l(u'The date could not be extracted from "{value}". '
+                      u'Please try using a date like "{example}".')}
+
+    def __init__(self, date_parser=None, **kwargs):
+        self.date_parser = date_parser or DateParser.default_parser
+        super(DateCharField, self).__init__(**kwargs)
+
+    def get_prep_value(self, value):
+        return str(value)
+
+    def to_python(self, value):
+        value = super(DateCharField, self).to_python(value)
+        if not value:
+            return value
+
+        try:
+            parsed = self.date_parser.parse(value)
+        except ValueError:
+            raise ValidationError(self.error_messages['invalid'].format(
+                value=value,
+                example=self.date_parser.canonical_short_date
+                                        .format(dt.datetime.now())))
+        return parsed

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -11,7 +11,6 @@ from .popolo_extra import PostExtra
 from .popolo_extra import MembershipExtra
 from .popolo_extra import PartySet
 from .popolo_extra import ImageExtra
-from .popolo_extra import parse_approximate_date
 from .popolo_extra import PostExtraElection
 
 from .field_mappings import CSV_ROW_FIELDS

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -179,31 +179,34 @@
       {% endif %}
       {% if 'birth_date' in simple_fields %}
         <dt>{% trans "Age" %}</dt>
-        {% with dob=person.birth_date %}
-          {% if dob %}
-            {% if dob|length_is:"4" %}
-              <dd>{{ person.extra.age }}
-                <small class="dob">({% blocktrans %}Year of birth: {{ dob }}{% endblocktrans %})</small>
-            {% else %}
-              <dd>{{ person.extra.age }}
-                <small class="dob">
+        <dd>
+          {% with dob=person.birth_date %}
+            {% if dob %}
+              {{ person.extra.age }}
+              <small class="dob">
+                {% if dob|length_is:"4" %}
+                  ({% blocktrans %}Year of birth: {{ dob }}{% endblocktrans %})
+                {% elif dob|length_is:"7" %}
+                  ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"F Y" %}Month and year of birth: {{ dob }}
+                   {% endblocktrans %})
+                {% else %}
                   {% comment %}
                     The 'S' format only gives an English ordinal suffix, so only
                     use it if the LANGUAGE is English.
                   {% endcomment %}
                   {% if LANGUAGE_CODE|slice:":2" == 'en' %}
-                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"jS E Y" %}Date of birth: {{ dob }}
-                     {% endblocktrans %})
+                    (Date of birth: {{ person.extra.dob_as_date|date:"jS E Y" }})
                   {% else %}
                     ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"j E Y" %}Date of birth: {{ dob }}
                      {% endblocktrans %})
                   {% endif %}
-                </small>
+                {% endif %}
+              </small>
+            {% else %}
+              {% trans "Unknown" %}
             {% endif %}
-          {% else %}
-            <dd>{% trans "Unknown" %}
-          {% endif %}</dd>
-        {% endwith %}
+          {% endwith %}
+        </dd>
       {% endif %}
       {% if 'national_identity' in simple_fields %}
         <dt>{% trans "National Identity" %}</dt>

--- a/candidates/tests/test_date_parsing.py
+++ b/candidates/tests/test_date_parsing.py
@@ -1,13 +1,10 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from django.utils.translation import override
-
-from django_date_extensions.fields import ApproximateDate
-
-from candidates.models import parse_approximate_date
+from ..date_parsing import Date, DateParser
 
 # These tests supplement the doctests; they're not done as
 # doctests because we need to override settings to pick
@@ -15,58 +12,97 @@ from candidates.models import parse_approximate_date
 
 class DateParsingTests(TestCase):
 
+    def setUp(self):
+        import icu
+        self.icu_version = tuple(map(int, icu.ICU_VERSION.split('.')))
+
     def test_only_year(self):
-        parsed = parse_approximate_date('1977')
-        self.assertEqual(type(parsed), ApproximateDate)
-        self.assertEqual(repr(parsed), '1977-00-00')
+        parsed = DateParser.default_parser.parse('1977')
+        self.assertIsInstance(parsed, Date)
+        self.assertEqual(str(parsed), '1977')
 
     def test_iso_8601(self):
-        parsed = parse_approximate_date('1977-04-01')
-        self.assertEqual(type(parsed), ApproximateDate)
-        self.assertEqual(repr(parsed), '1977-04-01')
+        parsed = DateParser.default_parser.parse('1977-04-01')
+        self.assertEqual(str(parsed), '1977-04-01')
 
     def test_nonsense(self):
         with self.assertRaises(ValueError):
-            parse_approximate_date('12345678')
+            DateParser.default_parser.parse('12345678')
 
     def test_dd_mm_yyyy_with_slashes(self):
-        parsed = parse_approximate_date('1/4/1977')
-        self.assertEqual(type(parsed), ApproximateDate)
-        self.assertEqual(repr(parsed), '1977-04-01')
+        parsed = DateParser.default_parser.parse('1/4/1977')
+        self.assertEqual(str(parsed), '1977-04-01')
 
-    @override_settings(DD_MM_DATE_FORMAT_PREFERRED=False)
+    @override_settings(LANGUAGE_CODE='en-us')
     def test_mm_dd_yyyy_with_slashes(self):
-        parsed = parse_approximate_date('4/1/1977')
-        self.assertEqual(type(parsed), ApproximateDate)
-        self.assertEqual(repr(parsed), '1977-04-01')
+        parsed = DateParser().parse('4/1/1977')
+        self.assertEqual(str(parsed), '1977-04-01')
 
     def test_dd_mm_yyyy_with_dashes(self):
-        parsed = parse_approximate_date('1-4-1977')
-        self.assertEqual(type(parsed), ApproximateDate)
-        self.assertEqual(repr(parsed), '1977-04-01')
+        parsed = DateParser.default_parser.parse('1-4-1977')
+        self.assertEqual(str(parsed), '1977-04-01')
 
     def test_natural_date_string(self):
-        parsed = parse_approximate_date('31st December 1999')
-        self.assertEqual(type(parsed), ApproximateDate)
-        self.assertEqual(repr(parsed), '1999-12-31')
+        parsed = DateParser.default_parser.parse('31 December 1999')
+        self.assertEqual(str(parsed), '1999-12-31')
+
+    def test_abbreviated_month(self):
+        parsed = DateParser.default_parser.parse('31 Dec 1999')
+        self.assertEqual(str(parsed), '1999-12-31')
 
     def test_empty_string(self):
         with self.assertRaises(ValueError):
-            parse_approximate_date('')
+            DateParser.default_parser.parse('')
 
-    def test_expanded_natural_date_string(self):
-        parsed = parse_approximate_date('31st of December 1999')
-        self.assertEqual(type(parsed), ApproximateDate)
-        self.assertEqual(repr(parsed), '1999-12-31')
+    def test_ordinals_and_preps(self):
+        with self.assertRaises(ValueError):
+            DateParser.default_parser.parse('31st of December 1999')
 
     def test_nonsense_string(self):
         with self.assertRaises(ValueError):
-            parse_approximate_date('this is not a date')
+            DateParser.default_parser.parse('this is not a date')
 
     def test_spanish_date_string(self):
         with self.assertRaises(ValueError):
-            parsed = parse_approximate_date('20 febrero 1954 ')
-        with override('es'):
-            parsed = parse_approximate_date('20 febrero 1954 ')
-            self.assertEqual(type(parsed), ApproximateDate)
-            self.assertEqual(repr(parsed), '1954-02-20')
+            DateParser.default_parser.parse('20 febrero 1954 ')
+        dp = DateParser('es')
+        parsed = dp.parse('20 febrero 1954 ')
+        self.assertEqual(str(parsed), '1954-02-20')
+        parsed = dp.parse('20 de febrero de 1954 ')
+        self.assertEqual(str(parsed), '1954-02-20')
+
+    def test_suggested_date(self):
+        suggested_date = DateParser.default_parser.canonical_short_date
+        if self.icu_version <= (21, 0, 1):
+            self.assertEqual(suggested_date.toPattern(), 'd/M/yyyy')
+        elif self.icu_version == (22, 1):
+            self.assertEqual(suggested_date.toPattern(), 'dd/MM/yyyy')
+        else:
+            self.assertEqual(suggested_date.toPattern(), 'dd/MM/y')
+
+        with override_settings(LANGUAGE_CODE='tr'):
+            suggested_date = DateParser().canonical_short_date
+            if self.icu_version <= (22, 1):
+                self.assertEqual(suggested_date.toPattern(), 'dd.MM.yyyy')
+            else:
+                self.assertEqual(suggested_date.toPattern(), 'dd.MM.y')
+
+    @override_settings(LANGUAGE_CODE='el')
+    def test_all_greek(self):
+        dp = DateParser()
+        parsed = dp.parse('20 Φεβρουαρίου 1954')
+        self.assertEqual(str(parsed), '1954-02-20')
+        parsed = dp.parse('Φεβρουάριος 1954')
+        self.assertEqual(str(parsed), '1954-02')
+        parsed = dp.parse('20/02/1954')
+        self.assertEqual(str(parsed), '1954-02-20')
+        parsed = dp.parse('20/2/1954')
+        self.assertEqual(str(parsed), '1954-02-20')
+        parsed = dp.parse('20-2-1954')
+        self.assertEqual(str(parsed), '1954-02-20')
+        parsed = dp.parse('1954-02-20')
+        self.assertEqual(str(parsed), '1954-02-20')
+        parsed = dp.parse('1954-02')
+        self.assertEqual(str(parsed), '1954-02')
+        parsed = dp.parse('1954')
+        self.assertEqual(str(parsed), '1954')

--- a/compat/__init__.py
+++ b/compat/__init__.py
@@ -1,3 +1,4 @@
 from ._compat import (BufferDictReader, BufferDictWriter,
                       bytes_to_unicode, unicode_to_bytes,
                       input, python_2_unicode_compatible, text_type)
+from ._django import StrippedCharField, StrippedEmailField, StrippedURLField

--- a/compat/_django.py
+++ b/compat/_django.py
@@ -1,0 +1,32 @@
+from django import forms, VERSION as django_version
+
+
+if django_version[:2] < (1, 9):
+    class StrippedCharField(forms.CharField):
+        """A backport of the Django 1.9 ``CharField`` ``strip`` option.
+
+        If ``strip`` is ``True`` (the default), leading and trailing
+        whitespace is removed.
+        """
+
+        def __init__(self, max_length=None, min_length=None, strip=True,
+                     *args, **kwargs):
+            self.strip = strip
+            super(StrippedCharField, self).__init__(max_length, min_length,
+                                                    *args, **kwargs)
+
+        def to_python(self, value):
+            value = super(StrippedCharField, self).to_python(value)
+            if self.strip:
+                value = value.strip()
+            return value
+else:
+    StrippedCharField = forms.CharField
+
+
+class StrippedEmailField(forms.EmailField, StrippedCharField):
+    pass
+
+
+class StrippedURLField(forms.URLField, StrippedCharField):
+    pass

--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -89,10 +89,6 @@ EDITS_ALLOWED: true
 # Google Analytics.
 USE_UNIVERSAL_ANALYTICS: true
 
-# In all of the world apart from the United States, dd/mm is preferred
-# to mm/dd.  So if your site is for the USA, set this to false:
-DD_MM_DATE_FORMAT_PREFERRED: true
-
 # If there are more than this number of candidates (either in current
 # elections or all elections) for a particular party set we use a
 # "weighted" party list - i.e. the party drop-down is ordered from the

--- a/conf/packages
+++ b/conf/packages
@@ -12,3 +12,4 @@ libssl-dev
 memcached
 gettext
 elasticsearch (<< 1)
+libicu-dev

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -285,7 +285,6 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'USE_I18N': True,
         'USE_L10N': True,
         'USE_TZ': True,
-        'DD_MM_DATE_FORMAT_PREFERRED': conf.get('DD_MM_DATE_FORMAT_PREFERRED', True),
 
         # The media and static file settings:
         'MEDIA_ROOT': media_root,

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ django-allauth==0.21.0
 django-appconf==1.0.1
 django-braces==1.4.0
 django-cors-headers==1.1.0
-django-date-extensions==1.1.0
 django-crispy-forms==1.6.0
 django-debug-toolbar==1.3.2
 django-debug-toolbar-template-timings==0.6.4
@@ -27,7 +26,7 @@ django-webtest==1.7.7
 djangorestframework==3.3.3
 docutils==0.10
 elasticsearch==0.4.5
-enum34==1.1.2
+enum34==1.1.4
 factory-boy==2.6.0
 fake-factory==0.5.3
 futures==3.0.3
@@ -56,6 +55,7 @@ psycopg2==2.5.4
 pyasn1==0.1.9
 pycparser==2.14
 pygeocoder==1.2.5
+-e git+https://github.com/ovalhub/pyicu@3d294c1#egg=PyICU
 pyOpenSSL==0.15.1
 python-dateutil==2.4.2
 python-magic==0.4.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ psycopg2==2.5.4
 pyasn1==0.1.9
 pycparser==2.14
 pygeocoder==1.2.5
--e git+https://github.com/ovalhub/pyicu@3d294c1#egg=PyICU
+PyICU==1.9.3
 pyOpenSSL==0.15.1
 python-dateutil==2.4.2
 python-magic==0.4.6


### PR DESCRIPTION
- Broadly, enable the input and display of day-less dates
- Vary short date format depending on locale (e.g. m/d/y for en-us,
  y/m/d for zh, etc.) and suggest date be input in forms
  in this format if invalid
- Per above, remove support for ``DD_MM_DATE_FORMAT_PREFERRED``
- Remove support for parsing ordinals and prepositions
  (motivation explained in ``DateParser`` docstring)
- Introduce new ``DateCharField`` class to encapsulate
  form-related date operations
- Factor out StrippedCharField into a new module and
  replace EmailField and URLField with their stripepd
  counterparts for completeness

Closes #907.