### PR TITLE
Add a wizard to add a new candidacy for a person

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -214,9 +214,11 @@ class BasePersonForm(forms.Form):
             election = election_data.slug
             election_name = election_data.name
 
-            standing_status = cleaned_data.get(
-                'standing_' + election, 'standing'
-            )
+            standing_key = 'standing_' + election
+            if standing_key not in cleaned_data:
+                continue
+
+            standing_status = cleaned_data[standing_key]
             if standing_status != 'standing':
                continue
 
@@ -399,6 +401,7 @@ class UpdatePersonForm(BasePersonForm):
                     label=_('Standing in %s') % election_data.name,
                     choices=self.STANDING_CHOICES,
                     widget=forms.Select(attrs={'class': 'standing-select'}),
+                    required=False,
                 )
             self.fields['constituency_' + election] = \
                 forms.ChoiceField(

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -278,10 +278,7 @@ class NewPersonForm(BasePersonForm):
         self.fields['standing_' + election] = \
             forms.ChoiceField(**standing_field_kwargs)
 
-        self.elections_with_fields = [
-            election_data
-        ]
-
+        self.elections_with_fields = [election_data]
 
         post_field_kwargs = {
             'label': _("Post in the {election}").format(

--- a/candidates/static/candidates/_person_edit.scss
+++ b/candidates/static/candidates/_person_edit.scss
@@ -1,3 +1,7 @@
 .person-edit-separate-form {
   margin-bottom: 1em;
 }
+
+.add-candidacy-link {
+  margin-bottom: 1.5em;
+}

--- a/candidates/templates/candidates/_person_form.html
+++ b/candidates/templates/candidates/_person_form.html
@@ -94,6 +94,15 @@
           {% endfor %}
 
         {% endfor %}
+
+        {% if not add_candidate_form %}
+          <div class="add-candidacy-link">
+            <a href="{% url 'person-update-add-candidacy' person_id=person.id %}">
+              {% trans "Add a candidacy in an election" %}
+            </a>
+          </div>
+        {% endif %}
+
     </div>
 
     <h2>{% trans "Links and social media:" %}</h2>

--- a/candidates/templates/candidates/person-edit-candidacy-pick-election.html
+++ b/candidates/templates/candidates/person-edit-candidacy-pick-election.html
@@ -1,0 +1,20 @@
+{% extends 'candidates/person-edit-candidacy-wizard.html' %}
+
+{% load i18n %}
+
+{% block title %}{% blocktrans with name=person.name %}Picking a new election for: {{ name }}{% endblocktrans %}{% endblock %}
+
+{% block candidacy_wizard_instruction %}
+    <h3>{% trans "Choose the election to which you're adding a candidacy" %}</h3>
+{% endblock %}
+
+{% block candidacy_wizard_submit %}
+      <input type="submit" class="button pick-election"
+        value="{% trans "Select" context "On the submit button to select an election to add a candidacy for." %}" />
+{% endblock %}
+
+{% block extra_js %}
+  <script type="text/javascript">
+    $(function() { $('#id_election-election').select2({width: '100%'}); })
+  </script>
+{% endblock %}

--- a/candidates/templates/candidates/person-edit-candidacy-pick-party.html
+++ b/candidates/templates/candidates/person-edit-candidacy-pick-party.html
@@ -1,0 +1,18 @@
+{% extends 'candidates/person-edit-candidacy-wizard.html' %}
+
+{% load i18n %}
+
+{% block title %}{% blocktrans with name=person.name election=election.name post=post.label %}Picking a new party for {{ name }}, standing for {{ post }} in {{ election }}{% endblocktrans %}{% endblock %}
+
+{% block candidacy_wizard_instruction %}
+    <h3>{% trans "Choose the party they're standing for:" %}</h3>
+{% endblock %}
+
+{% block candidacy_wizard_submit %}
+      <input type="submit" class="button pick-post"
+        value="{% trans "Select" context "On the submit button to select a party of someone you're add a candidacy for." %}" />
+{% endblock %}
+
+{% block js_end_of_body %}
+  $('#id_election-election').select2({width: '100%'});
+{% endblock %}

--- a/candidates/templates/candidates/person-edit-candidacy-pick-post.html
+++ b/candidates/templates/candidates/person-edit-candidacy-pick-post.html
@@ -1,0 +1,18 @@
+{% extends 'candidates/person-edit-candidacy-wizard.html' %}
+
+{% load i18n %}
+
+{% block title %}{% blocktrans with name=person.name election=election.name %}Picking a new post in {{ election }} for: {{ name }}{% endblocktrans %}{% endblock %}
+
+{% block candidacy_wizard_instruction %}
+    <h3>{% trans "Choose the post for which you're adding a candidacy" %}</h3>
+{% endblock %}
+
+{% block candidacy_wizard_submit %}
+    <input type="submit" class="button pick-post"
+        value="{% trans "Select" context "On the submit button to select a post to add a candidacy for." %}" />
+{% endblock %}
+
+{% block js_end_of_body %}
+  $('#id_post').select2({width: '100%'});
+{% endblock %}

--- a/candidates/templates/candidates/person-edit-candidacy-source.html
+++ b/candidates/templates/candidates/person-edit-candidacy-source.html
@@ -1,0 +1,14 @@
+{% extends 'candidates/person-edit-candidacy-wizard.html' %}
+
+{% load i18n %}
+
+{% block title %}{% blocktrans with name=person.name election=election.name post=post.label %}Picking a new party for {{ name }}, standing for {{ post }} in {{ election }}{% endblocktrans %}{% endblock %}
+
+{% block candidacy_wizard_instruction %}
+    <h3>{% trans "Enter the source of that information" %}</h3>
+{% endblock %}
+
+{% block candidacy_wizard_submit %}
+      <input type="submit" class="button pick-post"
+        value="{% trans "Add Candidacy" context "On the submit button to enter the information source of someone you're adding a candidacy for." %}" />
+{% endblock %}

--- a/candidates/templates/candidates/person-edit-candidacy-wizard.html
+++ b/candidates/templates/candidates/person-edit-candidacy-wizard.html
@@ -1,0 +1,59 @@
+{% extends 'base.html' %}
+
+{% load i18n %}
+{% load thumbnail %}
+{% load static %}
+
+{% block body_class %}person{% endblock %}
+
+{% block hero %}
+<div class="person__hero">
+  <div class="person__photo">
+    {% if person.extra.primary_image %}
+      {% thumbnail person.extra.primary_image "x80" as im %}
+        <img class="person-avatar" src="{{ im.url }}"/>
+      {% endthumbnail %}
+    {% elif person.gender|lower == 'female' %}
+      <img class="person-avatar" src="{% static 'candidates/img/blank-woman.png' %}"/>
+    {% else %}
+      <img class="person-avatar" src="{% static 'candidates/img/blank-man.png' %}"/>
+    {% endif %}
+  </div>
+  <h1>{% blocktrans with name=person.name %}Editing: {{ name }}{% endblocktrans %}</h1>
+  {% with last_candidacy=person.extra.last_candidacy %}
+    {% if last_candidacy %}
+      {% with post=last_candidacy.post %}
+        {% url 'constituency' election=last_candidacy.extra.election.slug post_id=post.extra.slug ignored_slug=post.extra.short_label|slugify as url %}
+          <p>{% blocktrans with election=last_candidacy.extra.election.name post_name=post.extra.short_label %}Candidate for <a href="{{ url }}">{{ post_name }}</a> in {{ election }}{% endblocktrans %}</p>
+      {% endwith %}
+    {% endif %}
+  {% endwith %}
+</div>
+{% endblock %}
+
+{% block content %}
+
+{% if user_can_edit %}
+
+    {% block candidacy_wizard_instruction %}{% endblock %}
+
+    {% if wizard.form.errors %}
+      <div class="form-error-summary">
+        {% if wizard.form.non_field_errors %}
+          {{ wizard.form.non_field_errors.as_ul }}
+        {% endif %}
+      </div>
+    {% endif %}
+
+    <form id="add-candidacy-wizard" action="" method="post">
+      {% csrf_token %}
+      {{ wizard.management_form }}
+      {{ wizard.form.as_p }}
+      {% block candidacy_wizard_submit %}{% endblock %}
+    </form>
+
+{% else %}
+  {% include 'candidates/_edits_disallowed_message.html' %}
+{% endif %}
+
+{% endblock %}

--- a/candidates/tests/test_add_candidacy.py
+++ b/candidates/tests/test_add_candidacy.py
@@ -1,0 +1,230 @@
+from __future__ import unicode_literals
+
+
+from django.core.urlresolvers import reverse
+from django.utils.six import text_type
+from django.utils.six.moves.urllib_parse import urlsplit
+
+from django_webtest import WebTest
+from popolo.models import Membership
+
+from candidates.models import PostExtra, LoggedAction
+
+from .auth import TestUserMixin
+from .settings import SettingsMixin
+from .uk_examples import UK2015ExamplesMixin
+from . import factories
+
+
+class TestAddCandidacyWizard(TestUserMixin, SettingsMixin, UK2015ExamplesMixin, WebTest):
+
+    def setUp(self):
+        super(TestAddCandidacyWizard, self).setUp()
+        self.person_extra = factories.PersonExtraFactory.create(
+            base__id=1234,
+            base__name='Testy McTestface',
+            base__gender='neuter',
+            base__email='mctestface@example.com',
+        )
+        self.person = self.person_extra.base
+        self.wizard_url = reverse(
+            'person-update-add-candidacy',
+            kwargs={'person_id': self.person.id})
+
+    def test_only_logged_in_users(self):
+        response = self.app.get(self.wizard_url)
+        self.assertEqual(response.status_code, 302)
+        split_location = urlsplit(response.location)
+        self.assertEqual(
+            split_location.path, '/accounts/login/')
+        self.assertEqual(
+            split_location.query, 'next=/person/1234/update/add-candidacy')
+
+    def test_no_posts_for_election(self):
+        factories.ElectionFactory.create(
+            slug='2058',
+            name='2058 Galactic Senate Election',
+            for_post_role='Senator',
+        )
+        response = self.app.get(self.wizard_url, user=self.user)
+        election_form = response.forms['add-candidacy-wizard']
+        election_form['election-election'].select(
+            text='2058 Galactic Senate Election')
+        submission_response = election_form.submit()
+        # There should be an error since there are no posts for this
+        # election:
+        form_after_submission = \
+            submission_response.forms['add-candidacy-wizard']
+        self.assertTrue(form_after_submission['election-election'])
+        self.assertIn(
+            'No posts have been created for the 2058 Galactic Senate Election',
+            submission_response)
+
+    def test_all_posts_for_election_locked(self):
+        PostExtra.objects.update(candidates_locked=True)
+        response = self.app.get(self.wizard_url, user=self.user)
+        election_form = response.forms['add-candidacy-wizard']
+        election_form['election-election'].select(text='2015 General Election')
+        submission_response = election_form.submit()
+        # We should still be on the election-picking page, and have a
+        # validation error saying that no posts for that election were
+        # unlocked.
+        form_after_submission = \
+            submission_response.forms['add-candidacy-wizard']
+        self.assertTrue(form_after_submission['election-election'])
+        expected_error = 'There are no unlocked posts in the election ' \
+            '2015 General Election - if you think the candidates for this ' \
+            'election are wrong or incomplete, please ' \
+            '<a href="mailto:yournextmp-support@example.org">' \
+            'contact us</a>.'
+        self.assertIn(expected_error, submission_response)
+
+    def test_election_with_single_post(self):
+        election = factories.ElectionFactory.create(
+            slug='2058',
+            name='2058 Galactic Senate Election',
+            for_post_role='Senator',
+        )
+        party_set = factories.PartySetFactory.create(
+            slug='pg', name='Pan-Galactic Party Set'
+        )
+        area_extra = factories.AreaExtraFactory.create(
+            base__identifier='area:tatooine',
+            base__name='Tatooine',
+            type=factories.AreaTypeFactory.create(),
+        )
+        factories.PostExtraFactory.create(
+            elections=(election,),
+            base__organization=self.commons,
+            base__area=area_extra.base,
+            slug='tatooine',
+            base__label='Senator for Tatooine',
+            party_set=party_set,
+        )
+        party = factories.PartyExtraFactory(
+            slug='tip',
+            base__name='Tatooine Independence Party',
+        )
+        party_set.parties.add(party.base)
+        # Now step through the election selection page - it should go
+        # directly to party select afterwards:
+        response = self.app.get(self.wizard_url, user=self.user)
+        election_form = response.forms['add-candidacy-wizard']
+        election_form['election-election'].select(
+            text='2058 Galactic Senate Election')
+        submission_response = election_form.submit()
+        # There should be an error since there are no posts for this
+        # election:
+        form_after_submission = \
+            submission_response.forms['add-candidacy-wizard']
+        party_select = form_after_submission['party-party']
+        self.assertEqual(
+            [('party:none', False, ''),
+             (str(party.base.id), False, 'Tatooine Independence Party')],
+            party_select.options
+        )
+
+    def test_all_steps_successful(self):
+        # Select the election:
+        response = self.app.get(self.wizard_url, user=self.user)
+        election_form = response.forms['add-candidacy-wizard']
+        election_form['election-election'].select(
+            text='2015 General Election')
+        response = election_form.submit()
+        # Select the post:
+        post_form = response.forms['add-candidacy-wizard']
+        post_form['post-post'].select(text='Dulwich and West Norwood')
+        response = post_form.submit()
+        # Select the party:
+        party_form = response.forms['add-candidacy-wizard']
+        party_form['party-party'].select(text='Labour Party')
+        response = party_form.submit()
+        # Explain the source:
+        source_form = response.forms['add-candidacy-wizard']
+        source_form['source-source'] = 'Testing adding a candidacy'
+        response = source_form.submit()
+        # Now check we're redirected back to the person edit page:
+        self.assertEqual(response.status_code, 302)
+        split_location = urlsplit(response.location)
+        self.assertEqual(
+            split_location.path,
+            '/person/1234/update'
+        )
+        # And check that all the changes we expect have been made.
+        # The action must have been logged:
+        la = LoggedAction.objects.order_by('updated').last()
+        self.assertEqual(la.user, self.user)
+        self.assertEqual(la.note, None)
+        self.assertTrue(la.popit_person_new_version)
+        self.assertEqual(la.person, self.person)
+        self.assertEqual(la.source, 'Testing adding a candidacy')
+        # Now check that that person has a new candidacy:
+        m = Membership.objects.select_related('extra', 'on_behalf_of').get(
+            person=self.person,
+            role='Candidate')
+        self.assertEqual(m.on_behalf_of.name, 'Labour Party')
+        self.assertEqual(m.post, self.dulwich_post_extra.base)
+
+    def test_locked_at_last_minute(self):
+        # Select the election:
+        response = self.app.get(self.wizard_url, user=self.user)
+        election_form = response.forms['add-candidacy-wizard']
+        election_form['election-election'].select(
+            text='2015 General Election')
+        response = election_form.submit()
+        # Select the post:
+        post_form = response.forms['add-candidacy-wizard']
+        post_form['post-post'].select(text='Dulwich and West Norwood')
+        response = post_form.submit()
+        # Select the party:
+        party_form = response.forms['add-candidacy-wizard']
+        party_form['party-party'].select(text='Labour Party')
+        response = party_form.submit()
+        # Now lock that post:
+        self.dulwich_post_extra.candidates_locked = True
+        self.dulwich_post_extra.save()
+        # Set a source and try to submit:
+        source_form = response.forms['add-candidacy-wizard']
+        source_form['source-source'] = 'Testing adding a candidacy'
+        with self.assertRaises(Exception) as context:
+            response = source_form.submit()
+        self.assertEqual(
+            text_type(context.exception),
+            'Attempt to edit a candidacy in a locked constituency')
+
+    def test_all_steps_with_party_list_position_successful(self):
+        self.election.party_lists_in_use = True
+        self.election.save()
+        # Now go through all the steps, but set a party list position
+        # too:
+        # Select the election:
+        response = self.app.get(self.wizard_url, user=self.user)
+        election_form = response.forms['add-candidacy-wizard']
+        election_form['election-election'].select(
+            text='2015 General Election')
+        response = election_form.submit()
+        # Select the post:
+        post_form = response.forms['add-candidacy-wizard']
+        post_form['post-post'].select(text='Dulwich and West Norwood')
+        response = post_form.submit()
+        # Select the party:
+        party_form = response.forms['add-candidacy-wizard']
+        party_form['party-party'].select(text='Labour Party')
+        party_form['party-party_list_position'] = 3
+        response = party_form.submit()
+        # Explain the source:
+        source_form = response.forms['add-candidacy-wizard']
+        source_form['source-source'] = 'Testing adding a candidacy'
+        response = source_form.submit()
+        # Now check we're redirected back to the person edit page:
+        self.assertEqual(response.status_code, 302)
+        split_location = urlsplit(response.location)
+        self.assertEqual(
+            split_location.path,
+            '/person/1234/update'
+        )
+        # Now check that that person has a new candidacy:
+        m = Membership.objects.select_related('extra', 'on_behalf_of').get(
+            person=self.person,
+            role='Candidate')
+        self.assertEqual(m.extra.party_list_position, 3)

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -110,6 +110,11 @@ patterns_to_format = [
         'name': 'person-update'
     },
     {
+        'pattern': r'^person/(?P<person_id>\d+)/update/add-candidacy$',
+        'view': views.AddCandidacyWizardView.as_view(),
+        'name': 'person-update-add-candidacy'
+    },
+    {
         'pattern': r'^update-disallowed$',
         'view': TemplateView.as_view(template_name="candidates/update-disallowed.html"),
         'name': 'update-disallowed'

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -91,7 +91,7 @@ patterns_to_format = [
     },
     {
         'pattern': r'^election/{election}/candidacy$',
-        'view': views.CandidacyView.as_view(),
+        'view': views.CandidacyCreateView.as_view(),
         'name': 'candidacy-create'
     },
     {

--- a/candidates/views/candidacies.py
+++ b/candidates/views/candidacies.py
@@ -16,7 +16,8 @@ from elections.mixins import ElectionMixin
 
 from .helpers import get_redirect_to_post
 from .version_data import get_client_ip, get_change_metadata
-from ..forms import CandidacyCreateForm, CandidacyDeleteForm
+from .. import forms
+
 from ..models import LoggedAction, TRUSTED_TO_LOCK_GROUP_NAME
 
 
@@ -32,7 +33,7 @@ def raise_if_locked(request, post):
 
 class CandidacyView(ElectionMixin, LoginRequiredMixin, FormView):
 
-    form_class = CandidacyCreateForm
+    form_class = forms.CandidacyCreateForm
     template_name = 'candidates/candidacy-create.html'
 
     def form_valid(self, form):
@@ -88,7 +89,7 @@ class CandidacyView(ElectionMixin, LoginRequiredMixin, FormView):
 
 class CandidacyDeleteView(ElectionMixin, LoginRequiredMixin, FormView):
 
-    form_class = CandidacyDeleteForm
+    form_class = forms.CandidacyDeleteForm
     template_name = 'candidates/candidacy-delete.html'
 
     def form_valid(self, form):

--- a/candidates/views/candidacies.py
+++ b/candidates/views/candidacies.py
@@ -35,7 +35,7 @@ def raise_if_locked(request, post):
         raise Exception(_("Attempt to edit a candidacy in a locked constituency"))
 
 
-class CandidacyView(ElectionMixin, LoginRequiredMixin, FormView):
+class CandidacyCreateView(ElectionMixin, LoginRequiredMixin, FormView):
 
     form_class = forms.CandidacyCreateForm
     template_name = 'candidates/candidacy-create.html'
@@ -84,7 +84,7 @@ class CandidacyView(ElectionMixin, LoginRequiredMixin, FormView):
         return get_redirect_to_post(self.election, post)
 
     def get_context_data(self, **kwargs):
-        context = super(CandidacyView, self).get_context_data(**kwargs)
+        context = super(CandidacyCreateView, self).get_context_data(**kwargs)
         context['person'] = get_object_or_404(Person, id=self.request.POST.get('person_id'))
         post = get_object_or_404(Post, extra__slug=self.request.POST.get('post_id'))
         context['post_label'] = post.label

--- a/candidates/views/helpers.py
+++ b/candidates/views/helpers.py
@@ -70,7 +70,10 @@ def get_redirect_to_party_list(election, post, party_slug):
         )
     )
 
-def get_person_form_fields(context, form):
+# If elections is not None, it should be a sequence of Election
+# objects, indicating that only candidacy fields for those elections
+# should be included.
+def get_person_form_fields(context, form, elections=None):
     context['extra_fields'] = []
     extra_fields = ExtraField.objects.all()
     for field in extra_fields:
@@ -99,16 +102,16 @@ def get_person_form_fields(context, form):
             )
 
     context['constituencies_form_fields'] = \
-        get_candidacy_fields_for_person_form(form)
+        get_candidacy_fields_for_person_form(form, elections)
 
     return context
 
 
-def get_candidacy_fields_for_person_form(form):
+def get_candidacy_fields_for_person_form(form, elections):
     fields = []
-    for election_data in form.elections_with_fields:
-        if not election_data.current:
-            continue
+    if elections is None:
+        elections = [e for e in form.elections_with_fields if e.current]
+    for election_data in elections:
         cons_form_fields = {
             'election': election_data,
             'election_name': election_data.name,

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -343,7 +343,13 @@ class UpdatePersonView(LoginRequiredMixin, FormView):
             json.loads(person.extra.versions)
         )
 
-        context = get_person_form_fields(context, kwargs['form'])
+        elections_standing_in = Election.objects.filter(
+            candidacies__base__person=person,
+            current=True,
+        ).order_by('-election_date', 'name')
+
+        context = get_person_form_fields(
+            context, kwargs['form'], elections_standing_in)
 
         return context
 

--- a/elections/models.py
+++ b/elections/models.py
@@ -88,6 +88,10 @@ class Election(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def number_of_posts(self):
+        return self.postextraelection_set.count()
+
     @classmethod
     def group_and_order_elections(cls, include_posts=False):
         """Group elections in a helpful order

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -192,6 +192,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             'django.contrib.messages',
             'django.contrib.staticfiles',
             'django.contrib.sites',
+            'formtools',
             'django_nose',
             'django_extensions',
             'pipeline',
@@ -401,6 +402,8 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             u"Please don't quote third-party candidate sites \u2014 "
             u"we prefer URLs of news stories or official candidate pages."
         ),
+
+        'SUPPORT_EMAIL': 'yournextmp-support@example.org',
 
         # By default, cache successful results from MapIt for a day
         'MAPIT_CACHE_SECONDS': 86400,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ django-debug-toolbar==1.3.2
 django-debug-toolbar-template-timings==0.6.4
 django-extensions==1.6.1
 django-filter==0.11.0
+django-formtools==1.0
 django-haystack==2.4.1
 django-model-utils==2.3.1
 django-nose==1.4.1


### PR DESCRIPTION
The motivation of this pull request is to deal with the problem that the person edit page included post and party selects for every current election in the database - this might be repeated for hundreds of elections, which makes the page very slow to load and crashes some browsers. (See https://github.com/mysociety/yournextrepresentative/pull/740 for more details.)

On the DemocracyClub fork of YNR, this problem has been dealt with by using Javascript to dynamically add those form elements. However, in this upstream versions, so far, all of the site works without Javascript, on the principle that progressive enhancement is a Good Thing, so I was reluctant to merge those changes as-is. This pull request adds a method which is not Javascript-dependent to do the same thing, and we can use this as a base to apply the DC Javascript enhancement in the future. (Which I'm intending to do.)

The person edit page still uses lots of queries in its generation, which is bad, especially since there are fixes for those issues that I made in the DC fork; however, those fixes will apply most easily after the Javascript enhancement has been merged, so my plan is to get this merged, apply the Javascript enhancement of adding new candidacies, and then apply the fixes for excessive queries.

I guess @symroe or @struan might be best placed to review this, if either of you have time? n.b. @symroe, we discussed recently that the formtools wizard examples suggest you need to specify `condition_dict` as a keyword parameter to `as_view`, but it works fine when specified as a class attribute instead, as in this example.

![add-candidacy-link](https://cloud.githubusercontent.com/assets/7907/20748081/beeab126-b6e4-11e6-87e4-1db183995cda.png)
![wizard-election-step](https://cloud.githubusercontent.com/assets/7907/20748084/c21e7f26-b6e4-11e6-8698-d1ce72c08d04.png)
