### PR TITLE
Move the LIABLE_TO_VANDALISM settings to the database

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -499,6 +499,8 @@ class UpdatePersonForm(AddElectionFieldsMixin, BasePersonForm):
         # with formsets?)
         self.add_elections_fields(self.elections_with_fields)
 
+    marked_for_review = forms.BooleanField(required=False)
+
     source = StrippedCharField(
         label=_("Source of information for this change ({0})").format(
             settings.SOURCE_HINTS

--- a/candidates/management/commands/candidates_import_from_live_site.py
+++ b/candidates/management/commands/candidates_import_from_live_site.py
@@ -356,7 +356,8 @@ class Command(BaseCommand):
                 )
                 kwargs = {
                     'base': p,
-                    'versions': json.dumps(person_data['versions'])
+                    'versions': json.dumps(person_data['versions']),
+                    'marked_for_review': person_data['marked_for_review'],
                 }
                 pe = models.PersonExtra.objects.create(**kwargs)
                 # Look for any data in ExtraFields

--- a/candidates/migrations/0036_add_trusted_to_mark_for_review_group.py
+++ b/candidates/migrations/0036_add_trusted_to_mark_for_review_group.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from auth_helpers.migrations import (
+    get_migration_group_create,
+    get_migration_group_delete,
+)
+from candidates.models import TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0035_merge'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            get_migration_group_create(TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME, []),
+            get_migration_group_delete(TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME),
+        )
+    ]

--- a/candidates/migrations/0037_personextra_marked_for_review.py
+++ b/candidates/migrations/0037_personextra_marked_for_review.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0036_add_trusted_to_mark_for_review_group'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='personextra',
+            name='marked_for_review',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/candidates/migrations/0038_migrate_liable_to_vandalism_to_db.py
+++ b/candidates/migrations/0038_migrate_liable_to_vandalism_to_db.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.db import migrations
+
+
+def migrate_liable_to_vandalism_from_settings_to_db(apps, schema_editor):
+    PersonExtra = apps.get_model('candidates', 'PersonExtra')
+    PersonExtra.objects.filter(pk__in=settings.PEOPLE_LIABLE_TO_VANDALISM) \
+        .update(marked_for_review=True)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0037_personextra_marked_for_review'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_liable_to_vandalism_from_settings_to_db,
+            lambda apps, schema_editor: None
+        )
+    ]

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -36,6 +36,7 @@ from .needs_review import needs_review_fns
 from .auth import TRUSTED_TO_MERGE_GROUP_NAME
 from .auth import TRUSTED_TO_LOCK_GROUP_NAME
 from .auth import TRUSTED_TO_RENAME_GROUP_NAME
+from .auth import TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME
 from .auth import RESULT_RECORDERS_GROUP_NAME
 from .auth import EDIT_SETTINGS_GROUP_NAME
 

--- a/candidates/models/auth.py
+++ b/candidates/models/auth.py
@@ -9,6 +9,7 @@ from auth_helpers.views import user_in_group
 TRUSTED_TO_MERGE_GROUP_NAME = 'Trusted To Merge'
 TRUSTED_TO_LOCK_GROUP_NAME = 'Trusted To Lock'
 TRUSTED_TO_RENAME_GROUP_NAME = 'Trusted To Rename'
+TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME = 'Trusted To Mark For Review'
 RESULT_RECORDERS_GROUP_NAME = 'Result Recorders'
 EDIT_SETTINGS_GROUP_NAME = 'Can Edit Settings'
 

--- a/candidates/models/needs_review.py
+++ b/candidates/models/needs_review.py
@@ -56,11 +56,9 @@ def needs_review_due_to_subject_having_died(logged_action_qs):
 
 
 def needs_review_due_to_candidate_specifically(logged_action_qs):
-    person_ids = set(logged_action_qs.values_list('person', flat=True))
-    needs_review_person_ids = person_ids & settings.PEOPLE_LIABLE_TO_VANDALISM
     return {
         la: [_("Edit of a candidate whose record may be particularly liable to vandalism")]
-        for la in logged_action_qs if la.person_id in needs_review_person_ids}
+        for la in logged_action_qs.filter(person__extra__marked_for_review=True)}
 
 
 needs_review_fns = [

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -69,6 +69,8 @@ def update_person_from_form(person, person_extra, form):
                 person=person, field=extra_field,
                 defaults={'value': form_data[extra_field.key]}
             )
