### PR TITLE
Improvements to the command for creating posts / areas from MapIt 

### DIFF
--- a/candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py
+++ b/candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py
@@ -6,7 +6,6 @@ from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.utils.six.moves.urllib_parse import urljoin
 
-from optparse import make_option
 import requests
 
 from popolo.models import Post, Area

--- a/candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py
+++ b/candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py
@@ -5,6 +5,7 @@ from django.db import transaction
 from django.utils.text import slugify
 from django.utils.translation import ugettext as _
 from django.utils.six.moves.urllib_parse import urljoin
+from django.utils.six import text_type
 
 import requests
 
@@ -115,7 +116,7 @@ in the Election objects in the app.
             for item in mapit_json.items():
                 area_json = item[1]
 
-                area_url = urljoin(mapit_url, '/area/' + str(area_json['id']))
+                area_url = urljoin(mapit_url, '/area/' + text_type(area_json['id']))
 
                 area, area_created = Area.objects.get_or_create(
                     name=area_json['name'],

--- a/candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py
+++ b/candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py
@@ -102,6 +102,10 @@ in the Election objects in the app.
             mapit_result = requests.get(all_areas_url)
             mapit_json = mapit_result.json()
 
+            if 'error' in mapit_json:
+                raise Command("Fetching the areas failed: {0}".format(
+                    mapit_json['error']))
+
             for_post_role = election.for_post_role
             org = election.organization
 


### PR DESCRIPTION
The changes in this PR allow you to manually specify the MapIt area IDs instead of finding them from a MapIt query, clarify how the MAPIT-URL supplied is used, and allow all areas of a type to be found.