### PR TITLE
Allow overriding SMTP settings in `general.yml`

### DIFF
--- a/conf/general.yml-example
+++ b/conf/general.yml-example
@@ -53,6 +53,15 @@ NGINX_SSL: false
 # the repository).
 MEDIA_ROOT: null
 
+# This is the outgoing mail server's settings.  You'll probably want to use
+# a third-party mail server, e.g. Gmail's or your host's.  Email is required for
+# user-account activation, error reporting and image moderation.
+EMAIL_HOST: ''
+EMAIL_PORT: 465
+EMAIL_HOST_USER: ''
+EMAIL_HOST_PASSWORD: ''
+EMAIL_USE_SSL: true
+
 # Old settings required by mySociety Deploy system.
 # These should now be edited at /settings in the YNR instance
 SUPPORT_EMAIL: yournextmp-support@example.org

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -160,6 +160,12 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         # SECURITY WARNING: keep the secret key used in production secret!
         'SECRET_KEY': conf['SECRET_KEY'],
 
+        'EMAIL_HOST': conf.get('EMAIL_HOST'),
+        'EMAIL_PORT': conf.get('EMAIL_PORT'),
+        'EMAIL_HOST_USER': conf.get('EMAIL_HOST_USER'),
+        'EMAIL_HOST_PASSWORD': conf.get('EMAIL_HOST_PASSWORD'),
+        'EMAIL_USE_SSL': conf.get('EMAIL_USE_SSL'),
+
         'TEMPLATE_DEBUG': True,
         'TEMPLATE_DIRS': (
             join(BASE_DIR, 'mysite', 'templates'),


### PR DESCRIPTION
Closes #890 and #956.