### PR TITLE
Move site settings into database and provide UI

### DIFF
--- a/alerts/tests.py
+++ b/alerts/tests.py
@@ -13,6 +13,7 @@ from candidates.tests.factories import (
     AreaExtraFactory, CandidacyExtraFactory, PersonExtraFactory,
     PostExtraFactory,
 )
+from candidates.tests.settings import SettingsMixin
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 
 from django.contrib.contenttypes.models import ContentType
@@ -23,7 +24,7 @@ from candidates.tests.auth import TestUserMixin
 from .models import Alert
 
 
-class AlertsTest(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class AlertsTest(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(AlertsTest, self).setUp()

--- a/cached_counts/tests.py
+++ b/cached_counts/tests.py
@@ -9,9 +9,10 @@ from django_webtest import WebTest
 from popolo.models import Person
 
 from candidates.tests import factories
+from candidates.tests.settings import SettingsMixin
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 
-class CachedCountTestCase(UK2015ExamplesMixin, WebTest):
+class CachedCountTestCase(SettingsMixin, UK2015ExamplesMixin, WebTest):
     maxDiff = None
 
     def setUp(self):

--- a/candidates/admin.py
+++ b/candidates/admin.py
@@ -5,9 +5,12 @@ from django.contrib import admin
 from django.core.urlresolvers import reverse
 from django.forms import ModelForm
 
+from usersettings.admin import SettingsAdmin
+
 from .models import (
     LoggedAction, PartySet, ExtraField, PersonExtraFieldValue,
-    SimplePopoloField, ComplexPopoloField, PostExtraElection
+    SimplePopoloField, ComplexPopoloField, PostExtraElection,
+    SiteSettings
 )
 
 
@@ -81,3 +84,35 @@ class PostExtraElectionAdmin(admin.ModelAdmin):
 class ComplexPopoloFieldAdmin(admin.ModelAdmin):
     list_display = ['name', 'label', 'order']
     ordering = ('order',)
+
+@admin.register(SiteSettings)
+class SiteSettingsAdmin(SettingsAdmin):
+    fieldsets = (
+        ("Site owner's details", {
+            'fields': ('SITE_OWNER', 'SITE_OWNER_URL', 'COPYRIGHT_HOLDER',
+                'TWITTER_USERNAME')
+        }),
+        ('Email addresses', {
+            'fields': ('SUPPORT_EMAIL', 'DEFAULT_FROM_EMAIL', 'SERVER_EMAIL')
+        }),
+        ('Localization', {
+            'fields': ('DATE_FORMAT', 'DD_MM_DATE_FORMAT_PREFERRED')
+        }),
+        ('Areas', {
+            'fields': ('MAPIT_BASE_URL',)
+        }),
+        ('Google Analytics', {
+            'fields': ('GOOGLE_ANALYTICS_ACCOUNT', 'USE_UNIVERSAL_ANALYTICS')
+        }),
+        ('Display options', {
+            'fields': ('HOIST_ELECTED_CANDIDATES',
+                       'CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST')
+        }),
+        ('Editing and account options', {
+            'fields': ('NEW_ACCOUNTS_ALLOWED', 'RESTRICT_RENAMES',
+                       'EDITS_ALLOWED')
+        }),
+        ('Other', {
+            'fields': ('TWITTER_APP_ONLY_BEARER_TOKEN', 'IMAGE_PROXY_URL')
+        })
+    )

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -15,7 +15,8 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
 from candidates.models import (
-    PartySet, parse_approximate_date, ExtraField, SimplePopoloField, ComplexPopoloField
+    PartySet, parse_approximate_date, ExtraField, SimplePopoloField,
+    ComplexPopoloField, SiteSettings
 )
 from popolo.models import Organization, OtherName, Post
 from .twitter_api import get_twitter_user_id, TwitterAPITokenMissing
@@ -526,3 +527,28 @@ class OtherNameForm(forms.ModelForm):
         ),
         max_length=512,
     )
+
+
+class SettingsForm(forms.ModelForm):
+    class Meta:
+        model = SiteSettings
+        fields = (
+            'SITE_OWNER',
+            'SITE_OWNER_URL',
+            'COPYRIGHT_HOLDER',
+            'TWITTER_USERNAME',
+            'SUPPORT_EMAIL',
+            'DEFAULT_FROM_EMAIL',
+            'SERVER_EMAIL',
+            'DATE_FORMAT',
+            'DD_MM_DATE_FORMAT_PREFERRED',
+            'MAPIT_BASE_URL',
+            'GOOGLE_ANALYTICS_ACCOUNT',
+            'USE_UNIVERSAL_ANALYTICS',
+            'NEW_ACCOUNTS_ALLOWED',
+            'HOIST_ELECTED_CANDIDATES',
+            'RESTRICT_RENAMES',
+            'EDITS_ALLOWED',
+            'CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST',
+            'TWITTER_APP_ONLY_BEARER_TOKEN',
+            'IMAGE_PROXY_URL')

--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -10,6 +10,8 @@ from django.core.management.base import BaseCommand, CommandError
 from django.utils.translation import ugettext as _
 from django.utils.six import text_type
 
+from usersettings.shortcuts import get_current_usersettings
+
 from popolo.models import ContactDetail, Identifier, Person
 import requests
 
@@ -150,7 +152,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         global VERBOSE
         VERBOSE = int(options['verbosity']) > 1
-        token = settings.TWITTER_APP_ONLY_BEARER_TOKEN
+        user_settings = get_current_usersettings()
+        token = user_settings.TWITTER_APP_ONLY_BEARER_TOKEN
         if not token:
             raise CommandError(_("TWITTER_APP_ONLY_BEARER_TOKEN was not set"))
         headers = {'Authorization': 'Bearer {token}'.format(token=token)}

--- a/candidates/middleware.py
+++ b/candidates/middleware.py
@@ -14,6 +14,8 @@ from django.shortcuts import render
 from django.utils.http import urlquote
 from django.utils.translation import ugettext as _
 
+from usersettings.shortcuts import get_current_usersettings
+
 from candidates.models.auth import (
     NameChangeDisallowedException,
     ChangeToLockedConstituencyDisallowedException
@@ -24,6 +26,7 @@ class DisallowedUpdateMiddleware(object):
 
     def process_exception(self, request, exc):
         if isinstance(exc, NameChangeDisallowedException):
+            usersettings = get_current_usersettings()
             intro = _('As a precaution, an update was blocked:')
             outro = _('If this update is appropriate, someone should apply it manually.')
             # Then email the support address about the name change...
@@ -37,8 +40,8 @@ class DisallowedUpdateMiddleware(object):
                     site_name=Site.objects.get_current().name
                 ),
                 message,
-                settings.DEFAULT_FROM_EMAIL,
-                [settings.SUPPORT_EMAIL],
+                usersettings.DEFAULT_FROM_EMAIL,
+                [usersettings.SUPPORT_EMAIL],
                 fail_silently=False
             )
             # And redirect to a page explaining to the user what has happened
@@ -63,6 +66,7 @@ class CopyrightAssignmentMiddleware(object):
         re.compile(r'^/copyright-question'),
         re.compile(r'^/accounts/'),
         re.compile(r'^/admin/'),
+        re.compile(r'^/settings/'),
     )
 
     def process_request(self, request):

--- a/candidates/migrations/0032_sitesettings.py
+++ b/candidates/migrations/0032_sitesettings.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sites', '0001_initial'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('candidates', '0031_loggedaction_note'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteSettings',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(auto_now_add=True, verbose_name='Created at')),
+                ('modified', models.DateTimeField(auto_now=True, verbose_name='Last Updated')),
+                ('DATE_FORMAT', models.CharField(max_length=250, verbose_name='Date Format', blank=True)),
+                ('SERVER_EMAIL', models.EmailField(max_length=250, verbose_name='From address for error emails')),
+                ('DEFAULT_FROM_EMAIL', models.EmailField(max_length=250, verbose_name='Default From email address')),
+                ('SUPPORT_EMAIL', models.EmailField(max_length=250, verbose_name='Support Email')),
+                ('SITE_OWNER', models.CharField(max_length=250, verbose_name='Site Owner')),
+                ('SITE_OWNER_URL', models.URLField(max_length=250, verbose_name='Website for Site Owner', blank=True)),
+                ('COPYRIGHT_HOLDER', models.CharField(max_length=250, verbose_name='Copyright Holder')),
+                ('MAPIT_BASE_URL', models.URLField(max_length=250, verbose_name='Mapit base URL', blank=True)),
+                ('IMAGE_PROXY_URL', models.URLField(max_length=250, verbose_name='Image proxy URL', blank=True)),
+                ('GOOGLE_ANALYTICS_ACCOUNT', models.CharField(max_length=250, verbose_name='Google Analytics Account ID', blank=True)),
+                ('USE_UNIVERSAL_ANALYTICS', models.BooleanField(default=True, verbose_name='Using Universal Google analytics')),
+                ('TWITTER_USERNAME', models.CharField(max_length=250, verbose_name='Twitter username', blank=True)),
+                ('TWITTER_APP_ONLY_BEARER_TOKEN', models.CharField(max_length=250, verbose_name='Twitter API bearer token', blank=True)),
+                ('RESTRICT_RENAMES', models.BooleanField(default=False, verbose_name='Restrict Renames')),
+                ('NEW_ACCOUNTS_ALLOWED', models.BooleanField(default=True, verbose_name='Allow new accounts')),
+                ('EDITS_ALLOWED', models.BooleanField(default=True, verbose_name='Allow edits')),
+                ('HOIST_ELECTED_CANDIDATES', models.BooleanField(default=True, verbose_name='Hoist elected Candidated')),
+                ('DD_MM_DATE_FORMAT_PREFERRED', models.BooleanField(default=True, verbose_name='Prefer DD/MM date format')),
+                ('CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST', models.IntegerField(default=20, verbose_name='Maximum party list size to display on post page')),
+                ('site', models.OneToOneField(related_name='usersettings', null=True, editable=False, to='sites.Site')),
+                ('user', models.ForeignKey(related_name='usersettings', editable=False, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                'verbose_name': 'Site Settings',
+                'verbose_name_plural': 'Site Settings',
+            },
+        ),
+    ]

