### PR TITLE
Allow election AreaType to be blank in forms/admin

### DIFF
--- a/elections/migrations/0013_optional_election_area_type.py
+++ b/elections/migrations/0013_optional_election_area_type.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('elections', '0012_election_people_elected_per_post'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='election',
+            name='area_types',
+            field=models.ManyToManyField(to='elections.AreaType', blank=True),
+        ),
+    ]

--- a/elections/models.py
+++ b/elections/models.py
@@ -68,7 +68,7 @@ class Election(models.Model):
     name = models.CharField(max_length=128)
     current = models.BooleanField()
     use_for_candidate_suggestions = models.BooleanField(default=False)
-    area_types = models.ManyToManyField(AreaType)
+    area_types = models.ManyToManyField(AreaType, blank=True)
     area_generation = models.CharField(max_length=128, blank=True)
     organization = models.ForeignKey(Organization, null=True, blank=True)
     party_lists_in_use = models.BooleanField(default=False)


### PR DESCRIPTION
Even though AreaType is a ManyToMany relationship and therefore option
unless blank=True is set on the field then the admin interface will
insist that you associate an election with an AreaType. We might not
want to do this if we are not using AreaType lookups, e.g. a simple YNR
instance which has no geolocation area lookup.

Fixes #942