### PR TITLE
Fixes for SiteSettings objects not existing

### DIFF
--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -36,3 +36,4 @@ from .auth import RESULT_RECORDERS_GROUP_NAME
 from .auth import EDIT_SETTINGS_GROUP_NAME
 
 from .sitesettings import SiteSettings
+from .sitesettings import get_site_setting

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -36,6 +36,7 @@ from .fields import (
 )
 from ..diffs import get_version_diffs
 from ..twitter_api import update_twitter_user_id, TwitterAPITokenMissing
+from .sitesettings import get_site_setting
 from .versions import get_person_as_version_data
 
 """Extensions to the base django-popolo classes for YourNextRepresentative
@@ -706,8 +707,8 @@ class PartySet(models.Model):
             role=models.F('extra__election__candidate_membership_role'),
             on_behalf_of__party_sets=self,
         )
-        user_settings = get_current_usersettings()
-        minimum_count = user_settings.CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST
+        minimum_count = get_site_setting(
+            'CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST')
         qs = None
         if candidacies_current_qs.count() > minimum_count:
             qs = candidacies_current_qs

--- a/candidates/models/sitesettings.py
+++ b/candidates/models/sitesettings.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from usersettings.models import UserSettings
+from usersettings.shortcuts import get_current_usersettings
 
 
 class SiteSettings(UserSettings):
@@ -181,3 +182,19 @@ least.
     class Meta:
         verbose_name = 'Site Settings'
         verbose_name_plural = 'Site Settings'
+
+
+def get_sitesettings_default(field_name):
+    field = SiteSettings._meta.get_field(field_name)
+    if field.has_default():
+        return field.default
+    else:
+        return None
+
+
+def get_site_setting(key):
+    user_settings = get_current_usersettings()
+    return getattr(
+        user_settings,
+        key,
+        get_sitesettings_default(key))

--- a/candidates/views/settings.py
+++ b/candidates/views/settings.py
@@ -29,8 +29,10 @@ class SettingsView(GroupRequiredMixin, FormView):
         # by those conveninence method, including the
         # self.request.usersettings attribute set by the middleware,
         # may not be in sync with the database any more.
-        kwargs['instance'] = SiteSettings.objects.get(
-            site_id=settings.SITE_ID)
+        kwargs['instance'], _ = SiteSettings.objects.get_or_create(
+            site_id=settings.SITE_ID,
+            defaults={'user': self.request.user}
+        )
         return kwargs
 
     def form_valid(self, form):

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -10,7 +10,8 @@ from candidates.models import (
     TRUSTED_TO_LOCK_GROUP_NAME,
     TRUSTED_TO_RENAME_GROUP_NAME,
     RESULT_RECORDERS_GROUP_NAME,
-    EDIT_SETTINGS_GROUP_NAME
+    EDIT_SETTINGS_GROUP_NAME,
+    get_site_setting,
 )
 from moderation_queue.models import QueuedImage, PHOTO_REVIEWERS_GROUP_NAME
 from official_documents.models import DOCUMENT_UPLOADERS_GROUP_NAME
@@ -44,9 +45,8 @@ def add_settings(request):
         k: getattr(settings, k) for k in SETTINGS_TO_ADD
     }
 
-    current = get_current_usersettings()
     usersettings = {
-        k: getattr(current, k) for k in USERSETTINGS_TO_ADD
+        k: get_site_setting(k) for k in USERSETTINGS_TO_ADD
     }
 
     all_settings.update(usersettings)
@@ -93,7 +93,7 @@ def add_group_permissions(request):
             ('user_can_edit_settings', EDIT_SETTINGS_GROUP_NAME),
         )
     }
-    result['user_can_edit'] = request.usersettings.EDITS_ALLOWED or request.user.is_staff
+    result['user_can_edit'] = get_site_setting('EDITS_ALLOWED') or request.user.is_staff
     return result
 
 def add_site(request):


### PR DESCRIPTION
There are two important situations where a SiteSettings object might not have been created:

* Setting up a site from scratch
* Running tests

In both those situations, migration `0032_sitesettings` in `candidates` is run before a site or a user exists, so the `SiteSettings` can't be created. This means that we need to take steps to make sure that the site still works when no SiteSettings object has been created.