### PR TITLE
856 show elections won on candidate page

### DIFF
--- a/candidates/static/candidates/_people.scss
+++ b/candidates/static/candidates/_people.scss
@@ -369,6 +369,13 @@
       border-color: mix($error-input-border-color, #fff, 50%);
     }
   }
+
+  .candidates__elected ul {
+    list-style: none;
+    li {
+      margin-top: 0.5em;
+    }
+  }
 }
 
 @media #{$medium-up} {

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -109,6 +109,20 @@
             {% endblocktrans %}</h4>
     </div>
     {% endif %}
+
+  {% for membership in elected_in %}
+  {% if forloop.first %}
+  <div class="candidates__elected">
+    <h3>{% trans "Elected as:" %}</h3>
+    <ul>
+  {% endif %}
+      <li>{% blocktrans with post_label=membership.post.label election_name=membership.extra.election.name %}{{ post_label }} in {{ election_name }}{% endblocktrans %}</li>
+  {% if forloop.last %}
+    </ul>
+  </div>
+  {% endif %}
+  {% endfor %}
+
   <h2>{% trans "Personal details:" %}</h2>
 
   <dl>

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -121,6 +121,13 @@ class PersonView(TemplateView):
             ).order_by('-election_date')
         else:
             context['elections_to_list'] = elections_by_date
+
+        context['elected_in'] = self.person.memberships.filter(
+            extra__elected=True
+        ).select_related(
+            'post', 'extra__election'
+        ).order_by('-extra__election__election_date')
+
         context['last_candidacy'] = self.person.extra.last_candidacy
         context['election_to_show'] = None
         context['simple_fields'] = [


### PR DESCRIPTION
This adds a list of elections won to the top of the person page. There's no limit to how many it shows at the moment. It uses the styles from constituency page which are possibly a bit heavy for this. Possibly once #929 is done it could use that.

currently looks like:

![screen shot 2016-05-16 at 16 06 01](https://cloud.githubusercontent.com/assets/5310/15293500/2cdb1032-1b80-11e6-944c-4437a5abab6c.png)