--- a/candidates/migrations/0033_migrate_settings_to_db.py
+++ b/candidates/migrations/0033_migrate_settings_to_db.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import importlib
+
+from django.conf import settings
+from django.db import migrations
+
+from mysite.settings.conf import get_conf
+
+def get_election_app_setting(setting_name):
+    election_app = settings.ELECTION_APP
+    if not election_app:
+        return None
+
+    election_app_fully_qualified = 'elections.' + election_app
+    election_settings_module = election_app_fully_qualified + '.settings'
+    elections_module = importlib.import_module(election_settings_module)
+    try:
+        setting = getattr(elections_module, setting_name)
+    except AttributeError:
+        setting = ''
+
+    return setting
+
+def migrate_settings(apps, schema_editor):
+    """
+    The idea is that this will only run for sites that already have
+    settings so they should have a SITE_OWNER and a super user in
+    existence. New sites won't have this so we won't try and set
+    any of these.
+    """
+    SiteSettings = apps.get_model('candidates', 'SiteSettings')
+    db_alias = schema_editor.connection.alias
+
+    User = apps.get_model('auth', 'User')
+
+    superusers = User.objects.filter(
+        is_superuser=True
+    ).order_by('date_joined')
+
+    user = superusers.first()
+
+    old_settings = get_conf('general.yml')
+
+    if user and get_election_app_setting('SITE_OWNER'):
+        SiteSettings.objects.using(db_alias).create(
+            site_id=1,
+            user_id=user.id,
+            # TODO: check default
+            DATE_FORMAT=old_settings.get('DATE_FORMAT', ''),
+            SERVER_EMAIL=old_settings.get('SERVER_EMAIL', ''),
+            DEFAULT_FROM_EMAIL=old_settings.get('DEFAULT_FROM_EMAIL', ''),
+            SUPPORT_EMAIL=old_settings.get('SUPPORT_EMAIL', ''),
+            SITE_OWNER=get_election_app_setting('SITE_OWNER'),
+            SITE_OWNER_URL=get_election_app_setting('SITE_OWNER_URL'),
+            COPYRIGHT_HOLDER=get_election_app_setting('COPYRIGHT_HOLDER'),
+            MAPIT_BASE_URL=get_election_app_setting('MAPIT_BASE_URL'),
+            IMAGE_PROXY_URL=get_election_app_setting('IMAGE_PROXY_URL'),
+            GOOGLE_ANALYTICS_ACCOUNT=old_settings.get('GOOGLE_ANALYTICS_ACCOUNT', ''),
+            USE_UNIVERSAL_ANALYTICS=old_settings.get('USE_UNIVERSAL_ANALYTICS', False),
+            TWITTER_USERNAME=old_settings.get('TWITTER_USERNAME', ''),
+            TWITTER_APP_ONLY_BEARER_TOKEN=old_settings.get('TWITTER_APP_ONLY_BEARER_TOKEN', ''),
+            RESTRICT_RENAMES=old_settings.get('RESTRICT_RENAMES', False),
+            EDITS_ALLOWED=old_settings.get('EDITS_ALLOWED', True),
+            HOIST_ELECTED_CANDIDATES=old_settings.get('HOIST_ELECTED_CANDIDATES', True),
+            DD_MM_DATE_FORMAT_PREFERRED=old_settings.get('DD_MM_DATE_FORMAT_PREFERRED', True),
+            CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST=old_settings.get('CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST', 20),
+        )
+
+
+# this just here so we can reverse the action
+def unmigrate_settings(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0032_sitesettings'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_settings, unmigrate_settings),
+    ]

--- a/candidates/migrations/0034_add_can_edit_settings_group.py
+++ b/candidates/migrations/0034_add_can_edit_settings_group.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from auth_helpers.migrations import (
+    get_migration_group_create,
+    get_migration_group_delete,
+)
+from candidates.models import EDIT_SETTINGS_GROUP_NAME
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0033_migrate_settings_to_db'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            get_migration_group_create(EDIT_SETTINGS_GROUP_NAME, []),
+            get_migration_group_delete(EDIT_SETTINGS_GROUP_NAME),
+        )
+    ]

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -29,3 +29,5 @@ from .auth import TRUSTED_TO_MERGE_GROUP_NAME
 from .auth import TRUSTED_TO_LOCK_GROUP_NAME
 from .auth import TRUSTED_TO_RENAME_GROUP_NAME
 from .auth import RESULT_RECORDERS_GROUP_NAME
+
+from .sitesettings import SiteSettings

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -29,5 +29,6 @@ from .auth import TRUSTED_TO_MERGE_GROUP_NAME
 from .auth import TRUSTED_TO_LOCK_GROUP_NAME
 from .auth import TRUSTED_TO_RENAME_GROUP_NAME
 from .auth import RESULT_RECORDERS_GROUP_NAME
+from .auth import EDIT_SETTINGS_GROUP_NAME
 
 from .sitesettings import SiteSettings

--- a/candidates/models/auth.py
+++ b/candidates/models/auth.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.utils.translation import ugettext as _
 
+from usersettings.shortcuts import get_current_usersettings
 from auth_helpers.views import user_in_group
 
 TRUSTED_TO_MERGE_GROUP_NAME = 'Trusted To Merge'
@@ -59,7 +60,8 @@ def check_creation_allowed(user, new_candidacies):
 def check_update_allowed(user, old_name, old_candidacies, new_name, new_candidacies):
     # Check whether an unauthorized user has tried to rename someone
     # while RESTRICT_RENAMES is set:
-    if settings.RESTRICT_RENAMES:
+    usersettings = get_current_usersettings()
+    if usersettings.RESTRICT_RENAMES:
         allowed_by_group = user_in_group(user, TRUSTED_TO_RENAME_GROUP_NAME)
         name_the_same = old_name == new_name
         if not (allowed_by_group or name_the_same):

--- a/candidates/models/auth.py
+++ b/candidates/models/auth.py
@@ -10,6 +10,7 @@ TRUSTED_TO_MERGE_GROUP_NAME = 'Trusted To Merge'
 TRUSTED_TO_LOCK_GROUP_NAME = 'Trusted To Lock'
 TRUSTED_TO_RENAME_GROUP_NAME = 'Trusted To Rename'
 RESULT_RECORDERS_GROUP_NAME = 'Result Recorders'
+EDIT_SETTINGS_GROUP_NAME = 'Can Edit Settings'
 
 class NameChangeDisallowedException(Exception):
     pass

--- a/candidates/models/sitesettings.py
+++ b/candidates/models/sitesettings.py
@@ -1,0 +1,97 @@
+from __future__ import unicode_literals
+
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+from usersettings.models import UserSettings
+
+
+class SiteSettings(UserSettings):
+    # TODO: is this actually used anywhere?
+    DATE_FORMAT = models.CharField(
+        _('Date Format'),
+        max_length=250,
+        blank=True
+    )
+    SERVER_EMAIL = models.EmailField(
+        _('From address for error emails'),
+        max_length=250,
+    )
+    DEFAULT_FROM_EMAIL = models.EmailField(
+        _('Default From email address'),
+        max_length=250,
+    )
+    SUPPORT_EMAIL = models.EmailField(
+        _('Support Email'),
+        max_length=250,
+    )
+    SITE_OWNER = models.CharField(
+        _('Site Owner'),
+        max_length=250,
+    )
+    SITE_OWNER_URL = models.URLField(
+        _('Website for Site Owner'),
+        max_length=250,
+        blank=True,
+    )
+    COPYRIGHT_HOLDER = models.CharField(
+        _('Copyright Holder'),
+        max_length=250,
+    )
+    MAPIT_BASE_URL = models.URLField(
+        _('MapIt base URL'),
+        max_length=250,
+        blank=True
+    )
+    IMAGE_PROXY_URL = models.URLField(
+        _('Image Proxy URL'),
+        max_length=250,
+        blank=True
+    )
+    GOOGLE_ANALYTICS_ACCOUNT = models.CharField(
+        _('Google Analytics Account ID'),
+        max_length=250,
+        blank=True
+    )
+    USE_UNIVERSAL_ANALYTICS = models.BooleanField(
+        _('Using Universal Google analytics'),
+        default=True
+    )
+    TWITTER_USERNAME = models.CharField(
+        _('Twitter username'),
+        max_length=250,
+        blank=True
+    )
+    TWITTER_APP_ONLY_BEARER_TOKEN = models.CharField(
+        _('Twitter API bearer token'),
+        max_length=250,
+        blank=True
+    )
+    RESTRICT_RENAMES = models.BooleanField(
+        _('Restrict Renames'),
+        default=False
+    )
+    NEW_ACCOUNTS_ALLOWED = models.BooleanField(
+        _('Allow new accounts'),
+        default=True
+    )
+    EDITS_ALLOWED = models.BooleanField(
+        _('Allow edits'),
+        default=True
+    )
+    HOIST_ELECTED_CANDIDATES = models.BooleanField(
+        _('Hoist elected Candidated'),
+        default=True
+    )
+    DD_MM_DATE_FORMAT_PREFERRED = models.BooleanField(
+        _('Prefer DD/MM date format'),
+        default=True
+    )
+    CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST = models.IntegerField(
+        _('Maximum party list size to display on post page'),
+        default=20
+    )
+
+    class Meta:
+        verbose_name = 'Site Settings'
+        verbose_name_plural = 'Site Settings'

