### PR TITLE
Add candidacy wizard: make historic elections an option

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -557,8 +557,13 @@ class SettingsForm(forms.ModelForm):
 
 class AddCandidacyPickElectionForm(forms.Form):
 
-    election = forms.ModelChoiceField(
-        queryset=Election.objects.order_by('-election_date', 'name'))
+    def __init__(self, *args, **kwargs):
+        include_historic = kwargs.pop('include_historic')
+        super(AddCandidacyPickElectionForm, self).__init__(*args, **kwargs)
+        election_qs = Election.objects.order_by('-election_date', 'name')
+        if not include_historic:
+            election_qs = election_qs.filter(current=True)
+        self.fields['election'] = forms.ModelChoiceField(queryset=election_qs)
 
     def clean_election(self):
         election = self.cleaned_data['election']

--- a/candidates/templates/candidates/_person_form.html
+++ b/candidates/templates/candidates/_person_form.html
@@ -96,9 +96,10 @@
         {% endfor %}
 
         {% if not add_candidate_form %}
+          <h2>{% trans "Add a candidacy in another election" %}</h2>
           <div class="add-candidacy-link">
             <a href="{% url 'person-update-add-candidacy' person_id=person.id %}">
-              {% trans "Add a candidacy in an election" %}
+              {% trans "Add a new candidacy" %}
             </a>
           </div>
         {% endif %}

--- a/candidates/templates/candidates/person-edit-candidacy-pick-election.html
+++ b/candidates/templates/candidates/person-edit-candidacy-pick-election.html
@@ -11,6 +11,9 @@
 {% block candidacy_wizard_submit %}
       <input type="submit" class="button pick-election"
         value="{% trans "Select" context "On the submit button to select an election to add a candidacy for." %}" />
+  {% if not include_historic %}
+    <p>Or there's <a href="?historic=1">another form if you need to add a candidacy for a historic election.</a></p>
+  {% endif %}
 {% endblock %}
 
 {% block extra_js %}

--- a/candidates/views/candidacies.py
+++ b/candidates/views/candidacies.py
@@ -185,7 +185,8 @@ class AddCandidacyWizardView(LoginRequiredMixin, SessionWizardView):
     def get_form_kwargs(self, step=None):
         kwargs = super(AddCandidacyWizardView, self).get_form_kwargs(step)
         if step == 'election':
-            return kwargs
+            include_historic = self.request.GET.get('historic') == '1'
+            kwargs['include_historic'] = include_historic
         elif step == 'post':
             cleaned_data = self.get_cleaned_data_for_step('election')
             kwargs['election'] = cleaned_data['election']
@@ -198,6 +199,7 @@ class AddCandidacyWizardView(LoginRequiredMixin, SessionWizardView):
     def get_context_data(self, form, **kwargs):
         context = super(AddCandidacyWizardView, self).get_context_data(form, **kwargs)
         context['person'] = self.person
+        context['include_historic'] = (self.request.GET.get('historic') == '1')
         return context
 
     def done(self, form_list, **kwargs):

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -464,7 +464,26 @@ msgstr ""
 msgid "Please indicate how you know that this is a valid alternative name"
 msgstr ""
 
-#: candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py:50
+#: candidates/forms.py:577
+#, python-brace-format
+msgid "No posts have been created for the {election_name}"
+msgstr ""
+
+#: candidates/forms.py:582
+#, python-brace-format
+msgid "There are no unlocked posts in the election {election_name} - if you think the candidates for this election are wrong or incomplete, please <a href=\"mailto:{support_email}\">contact us</a>."
+msgstr ""
+
+#: candidates/forms.py:598
+#, python-format
+msgid "Post in %s"
+msgstr ""
+
+#: candidates/forms.py:649
+msgid "You must specify a party"
+msgstr ""
+
+#: candidates/management/commands/candidates_create_areas_and_posts_from_mapit.py:55
 #, python-brace-format
 msgid "{post_role} for {area_name}"
 msgstr ""
@@ -753,6 +772,14 @@ msgid "Candidacy:"
 msgstr ""
 
 #: candidates/templates/candidates/_person_form.html:99
+msgid "Add a candidacy in another election"
+msgstr ""
+
+#: candidates/templates/candidates/_person_form.html:102
+msgid "Add a new candidacy"
+msgstr ""
+
+#: candidates/templates/candidates/_person_form.html:109
 #: candidates/templates/candidates/person-view.html:171
 msgid "Links and social media:"
 msgstr ""
@@ -1551,6 +1578,59 @@ msgstr ""
 msgid "Please make sure you read our <a href=\"https://docs.google.com/document/d/1iA5Tv3ZgjDHWNv6gbNESqL-C7Goz6ZSo1X9pPXwXspA/edit\">guidance on sourcing fields</a>."
 msgstr ""
 
+#: candidates/templates/candidates/person-edit-candidacy-pick-election.html:5
+#, python-format
+msgid "Picking a new election for: %(name)s"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-pick-election.html:8
+msgid "Choose the election to which you're adding a candidacy"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-pick-election.html:13
+msgctxt "On the submit button to select an election to add a candidacy for."
+msgid "Select"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-pick-party.html:5
+#: candidates/templates/candidates/person-edit-candidacy-source.html:5
+#, python-format
+msgid "Picking a new party for %(name)s, standing for %(post)s in %(election)s"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-pick-party.html:8
+msgid "Choose the party they're standing for:"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-pick-party.html:13
+msgctxt "On the submit button to select a party of someone you're add a candidacy for."
+msgid "Select"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-pick-post.html:5
+#, python-format
+msgid "Picking a new post in %(election)s for: %(name)s"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-pick-post.html:8
+msgid "Choose the post for which you're adding a candidacy"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-pick-post.html:13
+msgctxt "On the submit button to select a post to add a candidacy for."
+msgid "Select"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-source.html:8
+msgid "Enter the source of that information"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-source.html:13
+msgctxt "On the submit button to enter the information source of someone you're adding a candidacy for."
+msgid "Add Candidacy"
+msgstr ""
+
+#: candidates/templates/candidates/person-edit-candidacy-wizard.html:22
 #: candidates/templates/candidates/person-edit.html:9
 #: candidates/templates/candidates/person-edit.html:27
 #, python-format


### PR DESCRIPTION
Previously the default was to show all elections, whether they were
current or not, but @symroe pointed out that there might be thousands of
such elections, which in normal use would be irrelevant.

This commit makes the inclusion of non-current ('historic') elections in
the election picker stage an option - they're only shown if there's an
'historic=1' query parameter. There's also a link to that version of the
picker from the normal one.