### PR TITLE
Fix lack of validation errors from /settings and a caching bug

### DIFF
--- a/candidates/tests/auth.py
+++ b/candidates/tests/auth.py
@@ -7,6 +7,7 @@ from candidates.models import (
     TRUSTED_TO_LOCK_GROUP_NAME,
     TRUSTED_TO_RENAME_GROUP_NAME,
     RESULT_RECORDERS_GROUP_NAME,
+    EDIT_SETTINGS_GROUP_NAME,
 )
 from official_documents.models import DOCUMENT_UPLOADERS_GROUP_NAME
 
@@ -22,6 +23,7 @@ class TestUserMixin(object):
                 ('delilah', 'user_who_can_upload_documents', [DOCUMENT_UPLOADERS_GROUP_NAME]),
                 ('ermintrude', 'user_who_can_rename', [TRUSTED_TO_RENAME_GROUP_NAME]),
                 ('frankie', 'user_who_can_record_results', [RESULT_RECORDERS_GROUP_NAME]),
+                ('grover', 'user_who_can_edit_settings', [EDIT_SETTINGS_GROUP_NAME])
         ):
             u = User.objects.create_user(
                 username,

--- a/candidates/tests/test_leaderboard.py
+++ b/candidates/tests/test_leaderboard.py
@@ -82,7 +82,8 @@ class TestLeaderboardView(TestUserMixin, SettingsMixin, WebTest):
             '4,delilah,0\r\n'
             '5,ermintrude,0\r\n'
             '6,frankie,0\r\n'
-            '7,johnrefused,0\r\n'
-            '8,johnstaff,0\r\n'
-            '9,settings,0\r\n'
+            '7,grover,0\r\n'
+            '8,johnrefused,0\r\n'
+            '9,johnstaff,0\r\n'
+            '10,settings,0\r\n'
         )

--- a/candidates/tests/test_settings.py
+++ b/candidates/tests/test_settings.py
@@ -9,7 +9,6 @@ from usersettings.shortcuts import get_current_usersettings
 from django_webtest import WebTest
 from django.core.urlresolvers import reverse
 
-from ..models import EDIT_SETTINGS_GROUP_NAME
 from ..models import LoggedAction
 
 from .auth import TestUserMixin
@@ -17,19 +16,6 @@ from .settings import SettingsMixin
 
 
 class SettingsTests(TestUserMixin, SettingsMixin, WebTest):
-
-    def setUp(self):
-        super(SettingsTests, self).setUp()
-        self.test_setter = User.objects.create_superuser(
-            'jane',
-            'jane@example.com',
-            'alsonotagoodpassword',
-        )
-        self.test_setter.terms_agreement.assigned_to_dc = True
-        self.test_setter.terms_agreement.save()
-        self.test_setter.groups.add(
-            Group.objects.get(name=EDIT_SETTINGS_GROUP_NAME)
-        )
 
     def test_settings_view_unprivileged(self):
         settings_url = reverse(
@@ -46,14 +32,14 @@ class SettingsTests(TestUserMixin, SettingsMixin, WebTest):
         settings_url = reverse(
             'settings',
         )
-        response = self.app.get(settings_url, user=self.test_setter)
+        response = self.app.get(settings_url, user=self.user_who_can_edit_settings)
         self.assertEqual(response.status_code, 200)
 
     def test_settings_loaded(self):
         settings_url = reverse(
             'settings',
         )
-        response = self.app.get(settings_url, user=self.test_setter)
+        response = self.app.get(settings_url, user=self.user_who_can_edit_settings)
         form = response.forms['settings']
 
         # just check a sample
@@ -64,7 +50,7 @@ class SettingsTests(TestUserMixin, SettingsMixin, WebTest):
         settings_url = reverse(
             'settings',
         )
-        response = self.app.get(settings_url, user=self.test_setter)
+        response = self.app.get(settings_url, user=self.user_who_can_edit_settings)
         form = response.forms['settings']
 
         form['SITE_OWNER'].value = 'The New Owners'
@@ -79,7 +65,7 @@ class SettingsTests(TestUserMixin, SettingsMixin, WebTest):
         settings_url = reverse(
             'settings',
         )
-        response = self.app.get(settings_url, user=self.test_setter)
+        response = self.app.get(settings_url, user=self.user_who_can_edit_settings)
         form = response.forms['settings']
 
         form['SITE_OWNER'].value = 'The New Owners'

--- a/candidates/tests/test_settings.py
+++ b/candidates/tests/test_settings.py
@@ -61,6 +61,23 @@ class SettingsTests(TestUserMixin, SettingsMixin, WebTest):
         settings = get_current_usersettings()
         self.assertEqual(settings.SITE_OWNER, 'The New Owners')
 
+    def test_settings_validation_fails(self):
+        settings_url = reverse(
+            'settings',
+        )
+        response = self.app.get(settings_url, user=self.user_who_can_edit_settings)
+        form = response.forms['settings']
+
+        # SITE_OWNER is a required setting, so try setting it to the
+        # empty string to check we get a validation error:
+        form['SITE_OWNER'].value = ''
+        response = form.submit()
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIn('Oops!', response)
+        self.assertIn('This field is required.', response)
+
     def test_logged_action_created(self):
         settings_url = reverse(
             'settings',


### PR DESCRIPTION
No validation errors were being shown when trying to update settings at
/settings, because the form had the settings object instance set on it
in the wrong way: in get_context_data rather than via get_kwargs.

This commit fixes that, but this also exposed a bug where the cached
setting object was being updated when checking the validity of the
fields. This commit fixes that as well, otherwise the switch to
using get_form_kwargs causes test failures because of this bad
caching.