--- a/candidates/templates/candidates/settings.html
+++ b/candidates/templates/candidates/settings.html
@@ -1,0 +1,207 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block body_class %}{% endblock %}
+
+{% block title %}
+  {% blocktrans trimmed with site_name=site.name %}
+    {{ site_name }} settings
+  {% endblocktrans %}
+{% endblock %}
+
+{% block hero %}
+  <h1>
+      {% blocktrans trimmed with site_name=site.name %}
+        {{ site_name }} settings
+      {% endblocktrans %}
+  </h1>
+{% endblock %}
+
+{% block content %}
+
+<form id="settings" method="post" action="">
+  {% csrf_token %}
+    {% if form.errors %}
+      <div class="form-error-summary">
+        <h2>{% trans "Oops!" %}</h2>
+        <p>{% trans "We could not accept some of the changes you made." %}</p>
+        {% if form.non_field_errors %}
+          {{ form.non_field_errors.as_ul }}
+        {% else %}
+          <p>{% trans "Please check your information matches our requirements, below." %}</p>
+        {% endif %}
+      </div>
+    {% endif %}
+
+  <h2>{% trans "Site owner's details" %}</h2>
+
+  <div class="form-item {% if form.SITE_OWNER.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.SITE_OWNER.label_tag }}
+      {{ form.SITE_OWNER }}
+    </p>
+    {{ form.SITE_OWNER.errors }}
+  </div>
+
+  <div class="form-item {% if form.SITE_OWNER_URL.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.SITE_OWNER_URL.label_tag }}
+      {{ form.SITE_OWNER_URL }}
+    </p>
+    {{ form.SITE_OWNER_URL.errors }}
+  </div>
+
+  <div class="form-item {% if form.COPYRIGHT_HOLDER.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.COPYRIGHT_HOLDER.label_tag }}
+      {{ form.COPYRIGHT_HOLDER }}
+    </p>
+    {{ form.COPYRIGHT_HOLDER.errors }}
+  </div>
+
+  <div class="form-item {% if form.TWITTER_USERNAME.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.TWITTER_USERNAME.label_tag }}
+      {{ form.TWITTER_USERNAME }}
+    </p>
+    {{ form.TWITTER_USERNAME.errors }}
+  </div>
+
+  <h2>{% trans "Email addresses" %}</h2>
+
+  <div class="form-item {% if form.SUPPORT_EMAIL.errors %}form-item--errors{% endif %}">
+    <p>
+      <label for="id_SUPPORT_EMAIL">{% trans "Email address for support enquiries to be sent to" %}:</label>
+      {{ form.SUPPORT_EMAIL }}
+    </p>
+    {{ form.SUPPORT_EMAIL.errors }}
+  </div>
+
+  <div class="form-item {% if form.DEFAULT_FROM_EMAIL.errors %}form-item--errors{% endif %}">
+    <p>
+      <label for="id_DEFAULT_FROM_EMAIL">{% trans "From email address to use in emails sent by the site" %}:</label>
+      {{ form.DEFAULT_FROM_EMAIL }}
+    </p>
+    {{ form.DEFAULT_FROM_EMAIL.errors }}
+  </div>
+
+  <div class="form-item {% if form.SERVER_EMAIL.errors %}form-item--errors{% endif %}">
+    <p>
+      <label for="id_SERVER_EMAIL">{% trans "From email address to use in error emails" %}:</label>
+      {{ form.SERVER_EMAIL }}
+    </p>
+    {{ form.SERVER_EMAIL.errors }}
+  </div>
+
+  <h2>{% trans "Localization" %}</h2>
+
+  <div class="form-item {% if form.DATE_FORMAT.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.DATE_FORMAT.label_tag }}
+      {{ form.DATE_FORMAT }}
+    </p>
+    {{ form.DATE_FORMAT.errors }}
+  </div>
+
+  <div class="form-item {% if form.DD_MM_DATE_FORMAT_PREFERRED.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.DD_MM_DATE_FORMAT_PREFERRED }}
+      - <label for="id_DD_MM_DATE_FORMAT_PREFERRED">{% trans "Expect dates to come before month in numeric dates (e.g. dd/mm/yyyy format)" %}</label>
+    </p>
+    {{ form.DD_MM_DATE_FORMAT_PREFERRED.errors }}
+  </div>
+
+  <h2>{% trans "Areas" %}</h2>
+
+  <div class="form-item {% if form.MAPIT_BASE_URL.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.MAPIT_BASE_URL.label_tag }}
+      {{ form.MAPIT_BASE_URL }}
+    </p>
+    {{ form.MAPIT_BASE_URL.errors }}
+  </div>
+
+  <h2>{% trans "Google Analytics" %}</h2>
+
+  <div class="form-item {% if form.GOOGLE_ANALYTICS_ACCOUNT.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.GOOGLE_ANALYTICS_ACCOUNT.label_tag }}
+      {{ form.GOOGLE_ANALYTICS_ACCOUNT }}
+    </p>
+    {{ form.GOOGLE_ANALYTICS_ACCOUNT.errors }}
+  </div>
+
+  <div class="form-item {% if form.USE_UNIVERSAL_ANALYTICS.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.USE_UNIVERSAL_ANALYTICS }}
+      - <label for="id_USE_UNIVERSAL_ANALYTICS">{% trans "Site uses Universal Google analytics" %}</label>
+    </p>
+    {{ form.USE_UNIVERSAL_ANALYTICS.errors }}
+  </div>
+
+  <h2>{% trans "Display options" %}</h2>
+
+  <div class="form-item {% if form.CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST.label_tag }}
+      {{ form.CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST }}
+    </p>
+    {{ form.CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST.errors }}
+  </div>
+
+  <div class="form-item {% if form.HOIST_ELECTED_CANDIDATES.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.HOIST_ELECTED_CANDIDATES }}
+      - <label id="id_HOIST_ELECTED_CANDIDATES">{% trans "Only display elected candidates at top of page" %}</label>
+    </p>
+    {{ form.HOIST_ELECTED_CANDIDATES.errors }}
+  </div>
+
+  <h2>{% trans "Editing and account options" %}</h2>
+
+  <div class="form-item {% if form.RESTRICT_RENAMES.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.RESTRICT_RENAMES }}
+      - <label for="id_RESTRICT_RENAMES">{% trans "Prevent users from changing candidates names" %}</label>
+    </p>
+    {{ form.RESTRICT_RENAMES.errors }}
+  </div>
+
+  <div class="form-item {% if form.EDITS_ALLOWED.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.EDITS_ALLOWED }}
+      - <label for="id_EDITS_ALLOWED">{% trans "Allow candidates to be edited" %}</label>
+    </p>
+    {{ form.EDITS_ALLOWED.errors }}
+  </div>
+
+  <div class="form-item {% if form.NEW_ACCOUNTS_ALLOWED.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.NEW_ACCOUNTS_ALLOWED }}
+      - <label for="id_NEW_ACCOUNTS_ALLOWED">{% trans "Allow new accounts to be created" %}</label>
+    </p>
+    {{ form.NEW_ACCOUNTS_ALLOWED.errors }}
+  </div>
+
+  <h2>{% trans "Other" %}</h2>
+
+  <div class="form-item {% if form.TWITTER_APP_ONLY_BEARER_TOKEN.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.TWITTER_APP_ONLY_BEARER_TOKEN.label_tag }}
+      {{ form.TWITTER_APP_ONLY_BEARER_TOKEN }}
+    </p>
+    {{ form.TWITTER_APP_ONLY_BEARER_TOKEN.errors }}
+  </div>
+
+  <div class="form-item {% if form.IMAGE_PROXY_URL.errors %}form-item--errors{% endif %}">
+    <p>
+      {{ form.IMAGE_PROXY_URL.label_tag }}
+      {{ form.IMAGE_PROXY_URL }}
+    </p>
+    {{ form.IMAGE_PROXY_URL.errors }}
+  </div>
+
+  <input type="submit" class="button" value="{% trans "Save" %}">
+</form>
+
+{% endblock %}

--- a/candidates/tests/auth.py
+++ b/candidates/tests/auth.py
@@ -44,6 +44,17 @@ class TestUserMixin(object):
             'notagoodpasswordeither',
         )
         cls.users_to_delete.append(cls.user_refused)
+        cls.user_is_staff = User.objects.create_user(
+            'johnstaff',
+            'johnstaff@example.com',
+            'notagoodpasswordeither',
+        )
+        cls.user_is_staff.is_staff = True
+        cls.user_is_staff.save()
+        terms = cls.user_is_staff.terms_agreement
+        terms.assigned_to_dc = True
+        terms.save()
+        cls.users_to_delete.append(cls.user_is_staff)
 
     @classmethod
     def tearDownClass(cls):

