### PR TITLE
If none of the Twitter details are valid, remove them

### DIFF
--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -45,11 +45,21 @@ class Command(BaseCommand):
                 .get(contact_type='twitter').value
         except ContactDetail.DoesNotExist:
             screen_name = None
+        except ContactDetail.MultipleObjectsReturned:
+            print(_("WARNING: multiple Twitter screen names found for {name} ({id}), skipping.").format(
+                name=person.name, id=person.id
+            ))
+            return
         try:
             user_id = person.identifiers \
                 .get(scheme='twitter').identifier
         except Identifier.DoesNotExist:
             user_id = None
+        except Identifier.MultipleObjectsReturned:
+            print(_("WARNING: multiple Twitter user IDs found for {name} ({id}), skipping.").format(
+                name=person.name, id=person.id
+            ))
+            return
         # If they have a Twitter user ID, then check to see if we
         # need to update the screen name from that; if so, update
         # the screen name.  Skip to the next person. This catches

--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -26,9 +26,10 @@ class Command(BaseCommand):
 
     help = "Use the Twitter API to check / fix Twitter screen names and user IDs"
 
-    def record_new_version(self, person):
-        msg = 'Updated by the automated Twitter account checker ' \
-              '(candidates_update_twitter_usernames)'
+    def record_new_version(self, person, msg=None):
+        if msg is None:
+            msg = 'Updated by the automated Twitter account checker ' \
+                  '(candidates_update_twitter_usernames)'
         person.extra.record_version(
             {
                 'information_source': msg,
@@ -37,6 +38,28 @@ class Command(BaseCommand):
             }
         )
         person.extra.save()
+
+    def remove_twitter_screen_name(self, person, twitter_screen_name):
+        person.contact_details.get(
+            contact_type='twitter',
+            value=twitter_screen_name,
+        ).delete()
+        self.record_new_version(
+            person,
+            msg="This Twitter screen name no longer exists; removing it " \
+            "(candidates_update_twitter_usernames)"
+        )
+
+    def remove_twitter_user_id(self, person, twitter_user_id):
+        person.identifiers.get(
+            scheme='twitter',
+            identifier=twitter_user_id,
+        ).delete()
+        self.record_new_version(
+            person,
+            msg="This Twitter user ID no longer exists; removing it " \
+            "(candidates_update_twitter_usernames)",
+        )
 
     def handle_person(self, person):
         # Get the Twitter screen name and user ID if they exist:
@@ -65,17 +88,19 @@ class Command(BaseCommand):
         # the screen name.  Skip to the next person. This catches
         # people who have changed their Twitter screen name, or
         # anyone who had a user ID set but not a screen name
-        # (which should be rare).
+        # (which should be rare).  If the user ID is not a valid
+        # Twitter user ID, it is deleted.
         if user_id:
             verbose(_("{person} has a Twitter user ID: {user_id}").format(
                 person=person, user_id=user_id
             ))
             if user_id not in self.user_id_to_screen_name:
-                print(_("Warning: user ID {user_id} not found for {person_name}: {person_url}").format(
+                print(_("Removing user ID {user_id} for {person_name} as it is not a valid Twitter user ID. {person_url}").format(
                     user_id=user_id,
                     person_name=person.name,
                     person_url=person.extra.get_absolute_url(),
                 ))
+                self.remove_twitter_user_id(person, user_id)
                 return
             correct_screen_name = self.user_id_to_screen_name[user_id]
             if (screen_name is None) or (screen_name != correct_screen_name):
@@ -95,16 +120,19 @@ class Command(BaseCommand):
         # Otherwise, if they have a Twitter screen name (but no
         # user ID, since we already dealt with that case) then
         # find their Twitter user ID and set that as an identifier.
+        # If the screen name is not a valid Twitter screen name, it
+        # is deleted.
         elif screen_name:
             verbose(_("{person} has Twitter screen name ({screen_name}) but no user ID").format(
                 person=person, screen_name=screen_name
             ))
             if screen_name.lower() not in self.screen_name_to_user_id:
-                print(_("Warning: screen name {screen_name} not found for {person_name}: {person_url}").format(
+                print(_("Removing screen name {screen_name} for {person_name} as it is not a valid Twitter screen name. {person_url}").format(
                     screen_name=screen_name,
                     person_name=person.name,
                     person_url=person.extra.get_absolute_url(),
                 ))
+                self.remove_twitter_screen_name(person, screen_name)
                 return
             verbose(_("Adding the user ID {user_id}").format(
                 user_id=self.screen_name_to_user_id[screen_name.lower()]


### PR DESCRIPTION
The candidates_update_twitter_usernames script behaved less than ideally
in the case where none of their Twitter details correspond to a real
Twitter account (typically when they delete their account, or we only
have an old screen name that predates a change of screen name): it would
print out a warning, which would be emailed if the script is run from
a cron job.  This isn't ideal because we never want to be linking to
non-existent Twitter accounts from the site - the action you'd take on
seeing this warning is always going to be to remove or fix the bad data.
(The old values will still be in the version history, after all.)  You
might want to search for a new Twitter account too, but you can still do
that afterwards if the bad data were deleted.

This commit changes the behaviour of the script so this bad Twitter
account data is deleted automatically; it still emits a warning, so those
cases can be investigated (and in some cases new accounts found) by hand
afterwards.