+    if 'marked_for_review' in form_data:
+        person_extra.marked_for_review = form_data['marked_for_review']
     person.save()
     person_extra.save()
     try:
@@ -263,6 +265,8 @@ class PersonExtra(HasImageMixin, models.Model):
     # This field stores JSON data with previous version information
     # (as it did in PopIt).
     versions = models.TextField(blank=True)
+
+    marked_for_review = models.BooleanField(default=False)
 
     images = GenericRelation(Image)
 
@@ -498,6 +502,7 @@ class PersonExtra(HasImageMixin, models.Model):
                 person=self.base
         ).select_related('field'):
             initial_data[extra_field_value.field.key] = extra_field_value.value
+        initial_data['marked_for_review'] = self.marked_for_review
         not_standing_elections = set(self.not_standing.all())
         election_to_membershipextra = {
             me.election: me for me in

--- a/candidates/serializers.py
+++ b/candidates/serializers.py
@@ -337,6 +337,7 @@ class PersonSerializer(MinimalPersonSerializer):
             'images',
             'extra_fields',
             'thumbnail',
+            'marked_for_review',
         )
 
     contact_details = ContactDetailSerializer(many=True, read_only=True)
@@ -345,6 +346,7 @@ class PersonSerializer(MinimalPersonSerializer):
     other_names = OtherNameSerializer(many=True, read_only=True)
     images = ImageSerializer(many=True, read_only=True, source='extra.images')
 
+    marked_for_review = serializers.ReadOnlyField(source='extra.marked_for_review')
     versions = JSONSerializerField(source='extra.versions', read_only=True)
 
     memberships = MembershipSerializer(many=True, read_only=True)

--- a/candidates/templates/candidates/_person_form.html
+++ b/candidates/templates/candidates/_person_form.html
@@ -169,6 +169,18 @@
 
     {% endif %}
 
+    {% if user_can_mark_for_review and form.marked_for_review %}
+      <h2>{% trans "Vandalism protection:" %}</h2>
+
+      <div class="form-item {% if extra_field.errors %}form-item--errors{% endif %}">
+        <p>
+          {{ form.marked_for_review.label_tag }}
+          {{ form.marked_for_review }}
+        </p>
+        {{ form.marked_for_review.errors }}
+      </div>
+    {% endif %}
+
     <div class="source-confirmation {% if form.source.errors %}source-confirmation--errors{% endif %}">
       <p>
         <label for="{{ form.source.id_for_label }}">

--- a/candidates/tests/auth.py
+++ b/candidates/tests/auth.py
@@ -6,6 +6,7 @@ from candidates.models import (
     TRUSTED_TO_MERGE_GROUP_NAME,
     TRUSTED_TO_LOCK_GROUP_NAME,
     TRUSTED_TO_RENAME_GROUP_NAME,
+    TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME,
     RESULT_RECORDERS_GROUP_NAME,
     EDIT_SETTINGS_GROUP_NAME,
 )
@@ -24,7 +25,8 @@ class TestUserMixin(object):
                 ('delilah', 'user_who_can_upload_documents', [DOCUMENT_UPLOADERS_GROUP_NAME]),
                 ('ermintrude', 'user_who_can_rename', [TRUSTED_TO_RENAME_GROUP_NAME]),
                 ('frankie', 'user_who_can_record_results', [RESULT_RECORDERS_GROUP_NAME]),