--- a/candidates/tests/settings.py
+++ b/candidates/tests/settings.py
@@ -1,0 +1,41 @@
+from __future__ import unicode_literals
+
+from candidates.models import SiteSettings
+from django.contrib.auth.models import User
+
+
+class SettingsMixin(object):
+
+    def setUp(self):
+        super(SettingsMixin, self).setUp()
+        self.settings_user = User.objects.create_user(
+            'settings',
+            'settings' + '@example.com',
+            'notagoodpassword',
+        )
+
+        self.sitesettings = SiteSettings.objects.create(
+            site_id=1,
+            user_id=self.settings_user.id,
+            # COUNTRY=settings.COUNTRY,
+            LANGUAGE_CODE='en-gb',
+            TIME_ZONE='Europe/London',
+            # DATE_FORMAT=settings.DATE_FORMAT,
+            SERVER_EMAIL='root@localhost',
+            DEFAULT_FROM_EMAIL='webmaster@localhost',
+            SUPPORT_EMAIL='yournextmp-support@example.org',
+            SITE_OWNER='The Site Owners',
+            COPYRIGHT_HOLDER='The Copyright Holders',
+            MAPIT_BASE_URL='http://global.mapit.mysociety.org/',
+            GOOGLE_ANALYTICS_ACCOUNT='',
+            USE_UNIVERSAL_ANALYTICS=True,
+            TWITTER_USERNAME='',
+            RESTRICT_RENAMES=False,
+            EDITS_ALLOWED=True,
+            HOIST_ELECTED_CANDIDATES=True,
+            DD_MM_DATE_FORMAT_PREFERRED=True,
+        )
+
+    def tearDown(self):
+        self.sitesettings.delete()
+        self.settings_user.delete()

--- a/candidates/tests/settings.py
+++ b/candidates/tests/settings.py
@@ -17,10 +17,6 @@ class SettingsMixin(object):
         self.sitesettings = SiteSettings.objects.create(
             site_id=1,
             user_id=self.settings_user.id,
-            # COUNTRY=settings.COUNTRY,
-            LANGUAGE_CODE='en-gb',
-            TIME_ZONE='Europe/London',
-            # DATE_FORMAT=settings.DATE_FORMAT,
             SERVER_EMAIL='root@localhost',
             DEFAULT_FROM_EMAIL='webmaster@localhost',
             SUPPORT_EMAIL='yournextmp-support@example.org',

--- a/candidates/tests/test_api.py
+++ b/candidates/tests/test_api.py
@@ -7,11 +7,12 @@ from .factories import (
     PersonExtraFactory, PostExtraFactory,
 )
 from .uk_examples import UK2015ExamplesMixin
+from .settings import SettingsMixin
 
 from candidates.models import LoggedAction
 
 
-class TestAPI(UK2015ExamplesMixin, WebTest):
+class TestAPI(UK2015ExamplesMixin, SettingsMixin, WebTest):
 
     def setUp(self):
         super(TestAPI, self).setUp()

--- a/candidates/tests/test_api_help_view.py
+++ b/candidates/tests/test_api_help_view.py
@@ -4,11 +4,13 @@ from __future__ import unicode_literals
 
 from django_webtest import WebTest
 
+from .settings import SettingsMixin
 from . import factories
 
-class TestApiHelpView(WebTest):
+class TestApiHelpView(SettingsMixin, WebTest):
 
     def setUp(self):
+        super(TestApiHelpView, self).setUp()
         factories.ElectionFactory.create(
             slug='2015',
             name='2015 General Election',

--- a/candidates/tests/test_areas_of_type_view.py
+++ b/candidates/tests/test_areas_of_type_view.py
@@ -7,6 +7,7 @@ import re
 from django_webtest import WebTest
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 
 from .factories import (
     AreaExtraFactory, CandidacyExtraFactory, PersonExtraFactory,
@@ -14,7 +15,7 @@ from .factories import (
 )
 from .uk_examples import UK2015ExamplesMixin
 
-class TestAreasOfTypeView(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestAreasOfTypeView(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestAreasOfTypeView, self).setUp()

--- a/candidates/tests/test_areas_view.py
+++ b/candidates/tests/test_areas_view.py
@@ -12,9 +12,10 @@ from .factories import (
     AreaExtraFactory, CandidacyExtraFactory, PersonExtraFactory,
     PostExtraFactory,
 )
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
-class TestAreasView(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestAreasView(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestAreasView, self).setUp()

--- a/candidates/tests/test_complex_fields.py
+++ b/candidates/tests/test_complex_fields.py
@@ -9,6 +9,7 @@ from popolo.models import Person
 from candidates.models import PersonExtra, ComplexPopoloField
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
@@ -16,7 +17,7 @@ def get_next_dd(start):
     return [t for t in start.next_siblings if t.name == 'dd'][0]
 
 
-class ComplexFieldsTests(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class ComplexFieldsTests(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(ComplexFieldsTests, self).setUp()

--- a/candidates/tests/test_constituencies_declared.py
+++ b/candidates/tests/test_constituencies_declared.py
@@ -9,10 +9,11 @@ from .auth import TestUserMixin
 from .factories import (
     CandidacyExtraFactory, MembershipFactory, PersonExtraFactory,
 )
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestConstituenciesDeclared(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestConstituenciesDeclared(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestConstituenciesDeclared, self).setUp()

--- a/candidates/tests/test_constituencies_view.py
+++ b/candidates/tests/test_constituencies_view.py
@@ -4,9 +4,10 @@ import re
 
 from django_webtest import WebTest
 
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
-class TestConstituencyDetailView(UK2015ExamplesMixin, WebTest):
+class TestConstituencyDetailView(SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestConstituencyDetailView, self).setUp()

--- a/candidates/tests/test_constituency_lock.py
+++ b/candidates/tests/test_constituency_lock.py
@@ -7,9 +7,10 @@ from candidates.models import PostExtra
 
 from .auth import TestUserMixin
 from .factories import CandidacyExtraFactory, PersonExtraFactory
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
-class TestConstituencyLockAndUnlock(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestConstituencyLockAndUnlock(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestConstituencyLockAndUnlock, self).setUp()
@@ -119,7 +120,7 @@ class TestConstituencyLockAndUnlock(TestUserMixin, UK2015ExamplesMixin, WebTest)
         self.assertNotIn('Camberwell', response.text)
 
 
-class TestConstituencyLockWorks(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestConstituencyLockWorks(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestConstituencyLockWorks, self).setUp()

--- a/candidates/tests/test_copyright_assignment.py
+++ b/candidates/tests/test_copyright_assignment.py
@@ -5,10 +5,11 @@ from django.utils.six.moves.urllib_parse import urlsplit
 from django_webtest import WebTest
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestCopyrightAssignment(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestCopyrightAssignment(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestCopyrightAssignment, self).setUp()

--- a/candidates/tests/test_csv_export.py
+++ b/candidates/tests/test_csv_export.py
@@ -14,6 +14,7 @@ from ..csv_helpers import list_to_csv
 from . import factories
 from .auth import TestUserMixin
 from .dates import date_in_near_future, FOUR_YEARS_IN_DAYS
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
@@ -21,7 +22,7 @@ def get_person_extra_with_joins(person_id):
     return PersonExtra.objects.joins_for_csv_output().get(pk=person_id)
 
 
-class CSVTests(TestUserMixin, UK2015ExamplesMixin, TestCase):
+class CSVTests(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, TestCase):
 
     def setUp(self):
         super(CSVTests, self).setUp()

--- a/candidates/tests/test_csv_export.py
+++ b/candidates/tests/test_csv_export.py
@@ -116,7 +116,8 @@ class CSVTests(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, TestCase):
         # After the select_related and prefetch_related calls
         # PersonExtra there should only be one more query - that to
         # find the complex fields mapping:
-        with self.assertNumQueries(1):
+        # one for site settings, one for the person
+        with self.assertNumQueries(2):
             person_dict_list = person_extra.as_list_of_dicts(self.election)
         self.assertEqual(len(person_dict_list), 1)
         person_dict = person_dict_list[0]
@@ -126,9 +127,9 @@ class CSVTests(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, TestCase):
     def test_as_dict_2010(self):
         person_extra = get_person_extra_with_joins(self.gb_person_extra.id)
         # After the select_related and prefetch_related calls
-        # PersonExtra there should only be one more query - that to
-        # find the complex fields mapping:
-        with self.assertNumQueries(1):
+        # PersonExtra there should only be two more queries - that to
+        # find the complex fields mapping and another for the user settings:
+        with self.assertNumQueries(2):
             person_dict_list = person_extra.as_list_of_dicts(self.earlier_election)
         self.assertEqual(len(person_dict_list), 1)
         person_dict = person_dict_list[0]
@@ -151,8 +152,10 @@ class CSVTests(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, TestCase):
         gb_person_extra = get_person_extra_with_joins(self.gb_person_extra.id)
         ni_person_extra = get_person_extra_with_joins(self.ni_person_extra.id)
         # After the select_related and prefetch_related calls on
-        # PersonExtra, there should only be one query per PersonExtra:
-        with self.assertNumQueries(2):
+        # PersonExtra, there should only be two queries per PersonExtra,
+        # one for the data and one for the first time site settings
+        # are loaded:
+        with self.assertNumQueries(3):
             list_of_dicts = gb_person_extra.as_list_of_dicts(None)
             list_of_dicts += ni_person_extra.as_list_of_dicts(None)
         self.assertEqual(list_to_csv(list_of_dicts), example_output)

--- a/candidates/tests/test_date_parsing.py
+++ b/candidates/tests/test_date_parsing.py
@@ -7,13 +7,16 @@ from django.utils.translation import override
 
 from django_date_extensions.fields import ApproximateDate
 
+from usersettings.shortcuts import get_current_usersettings
+
+from .settings import SettingsMixin
 from candidates.models import parse_approximate_date
 
 # These tests supplement the doctests; they're not done as
 # doctests because we need to override settings to pick
 # either US or non-US day/month default ordering:
 
-class DateParsingTests(TestCase):
+class DateParsingTests(SettingsMixin, TestCase):
 
     def test_only_year(self):
         parsed = parse_approximate_date('1977')
@@ -34,8 +37,10 @@ class DateParsingTests(TestCase):
         self.assertEqual(type(parsed), ApproximateDate)
         self.assertEqual(repr(parsed), '1977-04-01')
 
-    @override_settings(DD_MM_DATE_FORMAT_PREFERRED=False)
     def test_mm_dd_yyyy_with_slashes(self):
+        settings = get_current_usersettings()
+        settings.DD_MM_DATE_FORMAT_PREFERRED=False
+        settings.save()
         parsed = parse_approximate_date('4/1/1977')
         self.assertEqual(type(parsed), ApproximateDate)
         self.assertEqual(repr(parsed), '1977-04-01')

--- a/candidates/tests/test_edit_restriction.py
+++ b/candidates/tests/test_edit_restriction.py
@@ -1,0 +1,82 @@
+from __future__ import unicode_literals
+
+from django_webtest import WebTest
+
+from usersettings.shortcuts import get_current_usersettings
+
+from .auth import TestUserMixin
+from .settings import SettingsMixin
+from .factories import PersonExtraFactory
+
+
+class TestEditRestriction(TestUserMixin, SettingsMixin, WebTest):
+
+    def setUp(self):
+        super(TestEditRestriction, self).setUp()
+        PersonExtraFactory.create(
+            base__id=4322,
+            base__name='Helen Hayes',
+            base__email='hayes@example.com',
+        )
+
+    def test_edit_restricted_unprivileged(self):
+        settings = get_current_usersettings()
+        settings.EDITS_ALLOWED = False
+        settings.save()
+        response = self.app.get(
+            '/person/4322/update',
+            user=self.user
+        )
+
+        self.assertContains(
+            response,
+            'Editing of data in  is now disabled'
+        )
+
+    def test_edit_restricted_privileged(self):
+        settings = get_current_usersettings()
+        settings.EDITS_ALLOWED = False
+        settings.save()
+        response = self.app.get(
+            '/person/4322/update',
+            user=self.user_is_staff,
+        )
+        form = response.forms['person-details']
+        form['email'] = 'helen@example.com'
+        form['source'] = 'Testing renaming'
+        submission_response = form.submit(expect_errors=True)
+        self.assertEqual(submission_response.status_code, 302)
+        self.assertEqual(
+            submission_response.location,
+            'http://localhost:80/person/4322',
+        )
+
+    def test_edit_unrestricted_unprivileged(self):
+        response = self.app.get(
+            '/person/4322/update',
+            user=self.user,
+        )
+        form = response.forms['person-details']
+        form['email'] = 'helen@example.com'
+        form['source'] = 'Testing renaming'
+        submission_response = form.submit(expect_errors=True)
+        self.assertEqual(submission_response.status_code, 302)
+        self.assertEqual(
+            submission_response.location,
+            'http://localhost:80/person/4322',
+        )
+
+    def test_edit_unrestricted_privileged(self):
+        response = self.app.get(
+            '/person/4322/update',
+            user=self.user_is_staff,
+        )
+        form = response.forms['person-details']
+        form['email'] = 'helen@example.com'
+        form['source'] = 'Testing renaming'
+        submission_response = form.submit(expect_errors=True)
+        self.assertEqual(submission_response.status_code, 302)
+        self.assertEqual(
+            submission_response.location,
+            'http://localhost:80/person/4322',
+        )

--- a/candidates/tests/test_extra_fields.py
+++ b/candidates/tests/test_extra_fields.py
@@ -13,10 +13,11 @@ from popolo.models import Person
 from candidates.models import ExtraField, PersonExtraFieldValue, PersonExtra
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class ExtraFieldTests(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class ExtraFieldTests(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(ExtraFieldTests, self).setUp()

--- a/candidates/tests/test_feeds.py
+++ b/candidates/tests/test_feeds.py
@@ -6,11 +6,13 @@ from django_webtest import WebTest
 
 from popolo.models import Person
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from ..models import LoggedAction
 
-class TestFeeds(TestUserMixin, WebTest):
+class TestFeeds(TestUserMixin, SettingsMixin, WebTest):
 
     def setUp(self):
+        super(TestFeeds, self).setUp()
         self.person1 = Person.objects.create(
             name='Test Person1'
         )

--- a/candidates/tests/test_flash_calls_to_action.py
+++ b/candidates/tests/test_flash_calls_to_action.py
@@ -7,12 +7,13 @@ from django.test import TestCase
 from candidates.views.people import get_call_to_action_flash_message
 
 from . import factories
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 def normalize_whitespace(s):
     return re.sub(r'(?ms)\s+', ' ', s)
 
-class TestGetFlashMessage(UK2015ExamplesMixin, TestCase):
+class TestGetFlashMessage(SettingsMixin, UK2015ExamplesMixin, TestCase):
 
     maxDiff = None
 

--- a/candidates/tests/test_geolocation.py
+++ b/candidates/tests/test_geolocation.py
@@ -10,6 +10,7 @@ from candidates.tests.factories import (
     AreaExtraFactory
 )
 
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
@@ -36,7 +37,7 @@ def fake_requests_for_mapit(url):
 
 
 @patch('candidates.views.frontpage.requests')
-class TestGeolocator(UK2015ExamplesMixin, WebTest):
+class TestGeolocator(SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestGeolocator, self).setUp()

--- a/candidates/tests/test_group_elections.py
+++ b/candidates/tests/test_group_elections.py
@@ -2,11 +2,12 @@ from django.test import TestCase
 
 from elections.models import Election
 
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 from .factories import ElectionFactory
 
 
-class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
+class TestElectionGrouping(SettingsMixin, UK2015ExamplesMixin, TestCase):
 
     def setUp(self):
         super(TestElectionGrouping, self).setUp()

--- a/candidates/tests/test_hide_record_winner_buttons.py
+++ b/candidates/tests/test_hide_record_winner_buttons.py
@@ -9,11 +9,12 @@ from .dates import (
     processors_on_election_day,
     processors_after,
 )
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 from .factories import CandidacyExtraFactory, PersonExtraFactory
 
 
-class TestWasElectedButtons(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestWasElectedButtons(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestWasElectedButtons, self).setUp()

--- a/candidates/tests/test_image_import.py
+++ b/candidates/tests/test_image_import.py
@@ -10,6 +10,7 @@ from candidates.models import ImageExtra
 
 from . import factories
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 
 
 def get_file_md5sum(filename):
@@ -17,9 +18,10 @@ def get_file_md5sum(filename):
         return hashlib.md5(f.read()).hexdigest()
 
 
-class TestImageImport(TestUserMixin, TestCase):
+class TestImageImport(TestUserMixin, SettingsMixin, TestCase):
 
     def setUp(self):
+        super(TestImageImport, self).setUp()
         self.labour_extra = factories.PartyExtraFactory.create(
             slug='party:53',
             base__name='Labour Party',

--- a/candidates/tests/test_language_switcher.py
+++ b/candidates/tests/test_language_switcher.py
@@ -1,7 +1,9 @@
 from django_webtest import WebTest
 
+from .settings import SettingsMixin
 
-class TestLanguageSwitcher(WebTest):
+
+class TestLanguageSwitcher(SettingsMixin, WebTest):
 
     def test_switch_language(self):
         response = self.app.get('/')

--- a/candidates/tests/test_leaderboard.py
+++ b/candidates/tests/test_leaderboard.py
@@ -83,5 +83,6 @@ class TestLeaderboardView(TestUserMixin, SettingsMixin, WebTest):
             '5,ermintrude,0\r\n'
             '6,frankie,0\r\n'
             '7,johnrefused,0\r\n'
-            '8,settings,0\r\n'
+            '8,johnstaff,0\r\n'
+            '9,settings,0\r\n'
         )

--- a/candidates/tests/test_leaderboard.py
+++ b/candidates/tests/test_leaderboard.py
@@ -6,11 +6,13 @@ from django_webtest import WebTest
 
 from .auth import TestUserMixin
 from .factories import PersonExtraFactory
+from .settings import SettingsMixin
 from ..models import LoggedAction
 
-class TestLeaderboardView(TestUserMixin, WebTest):
+class TestLeaderboardView(TestUserMixin, SettingsMixin, WebTest):
 
     def setUp(self):
+        super(TestLeaderboardView, self).setUp()
         self.user2 = User.objects.create_user(
             'jane',
             'jane@example.com',
@@ -81,4 +83,5 @@ class TestLeaderboardView(TestUserMixin, WebTest):
             '5,ermintrude,0\r\n'
             '6,frankie,0\r\n'
             '7,johnrefused,0\r\n'
+            '8,settings,0\r\n'
         )

--- a/candidates/tests/test_merge_view.py
+++ b/candidates/tests/test_merge_view.py
@@ -16,6 +16,7 @@ from popolo.models import Membership, Person
 from candidates.models import PersonRedirect, MembershipExtra, ImageExtra
 from mysite.helpers import mkdir_p
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 from . import factories
 
@@ -25,7 +26,7 @@ example_version_id = '5aa6418325c1a0bb'
 TEST_MEDIA_ROOT = realpath(join(dirname(__file__), 'media'))
 
 @override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT)
-class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestMergePeopleView(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestMergePeopleView, self).setUp()

--- a/candidates/tests/test_missing_fields.py
+++ b/candidates/tests/test_missing_fields.py
@@ -5,10 +5,11 @@ from django.test import TestCase
 from candidates.models import PersonExtra, ExtraField
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 from . import factories
 
-class TestMissingFields(TestUserMixin, UK2015ExamplesMixin, TestCase):
+class TestMissingFields(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, TestCase):
 
     def setUp(self):
         super(TestMissingFields, self).setUp()

--- a/candidates/tests/test_new_person_view.py
+++ b/candidates/tests/test_new_person_view.py
@@ -11,10 +11,11 @@ from popolo.models import Person
 from ..models import LoggedAction
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestNewPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestNewPersonView(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestNewPersonView, self).setUp()

--- a/candidates/tests/test_ordered_party_list.py
+++ b/candidates/tests/test_ordered_party_list.py
@@ -8,11 +8,12 @@ from .auth import TestUserMixin
 from .factories import (
     CandidacyExtraFactory, MembershipFactory, PersonExtraFactory
 )
+from .settings import SettingsMixin
 from popolo.models import Organization
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestRecordWinner(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestRecordWinner, self).setUp()

--- a/candidates/tests/test_other_names.py
+++ b/candidates/tests/test_other_names.py
@@ -6,10 +6,11 @@ from popolo.models import OtherName
 
 from .auth import TestUserMixin
 from .factories import PersonExtraFactory
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestOtherNamesViews(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestOtherNamesViews(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestOtherNamesViews, self).setUp()

--- a/candidates/tests/test_party_dropdown_ordering.py
+++ b/candidates/tests/test_party_dropdown_ordering.py
@@ -2,9 +2,10 @@ from django_webtest import WebTest
 
 from . import factories
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
-class TestPartyDropDownOrdering(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestPartyDropDownOrdering(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def test_hardly_any_candidates_at_all(self):
         party_choices = self.gb_parties.party_choices()

--- a/candidates/tests/test_party_pages.py
+++ b/candidates/tests/test_party_pages.py
@@ -7,9 +7,10 @@ from django_webtest import WebTest
 from .factories import (
     CandidacyExtraFactory, PersonExtraFactory, PostExtraFactory
 )
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
-class TestPartyPages(UK2015ExamplesMixin, WebTest):
+class TestPartyPages(UK2015ExamplesMixin, SettingsMixin, WebTest):
 
     def setUp(self):
         super(TestPartyPages, self).setUp()

--- a/candidates/tests/test_person_last_party.py
+++ b/candidates/tests/test_person_last_party.py
@@ -3,9 +3,10 @@ from __future__ import unicode_literals
 from django.test import TestCase
 
 from . import factories
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
-class TestPersonLastParty(UK2015ExamplesMixin, TestCase):
+class TestPersonLastParty(UK2015ExamplesMixin, SettingsMixin, TestCase):
 
     def setUp(self):
         super(TestPersonLastParty, self).setUp()

--- a/candidates/tests/test_person_view.py
+++ b/candidates/tests/test_person_view.py
@@ -11,10 +11,11 @@ from .dates import processors_before, processors_after
 from .factories import (
     CandidacyExtraFactory, PersonExtraFactory
 )
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestPersonView(UK2015ExamplesMixin, WebTest):
+class TestPersonView(UK2015ExamplesMixin, SettingsMixin, WebTest):
 
     def setUp(self):
         super(TestPersonView, self).setUp()

--- a/candidates/tests/test_posts_view.py
+++ b/candidates/tests/test_posts_view.py
@@ -2,10 +2,11 @@ from __future__ import unicode_literals
 
 from django_webtest import WebTest
 
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestPostsView(UK2015ExamplesMixin, WebTest):
+class TestPostsView(UK2015ExamplesMixin, SettingsMixin, WebTest):
 
     def test_single_election_posts_page(self):
 

--- a/candidates/tests/test_recent_changes_view.py
+++ b/candidates/tests/test_recent_changes_view.py
@@ -5,11 +5,13 @@ from django_webtest import WebTest
 from candidates.tests import factories
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from ..models import LoggedAction
 
-class TestRecentChangesView(TestUserMixin, WebTest):
+class TestRecentChangesView(TestUserMixin, SettingsMixin, WebTest):
 
     def setUp(self):
+        super(TestRecentChangesView, self).setUp()
         test_person_1 = factories.PersonExtraFactory.create(
             base__id=9876,
             base__name='Test Candidate for Recent Changes',

--- a/candidates/tests/test_record_winner.py
+++ b/candidates/tests/test_record_winner.py
@@ -8,6 +8,7 @@ from popolo.models import Person
 
 from ..models import PostExtraElection
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .factories import (
     CandidacyExtraFactory, MembershipFactory, PersonExtraFactory,
 )
@@ -15,7 +16,7 @@ from .dates import processors_after
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestRecordWinner(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestRecordWinner, self).setUp()
@@ -272,7 +273,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
         person = Person.objects.get(id=2009)
         self.assertTrue(person.extra.get_elected(self.election))
 
-class TestRetractWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestRetractWinner(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestRetractWinner, self).setUp()

--- a/candidates/tests/test_revert.py
+++ b/candidates/tests/test_revert.py
@@ -16,6 +16,7 @@ from candidates.models import MembershipExtra, PersonExtra, ExtraField
 from compat import bytes_to_unicode
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 from . import factories
 
@@ -24,7 +25,7 @@ example_version_id = '5aa6418325c1a0bb'
 
 # FIXME: add a test to check that unauthorized people can't revert
 
-class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestRevertPersonView(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     version_template = Template('''[
           {

--- a/candidates/tests/test_search.py
+++ b/candidates/tests/test_search.py
@@ -4,12 +4,13 @@ from django.core.management import call_command
 from django_webtest import WebTest
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 
 from popolo.models import Person
 
 from .uk_examples import UK2015ExamplesMixin
 
-class TestSearchView(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestSearchView(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestSearchView, self).setUp()

--- a/candidates/tests/test_settings.py
+++ b/candidates/tests/test_settings.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from django.contrib.auth.models import User, Group
+
+from usersettings.shortcuts import get_current_usersettings
+
+from django_webtest import WebTest
+from django.core.urlresolvers import reverse
+
+from ..models import EDIT_SETTINGS_GROUP_NAME
+from ..models import LoggedAction
+
+from .auth import TestUserMixin
+from .settings import SettingsMixin
+
+
+class SettingsTests(TestUserMixin, SettingsMixin, WebTest):
+
+    def setUp(self):
+        super(SettingsTests, self).setUp()
+        self.test_setter = User.objects.create_superuser(
+            'jane',
+            'jane@example.com',
+            'alsonotagoodpassword',
+        )
+        self.test_setter.terms_agreement.assigned_to_dc = True
+        self.test_setter.terms_agreement.save()
+        self.test_setter.groups.add(
+            Group.objects.get(name=EDIT_SETTINGS_GROUP_NAME)
+        )
+
+    def test_settings_view_unprivileged(self):
+        settings_url = reverse(
+            'settings',
+        )
+        response = self.app.get(
+            settings_url,
+            user=self.user,
+            expect_errors=True
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_settings_view_privileged(self):
+        settings_url = reverse(
+            'settings',
+        )
+        response = self.app.get(settings_url, user=self.test_setter)
+        self.assertEqual(response.status_code, 200)
+
+    def test_settings_loaded(self):
+        settings_url = reverse(
+            'settings',
+        )
+        response = self.app.get(settings_url, user=self.test_setter)
+        form = response.forms['settings']
+
+        # just check a sample
+        self.assertEqual(form['SITE_OWNER'].value, 'The Site Owners')
+        self.assertEqual(form['SERVER_EMAIL'].value, 'root@localhost')
+
+    def test_settings_saved(self):
+        settings_url = reverse(
+            'settings',
+        )
+        response = self.app.get(settings_url, user=self.test_setter)
+        form = response.forms['settings']
+
+        form['SITE_OWNER'].value = 'The New Owners'
+        response = form.submit()
+
+        self.assertEqual(form['SITE_OWNER'].value, 'The New Owners')
+
+        settings = get_current_usersettings()
+        self.assertEqual(settings.SITE_OWNER, 'The New Owners')
+
+    def test_logged_action_created(self):
+        settings_url = reverse(
+            'settings',
+        )
+        response = self.app.get(settings_url, user=self.test_setter)
+        form = response.forms['settings']
+
+        form['SITE_OWNER'].value = 'The New Owners'
+        response = form.submit()
+
+        settings = get_current_usersettings()
+        self.assertEqual(settings.SITE_OWNER, 'The New Owners')
+
+        actions = LoggedAction.objects.filter(
+            action_type='settings-edited'
+        ).order_by('-created')
+
+        action = actions[0]
+
+        self.assertEqual(
+            action.note,
+            "Changed SITE_OWNER from \"The Site Owners\" to \"The New Owners\"\n"
+        )

--- a/candidates/tests/test_signup.py
+++ b/candidates/tests/test_signup.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
+from usersettings.shortcuts import get_current_usersettings
+
+from django_webtest import WebTest
+from django.core.urlresolvers import reverse
+
+from .settings import SettingsMixin
+
+
+class SettingsTests(SettingsMixin, WebTest):
+
+    def test_signup_allowed(self):
+        settings_url = reverse(
+            'account_signup',
+        )
+        response = self.app.get(
+            settings_url,
+            expect_errors=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Password (again)')
+        self.assertNotContains(response, 'Sign Up Closed')
+
+    def test_signup_disabled(self):
+        user_settings = get_current_usersettings()
+        user_settings.NEW_ACCOUNTS_ALLOWED = False;
+        user_settings.save()
+        settings_url = reverse(
+            'account_signup',
+        )
+        response = self.app.get(
+            settings_url,
+            expect_errors=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Sign Up Closed')
+        self.assertNotContains(response, 'Password (again)')

--- a/candidates/tests/test_simple_fields.py
+++ b/candidates/tests/test_simple_fields.py
@@ -9,6 +9,7 @@ from popolo.models import Person
 from candidates.models import PersonExtra, SimplePopoloField
 
 from .auth import TestUserMixin
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
@@ -16,7 +17,7 @@ def get_next_dd(start):
     return [t for t in start.next_siblings if t.name == 'dd'][0]
 
 
-class SimpleFieldsTests(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class SimpleFieldsTests(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(SimpleFieldsTests, self).setUp()

--- a/candidates/tests/test_upcoming_elections_api.py
+++ b/candidates/tests/test_upcoming_elections_api.py
@@ -16,6 +16,7 @@ from candidates.tests.factories import (
     AreaTypeFactory, AreaExtraFactory, ElectionFactory,
     ParliamentaryChamberExtraFactory, PostExtraFactory,
 )
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 from elections.uk.tests.mapit_postcode_results \
     import se240ag_result, sw1a1aa_result
@@ -52,7 +53,7 @@ def fake_requests_for_mapit(url):
 
 @attr(country='uk')
 @patch('elections.uk.mapit.requests')
-class TestUpcomingElectionsAPI(UK2015ExamplesMixin, WebTest):
+class TestUpcomingElectionsAPI(UK2015ExamplesMixin, SettingsMixin, WebTest):
     def setUp(self):
         super(TestUpcomingElectionsAPI, self).setUp()
 

--- a/candidates/tests/test_update_view.py
+++ b/candidates/tests/test_update_view.py
@@ -14,10 +14,11 @@ from popolo.models import Person
 
 from candidates.models import ExtraField
 from .factories import CandidacyExtraFactory, PersonExtraFactory
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestUpdatePersonView(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestUpdatePersonView, self).setUp()

--- a/candidates/tests/test_validators.py
+++ b/candidates/tests/test_validators.py
@@ -4,10 +4,11 @@ from django.test import TestCase
 
 from ..forms import BasePersonForm, UpdatePersonForm
 
+from .settings import SettingsMixin
 from .uk_examples import UK2015ExamplesMixin
 
 
-class TestValidators(UK2015ExamplesMixin, TestCase):
+class TestValidators(SettingsMixin, UK2015ExamplesMixin, TestCase):
 
     def setUp(self):
         super(TestValidators, self).setUp()

--- a/candidates/twitter_api.py
+++ b/candidates/twitter_api.py
@@ -4,6 +4,8 @@ from django.utils.six import text_type
 
 import requests
 
+from usersettings.shortcuts import get_current_usersettings
+
 from popolo.models import ContactDetail
 
 
@@ -16,7 +18,8 @@ def get_twitter_user_id(twitter_screen_name):
     cached_result = cache.get(cache_key)
     if cached_result:
         return cached_result
-    token = settings.TWITTER_APP_ONLY_BEARER_TOKEN
+    user_settings = get_current_usersettings()
+    token = user_settings.TWITTER_APP_ONLY_BEARER_TOKEN
     if not token:
         raise TwitterAPITokenMissing()
     headers = {'Authorization': 'Bearer {token}'.format(token=token)}

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -243,7 +243,12 @@ patterns_to_format = [
         'pattern': r'^geolocator/(?P<latitude>[\d.\-]+),(?P<longitude>[\d.\-]+)',
         'view': views.GeoLocatorView.as_view(),
         'name': 'geolocator'
-    }
+    },
+    {
+        'pattern': r'^settings$',
+        'view': views.SettingsView.as_view(),
+        'name': 'settings'
+    },
 ]
 
 urlpatterns += [

--- a/candidates/views/__init__.py
+++ b/candidates/views/__init__.py
@@ -9,5 +9,6 @@ from .parties import *
 from .people import *
 from .posts import *
 from .search import *
+from .settings import *
 from .users import *
 from .other_names import *

--- a/candidates/views/helpers.py
+++ b/candidates/views/helpers.py
@@ -6,6 +6,8 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 
+from usersettings.shortcuts import get_current_usersettings
+
 from elections.models import Election
 
 from slugify import slugify
@@ -185,7 +187,8 @@ def split_by_elected(election_data, memberships):
     for membership in memberships:
         if membership.extra.elected:
             elected_candidates.add(membership)
-            if not settings.HOIST_ELECTED_CANDIDATES:
+            user_settings = get_current_usersettings()
+            if not user_settings.HOIST_ELECTED_CANDIDATES:
                 unelected_candidates.add(membership)
         else:
             unelected_candidates.add(membership)

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -349,7 +349,8 @@ class UpdatePersonView(LoginRequiredMixin, FormView):
 
     def form_valid(self, form):
 
-        if not (settings.EDITS_ALLOWED or self.request.user.is_staff):
+        if not (self.request.usersettings.EDITS_ALLOWED
+                or self.request.user.is_staff):
             return HttpResponseRedirect(reverse('all-edits-disallowed'))
 
         with transaction.atomic():

--- a/candidates/views/settings.py
+++ b/candidates/views/settings.py
@@ -1,0 +1,32 @@
+from __future__ import unicode_literals
+
+from django.views.generic import FormView
+from django.core.urlresolvers import reverse
+from django.http import HttpResponseRedirect
+
+from auth_helpers.views import GroupRequiredMixin
+from ..forms import SettingsForm
+from ..models import EDIT_SETTINGS_GROUP_NAME
+
+
+class SettingsView(GroupRequiredMixin, FormView):
+    template_name = 'candidates/settings.html'
+    form_class = SettingsForm
+    required_group_name = EDIT_SETTINGS_GROUP_NAME
+
+    def get_context_data(self, **kwargs):
+        context = super(SettingsView, self).get_context_data(**kwargs)
+
+        settings = self.request.usersettings
+        context['form'] = SettingsForm(instance=settings)
+
+        return context
+
+    def form_valid(self, form):
+        settings = self.request.usersettings
+        for field in form.fields:
+            setattr(settings, field, form[field].value())
+        settings.user = self.request.user
+        settings.save()
+
+        return HttpResponseRedirect(reverse('settings'))

--- a/elections/st_paul_municipal_2015/tests.py
+++ b/elections/st_paul_municipal_2015/tests.py
@@ -13,6 +13,7 @@ import pygeocoder
 
 from candidates.models import PartySet
 from candidates.tests.factories import PostExtraFactory, AreaExtraFactory
+from candidates.tests.settings import SettingsMixin
 from elections.models import AreaType, Election
 from popolo.models import Organization
 
@@ -132,8 +133,9 @@ def fake_represent_boundaries(url, params):
 
 
 @attr(country='st_paul')
-class StPaulTests(WebTest):
+class StPaulTests(SettingsMixin, WebTest):
     def setUp(self):
+        super(StPaulTests, self).setUp()
         election_school = Election.objects.get(slug='school-board-2015')
         election_council = Election.objects.get(slug='council-member-2015')
         ward_area_type = AreaType.objects.get(name='WARD')

--- a/elections/uk/tests/test_csv.py
+++ b/elections/uk/tests/test_csv.py
@@ -67,9 +67,9 @@ class CSVTests(UK2015ExamplesMixin, TestCase):
         person_extra = PersonExtra.objects \
             .joins_for_csv_output().get(pk=self.gb_person_extra.id)
         # After the select_related and prefetch_related calls
-        # PersonExtra there should only be one more query - that to
-        # find the complex fields mapping:
-        with self.assertNumQueries(1):
+        # PersonExtra there should two more queries - that to
+        # find the complex fields mapping and another for settings:
+        with self.assertNumQueries(2):
             person_dict_list = person_extra.as_list_of_dicts(self.election)
         self.assertEqual(len(person_dict_list), 1)
         person_dict = person_dict_list[0]

--- a/elections/uk/tests/test_finders.py
+++ b/elections/uk/tests/test_finders.py
@@ -15,6 +15,7 @@ from candidates.tests.factories import (
     ParliamentaryChamberFactory, ParliamentaryChamberExtraFactory,
     PartySetFactory, AreaExtraFactory
 )
+from candidates.tests.settings import SettingsMixin
 from elections.models import Election
 from .mapit_postcode_results import se240ag_result, sw1a1aa_result
 
@@ -48,8 +49,9 @@ def fake_requests_for_mapit(url):
 
 @attr(country='uk')
 @patch('elections.uk.mapit.requests')
-class TestConstituencyPostcodeFinderView(WebTest):
+class TestConstituencyPostcodeFinderView(SettingsMixin, WebTest):
     def setUp(self):
+        super(TestConstituencyPostcodeFinderView, self).setUp()
         wmc_area_type = AreaTypeFactory.create()
         gb_parties = PartySetFactory.create(slug='gb', name='Great Britain')
         commons = ParliamentaryChamberFactory.create()

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -201,11 +201,11 @@ class PhotoReview(GroupRequiredMixin, TemplateView):
     def send_mail(self, subject, message, email_support_too=False):
         recipients = [self.queued_image.user.email]
         if email_support_too:
-            recipients.append(settings.SUPPORT_EMAIL)
+            recipients.append(self.request.usersettings.SUPPORT_EMAIL)
         return send_mail(
             subject,
             message,
-            settings.DEFAULT_FROM_EMAIL,
+            self.request.usersettings.DEFAULT_FROM_EMAIL,
             recipients,
             fail_silently=False,
         )

--- a/mysite/account_adapter.py
+++ b/mysite/account_adapter.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
 
 from allauth.account.adapter import DefaultAccountAdapter
+from usersettings.shortcuts import get_current_usersettings
 
-class NoNewUsersAccountAdapter(DefaultAccountAdapter):
+class CheckIfAllowedNewUsersAccountAdapter(DefaultAccountAdapter):
 
     def is_open_for_signup(self, request):
         """
@@ -13,4 +14,9 @@ class NoNewUsersAccountAdapter(DefaultAccountAdapter):
 
         (Comment reproduced from the overridden method.)
         """
+
+        userconf = get_current_usersettings()
+        if userconf.NEW_ACCOUNTS_ALLOWED:
+            return True
+
         return False

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -91,7 +91,7 @@ def add_group_permissions(request):
             ('user_can_record_results', RESULT_RECORDERS_GROUP_NAME),
         )
     }
-    result['user_can_edit'] = settings.EDITS_ALLOWED or request.user.is_staff
+    result['user_can_edit'] = request.usersettings.EDITS_ALLOWED or request.user.is_staff
     return result
 
 def add_site(request):

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from datetime import date
 from django.conf import settings
 from django.contrib.sites.models import Site
+from usersettings.shortcuts import get_current_usersettings
 from auth_helpers.views import user_in_group
 from candidates.models import (
     TRUSTED_TO_MERGE_GROUP_NAME,
@@ -16,28 +17,40 @@ from django.utils.translation import to_locale, get_language
 
 SETTINGS_TO_ADD = (
     'ELECTION_APP',
+    'SOURCE_HINTS',
+    'MEDIA_URL',
+    'RUNNING_TESTS',
+)
+
+USERSETTINGS_TO_ADD = (
     'GOOGLE_ANALYTICS_ACCOUNT',
     'USE_UNIVERSAL_ANALYTICS',
     'TWITTER_USERNAME',
-    'SOURCE_HINTS',
-    'MEDIA_URL',
     'SUPPORT_EMAIL',
     'EDITS_ALLOWED',
     'SITE_OWNER',
+    'SITE_OWNER_URL',
     'COPYRIGHT_HOLDER',
     'HOIST_ELECTED_CANDIDATES',
-    'RUNNING_TESTS',
+    'CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST',
 )
 
 
 def add_settings(request):
     """Add some selected settings values to the context"""
 
-    return {
-        'settings': {
-            k: getattr(settings, k) for k in SETTINGS_TO_ADD
-        }
+    all_settings = {
+        k: getattr(settings, k) for k in SETTINGS_TO_ADD
     }
+
+    current = get_current_usersettings()
+    usersettings = {
+        k: getattr(current, k) for k in USERSETTINGS_TO_ADD
+    }
+
+    all_settings.update(usersettings)
+
+    return {'settings': all_settings}
 
 
 def election_date(request):

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -263,6 +263,9 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'ACCOUNT_USERNAME_REQUIRED': True,
         'SOCIALACCOUNT_AUTO_SIGNUP': True,
 
+        # use our own adapter that checks if user signup has been disabled
+        'ACCOUNT_ADAPTER': 'mysite.account_adapter.CheckIfAllowedNewUsersAccountAdapter',
+
         'ROOT_URLCONF': 'mysite.urls',
         'WSGI_APPLICATION': 'mysite.wsgi.application',
 

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -154,25 +154,8 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'DEBUG': debug,
         'RUNNING_TESTS': tests,
 
-        # Google analytics settings:
-        'GOOGLE_ANALYTICS_ACCOUNT': conf.get('GOOGLE_ANALYTICS_ACCOUNT'),
-        'USE_UNIVERSAL_ANALYTICS': conf.get('USE_UNIVERSAL_ANALYTICS', True),
-
-        # The Twitter account referenced in the Twitter card data:
-        'TWITTER_USERNAME': conf.get('TWITTER_USERNAME', ''),
-
-        # The email address which is made public on the site for sending
-        # support email to:
-        'SUPPORT_EMAIL': conf['SUPPORT_EMAIL'],
-
         # Email addresses that error emails are sent to when DEBUG = False
         'ADMINS': conf['ADMINS'],
-
-        # The From: address for all emails except error emails
-        'DEFAULT_FROM_EMAIL': conf['DEFAULT_FROM_EMAIL'],
-
-        # The From: address for error emails
-        'SERVER_EMAIL': conf['SERVER_EMAIL'],
 
         # SECURITY WARNING: keep the secret key used in production secret!
         'SECRET_KEY': conf['SECRET_KEY'],
@@ -310,7 +293,6 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'USE_I18N': True,
         'USE_L10N': True,
         'USE_TZ': True,
-        'DD_MM_DATE_FORMAT_PREFERRED': conf.get('DD_MM_DATE_FORMAT_PREFERRED', True),
 
         # The media and static file settings:
         'MEDIA_ROOT': media_root,
@@ -429,14 +411,6 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'THUMBNAIL_CACHE': 'thumbnails',
         'THUMBNAIL_DEBUG': debug,
 
-        # Settings for restricting user activity to reduce abuse:
-        'RESTRICT_RENAMES': conf.get('RESTRICT_RENAMES'),
-        'EDITS_ALLOWED': conf.get('EDITS_ALLOWED', True),
-
-        # A bearer token for the Twitter API for mapping between
-        # Twitter usernames and IDs.
-        'TWITTER_APP_ONLY_BEARER_TOKEN': conf.get('TWITTER_APP_ONLY_BEARER_TOKEN'),
-
         # Django Rest Framework settings:
         'REST_FRAMEWORK': {
             'DEFAULT_PERMISSION_CLASSES': ('candidates.api_permissions.ReadOnly',),
@@ -466,13 +440,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             'OPTIONS',
         ),
     }
-    if not conf.get('NEW_ACCOUNTS_ALLOWED', True):
-        result['ACCOUNT_ADAPTER'] = \
-            'mysite.account_adapter.NoNewUsersAccountAdapter'
-    result['CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST'] = \
-        conf.get('CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST', 20)
-    result['HOIST_ELECTED_CANDIDATES'] = \
-        conf.get('HOIST_ELECTED_CANDIDATES', True)
+
     if tests:
         result['NOSE_ARGS'] = [
             '--nocapture',
@@ -490,16 +458,8 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
     if conf.get('NGINX_SSL'):
         result['SECURE_PROXY_SSL_HEADER'] = ('HTTP_X_FORWARDED_PROTO', 'https')
         result['ACCOUNT_DEFAULT_HTTP_PROTOCOL'] = 'https'
-    for required_election_app_setting in (
-            'SITE_OWNER',
-            'COPYRIGHT_HOLDER',
-    ):
-        result[required_election_app_setting] = \
-            getattr(elections_module, required_election_app_setting)
     for optional_election_app_setting, default in (
-            ('SITE_OWNER_URL', ''),
             ('AREAS_TO_ALWAYS_RETURN', []),
-            ('IMAGE_PROXY_URL', ''),
     ):
         try:
             result[optional_election_app_setting] = \

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -240,9 +240,12 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             'allauth.socialaccount.providers.twitter',
             'corsheaders',
             'crispy_forms',
+            'usersettings',
         ),
 
         'SITE_ID': 1,
+
+        'USERSETTINGS_MODEL': 'candidates.SiteSettings',
 
         'MIDDLEWARE_CLASSES': (
             'debug_toolbar.middleware.DebugToolbarMiddleware',
@@ -256,6 +259,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             'candidates.middleware.DisallowedUpdateMiddleware',
             'django.contrib.messages.middleware.MessageMiddleware',
             'django.middleware.clickjacking.XFrameOptionsMiddleware',
+            'usersettings.middleware.CurrentUserSettingsMiddleware',
         ),
 
         # django-allauth settings:

--- a/official_documents/tests/test_upload.py
+++ b/official_documents/tests/test_upload.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.urlresolvers import reverse
 
 from candidates.tests.auth import TestUserMixin
+from candidates.tests.settings import SettingsMixin
 
 from official_documents.models import OfficialDocument
 
@@ -31,13 +32,14 @@ TEST_MEDIA_ROOT=realpath(
 # check whether the upload text appears correctly should be moved to
 # the candidates application tests.
 
-class TestModels(TestUserMixin, WebTest):
+class TestModels(TestUserMixin, SettingsMixin, WebTest):
 
     example_image_filename = join(
         settings.BASE_DIR, 'moderation_queue', 'tests', 'example-image.jpg'
     )
 
     def setUp(self):
+        super(TestModels, self).setUp()
         wmc_area_type = AreaTypeFactory.create()
         gb_parties = PartySetFactory.create(slug='gb', name='Great Britain')
         election = ElectionFactory.create(

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ django-model-utils==2.3.1
 django-nose==1.4.1
 django-notifications-hq==1.0.0
 django-pipeline==1.6.8
+django-usersettings2==0.1.5
 -e git+https://github.com/mysociety/django-popolo@fix-migrations-for-python-3#egg=mysociety-django-popolo
 django-statici18n==1.1.5
 django-webtest==1.7.7

--- a/tasks/tests/test_views.py
+++ b/tasks/tests/test_views.py
@@ -7,10 +7,11 @@ from candidates.tests.factories import (
     ParliamentaryChamberFactory, PartyFactory, PartyExtraFactory,
     PersonExtraFactory, PostExtraFactory
 )
+from candidates.tests.settings import SettingsMixin
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 
 
-class TestFieldView(UK2015ExamplesMixin, TestCase):
+class TestFieldView(UK2015ExamplesMixin, SettingsMixin, TestCase):
 
     def setUp(self):
         super(TestFieldView, self).setUp()


### PR DESCRIPTION
Move most of the settings for setting up a site into the database and provide an interface to edit them as part of the plan to make site setup easier.

Does not handle country, language or timezone because of loading complexities.

Also does not handle AREAS_TO_ALWAYS_RETURN as this is a bit more complicated than a simple setting.

Uses django-usersettings2 as a basis.

Fixes #943 
Also partially handles #944 in that there is an interface for the basic settings.