-                ('grover', 'user_who_can_edit_settings', [EDIT_SETTINGS_GROUP_NAME])
+                ('grover', 'user_who_can_edit_settings', [EDIT_SETTINGS_GROUP_NAME]),
+                ('hermione', 'user_who_can_mark_for_review', [TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME]),
         ):
             u = User.objects.create_user(
                 username,

--- a/candidates/tests/helpers.py
+++ b/candidates/tests/helpers.py
@@ -73,3 +73,9 @@ def equal_call_args(args1, args2):
             return False
 
     return True
+
+def add_webtest_form_field(form, field_class, name):
+    new_field = field_class(
+        form, 'input', name, None, id='id_{0}'.format(name))
+    form.fields[name] = [new_field]
+    form.field_order.append((name, new_field))

--- a/candidates/tests/test_changes_for_review.py
+++ b/candidates/tests/test_changes_for_review.py
@@ -9,7 +9,6 @@ from datetime import datetime, timedelta
 
 from django_webtest import WebTest
 from django.test import TestCase
-from django.test.utils import override_settings
 
 from lxml import etree
 
@@ -49,7 +48,6 @@ def fake_diff_html(self, version_id, inline_style=False):
 
 @patch.object(PersonExtra, 'diff_for_version', fake_diff_html)
 @patch('candidates.models.db.datetime')
-@override_settings(PEOPLE_LIABLE_TO_VANDALISM={2811})
 class TestNeedsReview(TestUserMixin, WebTest):
 
     maxDiff = None
@@ -147,6 +145,7 @@ class TestNeedsReview(TestUserMixin, WebTest):
         prime_minister = factories.PersonExtraFactory.create(
             base__id='2811',
             base__name='Theresa May',
+            marked_for_review=True,
         ).base
         # Create a candidate on the "liable to vandalism" list.
         la = LoggedAction.objects.create(

--- a/candidates/tests/test_leaderboard.py
+++ b/candidates/tests/test_leaderboard.py
@@ -83,7 +83,8 @@ class TestLeaderboardView(TestUserMixin, SettingsMixin, WebTest):
             '5,ermintrude,0\r\n'
             '6,frankie,0\r\n'
             '7,grover,0\r\n'
-            '8,johnrefused,0\r\n'
-            '9,johnstaff,0\r\n'
-            '10,settings,0\r\n'
+            '8,hermione,0\r\n'
+            '9,johnrefused,0\r\n'
+            '10,johnstaff,0\r\n'
+            '11,settings,0\r\n'
         )

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -350,20 +350,9 @@ class UpdatePersonView(LoginRequiredMixin, PersonMixin, FormView):
             return HttpResponseRedirect(reverse('all-edits-disallowed'))
 
         with transaction.atomic():
-
-            old_name = self.person.name
             person_extra = self.person.extra
-            old_candidacies = person_extra.current_candidacies
-            old_marked_for_review = person_extra.marked_for_review
-            person_extra.update_from_form(form)
-            new_name = person_extra.base.name
-            new_candidacies = person_extra.current_candidacies
-            new_marked_for_review = person_extra.marked_for_review
-            check_update_allowed(
-                self.request.user,
-                old_name, old_candidacies, old_marked_for_review,
-                new_name, new_candidacies, new_marked_for_review,
-            )
+            with check_update_allowed(self.request.user, self.person):
+                person_extra.update_from_form(form)
             change_metadata = get_change_metadata(
                 self.request, form.cleaned_data.pop('source')
             )

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -354,13 +354,15 @@ class UpdatePersonView(LoginRequiredMixin, PersonMixin, FormView):
             old_name = self.person.name
             person_extra = self.person.extra
             old_candidacies = person_extra.current_candidacies
+            old_marked_for_review = person_extra.marked_for_review
             person_extra.update_from_form(form)
             new_name = person_extra.base.name
             new_candidacies = person_extra.current_candidacies
+            new_marked_for_review = person_extra.marked_for_review
             check_update_allowed(
                 self.request.user,
-                old_name, old_candidacies,
-                new_name, new_candidacies
+                old_name, old_candidacies, old_marked_for_review,
+                new_name, new_candidacies, new_marked_for_review,
             )
             change_metadata = get_change_metadata(
                 self.request, form.cleaned_data.pop('source')

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -9,6 +9,7 @@ from candidates.models import (
     TRUSTED_TO_MERGE_GROUP_NAME,
     TRUSTED_TO_LOCK_GROUP_NAME,
     TRUSTED_TO_RENAME_GROUP_NAME,
+    TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME,
     RESULT_RECORDERS_GROUP_NAME,
     EDIT_SETTINGS_GROUP_NAME,
     get_site_setting,
@@ -89,6 +90,7 @@ def add_group_permissions(request):
             ('user_can_review_photos', PHOTO_REVIEWERS_GROUP_NAME),
             ('user_can_lock', TRUSTED_TO_LOCK_GROUP_NAME),
             ('user_can_rename', TRUSTED_TO_RENAME_GROUP_NAME),
+            ('user_can_mark_for_review', TRUSTED_TO_MARK_FOR_REVIEW_GROUP_NAME),
             ('user_can_record_results', RESULT_RECORDERS_GROUP_NAME),
             ('user_can_edit_settings', EDIT_SETTINGS_GROUP_NAME),
         )


### PR DESCRIPTION
**Not for merging yet:** this adds database migrations to `candidates`, so for simplicity I would rather backport the remaining schema changes from the DC fork before merging this.

Fixes #996 